### PR TITLE
Feature: (BRD-66) API 예외 메시지 처리

### DIFF
--- a/board-system-container/build.gradle.kts
+++ b/board-system-container/build.gradle.kts
@@ -7,6 +7,7 @@ dependencies {
 
     // external
     implementation(project(":board-system-external:external-message"))
+    implementation(project(":board-system-external:external-exception-handle"))
 }
 
 tasks.getByName("bootJar") {

--- a/board-system-external/external-exception-handle/build.gradle.kts
+++ b/board-system-external/external-exception-handle/build.gradle.kts
@@ -1,0 +1,5 @@
+dependencies {
+    implementation(project(":board-system-api:api-core"))
+    implementation(Dependencies.SPRING_BOOT_WEB.fullName)
+    implementation(Dependencies.KOTLIN_JACKSON.fullName)
+}

--- a/board-system-external/external-exception-handle/src/main/kotlin/com/ttasjwi/board/system/core/config/ExceptionHandleFilterConfig.kt
+++ b/board-system-external/external-exception-handle/src/main/kotlin/com/ttasjwi/board/system/core/config/ExceptionHandleFilterConfig.kt
@@ -1,0 +1,32 @@
+package com.ttasjwi.board.system.core.config
+
+import com.ttasjwi.board.system.core.exception.filter.CustomExceptionHandleFilter
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.web.servlet.FilterRegistrationBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.HandlerExceptionResolver
+
+@Configuration
+class ExceptionHandleFilterConfig {
+
+    companion object {
+        /**
+         * 로케일 설정 필터 우선도는 -104 이므로 로케일이 설정되고 실행됨
+         * 스프링 시큐리티 필터(DelegatingFilterProxy) 기본 순서는 -100 이므로 스프링 시큐리티보다 먼저 시행됨
+         */
+        private const val EXCEPTION_HANDLE_FILTER_ORDER = -103
+    }
+
+    @Bean
+    fun customExceptionHandleFilter(
+        @Qualifier(value = "handlerExceptionResolver")
+        exceptionResolver: HandlerExceptionResolver
+    ): FilterRegistrationBean<CustomExceptionHandleFilter> {
+
+        val registration = FilterRegistrationBean<CustomExceptionHandleFilter>()
+        registration.filter = CustomExceptionHandleFilter(exceptionResolver)
+        registration.order = EXCEPTION_HANDLE_FILTER_ORDER
+        return registration
+    }
+}

--- a/board-system-external/external-exception-handle/src/main/kotlin/com/ttasjwi/board/system/core/exception/api/ErrorHttpStatusResolveFunction.kt
+++ b/board-system-external/external-exception-handle/src/main/kotlin/com/ttasjwi/board/system/core/exception/api/ErrorHttpStatusResolveFunction.kt
@@ -1,0 +1,15 @@
+package com.ttasjwi.board.system.core.exception.api
+
+import com.ttasjwi.board.system.core.exception.ErrorStatus
+import org.springframework.http.HttpStatus
+
+internal fun resolveHttpStatus(status: ErrorStatus): HttpStatus {
+    return when (status) {
+        ErrorStatus.INVALID_ARGUMENT -> HttpStatus.BAD_REQUEST
+        ErrorStatus.NOT_FOUND -> HttpStatus.NOT_FOUND
+        ErrorStatus.UNAUTHENTICATED -> HttpStatus.UNAUTHORIZED
+        ErrorStatus.FORBIDDEN -> HttpStatus.FORBIDDEN
+        ErrorStatus.CONFLICT -> HttpStatus.CONFLICT
+        ErrorStatus.APPLICATION_ERROR -> HttpStatus.INTERNAL_SERVER_ERROR
+    }
+}

--- a/board-system-external/external-exception-handle/src/main/kotlin/com/ttasjwi/board/system/core/exception/api/GlobalExceptionController.kt
+++ b/board-system-external/external-exception-handle/src/main/kotlin/com/ttasjwi/board/system/core/exception/api/GlobalExceptionController.kt
@@ -1,0 +1,108 @@
+package com.ttasjwi.board.system.core.exception.api
+
+import com.ttasjwi.board.system.core.api.ErrorResponse
+import com.ttasjwi.board.system.core.exception.CustomException
+import com.ttasjwi.board.system.core.exception.ValidationExceptionCollector
+import com.ttasjwi.board.system.core.message.MessageResolver
+import com.ttasjwi.board.system.logging.getLogger
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+internal class GlobalExceptionController(
+    private val messageResolver: MessageResolver
+) {
+
+    companion object {
+        private val log = getLogger(GlobalExceptionController::class.java)
+    }
+
+    /**
+     * 커스텀 예외가 아닌 모든 예외들은 기본적으로 여기로 오게 됩니다.
+     * 커스텀 예외가 아닌 예외들은 커스텀 예외로 감싸거나 다른 ExceptionHandler 를 통해 처리할 수 있도록 만들어야 합니다.
+     * 여기로 온 예외는 모두 500 예외로 나가게 됩니다.
+     */
+    @ExceptionHandler(Exception::class)
+    fun handleException(e: Exception): ResponseEntity<ErrorResponse> {
+        val code = "Error.Server"
+        val httpStatus = HttpStatus.INTERNAL_SERVER_ERROR
+
+        log.error(e)
+
+        return ResponseEntity
+            .status(httpStatus)
+            .body(
+                makeErrorResponse(
+                    listOf(
+                        ErrorResponse.ErrorItem(
+                            code = code,
+                            message = messageResolver.resolveMessage(code),
+                            description = messageResolver.resolveDescription(code),
+                            source = "server"
+                        )
+                    )
+                )
+            )
+    }
+
+    /**
+     * 커스텀 예외를 처리합니다.
+     */
+    @ExceptionHandler(CustomException::class)
+    fun handleCustomException(e: CustomException): ResponseEntity<ErrorResponse> {
+        val code = e.code
+        val httpStatus = resolveHttpStatus(e.status)
+
+        return ResponseEntity
+            .status(httpStatus)
+            .body(
+                makeErrorResponse(
+                    listOf(
+                        ErrorResponse.ErrorItem(
+                            code = code,
+                            message = messageResolver.resolveMessage(code),
+                            description = messageResolver.resolveDescription(code, e.args),
+                            source = e.source
+                        )
+                    )
+                )
+            )
+    }
+
+    /**
+     * 검증 예외 수집기에 수집된 예외들을 모아서 하나의 응답으로 내립니다.
+     */
+    @ExceptionHandler(ValidationExceptionCollector::class)
+    fun handleValidationExceptionCollector(exceptionCollector: ValidationExceptionCollector): ResponseEntity<ErrorResponse> {
+        val httpStatus = resolveHttpStatus(exceptionCollector.status)
+        return ResponseEntity
+            .status(httpStatus)
+            .body(
+                makeErrorResponse(
+                    exceptionCollector.getExceptions().map {
+                        ErrorResponse.ErrorItem(
+                            code = it.code,
+                            message = messageResolver.resolveMessage(it.code),
+                            description = messageResolver.resolveDescription(it.code, it.args),
+                            source = it.source
+                        )
+                    }
+                )
+            )
+    }
+
+    private fun makeErrorResponse(
+        errors: List<ErrorResponse.ErrorItem>
+    ): ErrorResponse {
+
+        val commonCode = "Error.Occurred"
+        return ErrorResponse(
+            code = commonCode,
+            message = messageResolver.resolveMessage(commonCode),
+            description = messageResolver.resolveDescription(commonCode),
+            errors = errors
+        )
+    }
+}

--- a/board-system-external/external-exception-handle/src/main/kotlin/com/ttasjwi/board/system/core/exception/filter/CustomExceptionHandleFilter.kt
+++ b/board-system-external/external-exception-handle/src/main/kotlin/com/ttasjwi/board/system/core/exception/filter/CustomExceptionHandleFilter.kt
@@ -1,0 +1,24 @@
+package com.ttasjwi.board.system.core.exception.filter
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.web.filter.OncePerRequestFilter
+import org.springframework.web.servlet.HandlerExceptionResolver
+
+class CustomExceptionHandleFilter(
+    private val handlerExceptionResolver: HandlerExceptionResolver
+) : OncePerRequestFilter() {
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        try {
+            filterChain.doFilter(request, response)
+        } catch (e: Exception) {
+            handlerExceptionResolver.resolveException(request, response, null, e)
+        }
+    }
+}

--- a/board-system-external/external-exception-handle/src/test/kotlin/com/ttasjwi/board/system/ExceptionApiTestApplication.kt
+++ b/board-system-external/external-exception-handle/src/test/kotlin/com/ttasjwi/board/system/ExceptionApiTestApplication.kt
@@ -1,0 +1,40 @@
+package com.ttasjwi.board.system
+
+import com.ttasjwi.board.system.core.message.MessageResolver
+import com.ttasjwi.board.system.core.message.fixture.MessageResolverFixture
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+import org.springframework.boot.web.servlet.FilterRegistrationBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
+
+@SpringBootApplication
+@Import(TestConfig::class)
+class ExceptionApiTestApplication
+
+fun main(args: Array<String>) {
+    runApplication<ExceptionApiTestApplication>(*args)
+}
+
+@Configuration
+class TestConfig {
+
+    @Bean
+    fun messageResolverFixture(): MessageResolver {
+        return MessageResolverFixture()
+    }
+
+    /**
+     * CustomExceptionHandleFilter 뒤에서 예외를 던지기 위한 필터
+     */
+    @Bean
+    fun testFilter(): FilterRegistrationBean<ExceptionApiTestFilter> {
+        val registration = FilterRegistrationBean<ExceptionApiTestFilter>()
+        registration.filter = ExceptionApiTestFilter()
+
+        // CustomExceptionHandleFilter (-103) 보다 뒤에 둠
+        registration.order = -102
+        return registration
+    }
+}

--- a/board-system-external/external-exception-handle/src/test/kotlin/com/ttasjwi/board/system/ExceptionApiTestController.kt
+++ b/board-system-external/external-exception-handle/src/test/kotlin/com/ttasjwi/board/system/ExceptionApiTestController.kt
@@ -1,0 +1,33 @@
+package com.ttasjwi.board.system
+
+import com.ttasjwi.board.system.core.exception.ErrorStatus
+import com.ttasjwi.board.system.core.exception.fixture.customExceptionFixture
+import com.ttasjwi.board.system.logging.getLogger
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class ExceptionApiTestController {
+
+    companion object {
+        private val log = getLogger(ExceptionApiTestController::class.java)
+    }
+
+
+    @GetMapping("/api/test-ex")
+    fun throwException(): String {
+        log.info{ "컨트롤러에서 예외를 발생시킵니다" }
+        throw customExceptionFixture(
+            code = "Error.Fixture",
+            source = "controller",
+            status = ErrorStatus.INVALID_ARGUMENT,
+            args = emptyList(),
+            debugMessage = "컨트롤러에서 발생한 예외"
+        )
+    }
+
+    @GetMapping("/api/test-success")
+    fun success(): String {
+        return "hello"
+    }
+}

--- a/board-system-external/external-exception-handle/src/test/kotlin/com/ttasjwi/board/system/ExceptionApiTestFilter.kt
+++ b/board-system-external/external-exception-handle/src/test/kotlin/com/ttasjwi/board/system/ExceptionApiTestFilter.kt
@@ -1,0 +1,37 @@
+package com.ttasjwi.board.system
+
+import com.ttasjwi.board.system.core.exception.ErrorStatus
+import com.ttasjwi.board.system.core.exception.fixture.customExceptionFixture
+import com.ttasjwi.board.system.logging.getLogger
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.web.filter.OncePerRequestFilter
+
+class ExceptionApiTestFilter : OncePerRequestFilter() {
+
+    companion object {
+        private val log = getLogger(ExceptionApiTestFilter::class.java)
+    }
+
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        val param: String? = request.getParameter("ex")
+
+        if (param == "true") {
+            log.info{ "ex param 이 true 이므로 필터에서 예외를 발생시킵니다." }
+            throw customExceptionFixture(
+                code = "Error.Fixture",
+                source = "filter",
+                status = ErrorStatus.INVALID_ARGUMENT,
+                args = emptyList(),
+                debugMessage = "필터에서 발생한 예외"
+            )
+        }
+        filterChain.doFilter(request, response)
+    }
+}

--- a/board-system-external/external-exception-handle/src/test/kotlin/com/ttasjwi/board/system/core/exception/WebMvcExceptionHandleTest.kt
+++ b/board-system-external/external-exception-handle/src/test/kotlin/com/ttasjwi/board/system/core/exception/WebMvcExceptionHandleTest.kt
@@ -1,0 +1,83 @@
+package com.ttasjwi.board.system.core.exception
+
+import com.ttasjwi.board.system.ExceptionApiTestController
+import com.ttasjwi.board.system.TestConfig
+import com.ttasjwi.board.system.core.config.ExceptionHandleFilterConfig
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+
+@ActiveProfiles("test")
+@WebMvcTest(controllers = [ExceptionApiTestController::class])
+@AutoConfigureMockMvc
+@Import(TestConfig::class, ExceptionHandleFilterConfig::class)
+@DisplayName("WebMvc에서 예외 처리가 잘 적용되는 지 테스트")
+class WebMvcExceptionHandleTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Test
+    @DisplayName("'/api/test-success' 엔드포인트를 호출하면 hello 문자열이 반환된다.")
+    fun caseTestSuccessEndPointSuccess() {
+        mockMvc
+            .perform(get("/api/test-success"))
+            .andDo(print())
+            .andExpectAll(
+                status().isOk,
+                content().contentType("text/plain;charset=UTF-8"),
+                content().string("hello")
+            )
+    }
+
+    @Test
+    @DisplayName("'/api/test-success' 엔드포인트 호출시 ex=true 파라미터를 전달하면 필터에서 예외가 발생하고, 이를 앞단의 필터가 처리한다.")
+    fun caseFilterException() {
+        mockMvc
+            .perform(get("/api/test-success?ex=true")) // ex=true 파라미터를 전달하면 ExceptionApiTestFilter에서 예외 발생함
+            .andDo(print())
+            .andExpectAll(
+                status().isBadRequest,
+                content().contentType(MediaType.APPLICATION_JSON),
+                jsonPath("$.isSuccess").value(false),
+                jsonPath("$.code").value("Error.Occurred"),
+                jsonPath("$.message").value("Error.Occurred.message"),
+                jsonPath("$.description").value("Error.Occurred.description(args=[])"),
+                jsonPath("$.data").doesNotExist(),
+                jsonPath("$.errors[0].code").value("Error.Fixture"),
+                jsonPath("$.errors[0].message").value("Error.Fixture.message"),
+                jsonPath("$.errors[0].description").value("Error.Fixture.description(args=[])"),
+                jsonPath("$.errors[0].source").value("filter"),
+            )
+    }
+
+    @Test
+    @DisplayName("컨트롤러에서 예외 발생하면 HandlerExceptionResolver 에서 처리한다.")
+    fun caseControllerException() {
+        mockMvc
+            .perform(get("/api/test-ex")) // 컨트롤러에서 예외 발생함
+            .andDo(print())
+            .andExpectAll(
+                status().isBadRequest,
+                content().contentType(MediaType.APPLICATION_JSON),
+                jsonPath("$.isSuccess").value(false),
+                jsonPath("$.code").value("Error.Occurred"),
+                jsonPath("$.message").value("Error.Occurred.message"),
+                jsonPath("$.description").value("Error.Occurred.description(args=[])"),
+                jsonPath("$.data").doesNotExist(),
+                jsonPath("$.errors[0].code").value("Error.Fixture"),
+                jsonPath("$.errors[0].message").value("Error.Fixture.message"),
+                jsonPath("$.errors[0].description").value("Error.Fixture.description(args=[])"),
+                jsonPath("$.errors[0].source").value("controller"),
+            )
+    }
+}

--- a/board-system-external/external-exception-handle/src/test/kotlin/com/ttasjwi/board/system/core/exception/api/ErrorHttpStatusResolveFunctionTest.kt
+++ b/board-system-external/external-exception-handle/src/test/kotlin/com/ttasjwi/board/system/core/exception/api/ErrorHttpStatusResolveFunctionTest.kt
@@ -1,0 +1,59 @@
+package com.ttasjwi.board.system.core.exception.api
+
+import com.ttasjwi.board.system.core.exception.ErrorStatus
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+
+@DisplayName("ErrorHttpStatusResolveFunction 테스트")
+class ErrorHttpStatusResolveFunctionTest {
+
+    @Test
+    @DisplayName("ErrorStatus.INVALID_ARGUMENT 는 BAD REQUEST 상태코드로 변환한다.")
+    fun caseInvalidArgument() {
+        val errorStatus = ErrorStatus.INVALID_ARGUMENT
+        val httpStatus = resolveHttpStatus(errorStatus)
+        assertThat(httpStatus).isEqualTo(HttpStatus.BAD_REQUEST)
+    }
+
+    @Test
+    @DisplayName("ErrorStatus.NOT_FOUND 는 NOT FOUND 상태코드로 변환한다.")
+    fun caseNotFound() {
+        val errorStatus = ErrorStatus.NOT_FOUND
+        val httpStatus = resolveHttpStatus(errorStatus)
+        assertThat(httpStatus).isEqualTo(HttpStatus.NOT_FOUND)
+    }
+
+    @Test
+    @DisplayName("ErrorStatus.UNAUTHENTICATED 는 UNAUTHORIZED 상태코드로 변환한다.")
+    fun caseUnauthenticated() {
+        val errorStatus = ErrorStatus.UNAUTHENTICATED
+        val httpStatus = resolveHttpStatus(errorStatus)
+        assertThat(httpStatus).isEqualTo(HttpStatus.UNAUTHORIZED)
+    }
+
+    @Test
+    @DisplayName("ErrorStatus.FORBIDDEN 은 FORBIDDEN 상태코드로 변환한다.")
+    fun caseForbidden() {
+        val errorStatus = ErrorStatus.FORBIDDEN
+        val httpStatus = resolveHttpStatus(errorStatus)
+        assertThat(httpStatus).isEqualTo(HttpStatus.FORBIDDEN)
+    }
+
+    @Test
+    @DisplayName("ErrorStatus.CONFLICT 는 CONFLICT 상태코드로 변환한다.")
+    fun caseConflict() {
+        val errorStatus = ErrorStatus.CONFLICT
+        val httpStatus = resolveHttpStatus(errorStatus)
+        assertThat(httpStatus).isEqualTo(HttpStatus.CONFLICT)
+    }
+
+    @Test
+    @DisplayName("ErrorStatus.APPLICATION 은 INTERNAL_SERVER_ERROR 상태코드로 변환한다.")
+    fun caseApplicationError() {
+        val errorStatus = ErrorStatus.APPLICATION_ERROR
+        val httpStatus = resolveHttpStatus(errorStatus)
+        assertThat(httpStatus).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+    }
+}

--- a/board-system-external/external-exception-handle/src/test/kotlin/com/ttasjwi/board/system/core/exception/api/GlobalExceptionControllerTest.kt
+++ b/board-system-external/external-exception-handle/src/test/kotlin/com/ttasjwi/board/system/core/exception/api/GlobalExceptionControllerTest.kt
@@ -1,0 +1,94 @@
+package com.ttasjwi.board.system.core.exception.api
+
+import com.ttasjwi.board.system.core.api.ErrorResponse
+import com.ttasjwi.board.system.core.exception.NullArgumentException
+import com.ttasjwi.board.system.core.exception.ValidationExceptionCollector
+import com.ttasjwi.board.system.core.message.fixture.MessageResolverFixture
+import org.assertj.core.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+
+
+@DisplayName("GlobalExceptionController 테스트")
+class GlobalExceptionControllerTest {
+
+    private val exceptionController = GlobalExceptionController(MessageResolverFixture())
+
+    @Test
+    @DisplayName("Exception 및 그 자손은 서버 에러로 취급한다.")
+    fun handleExceptionTest() {
+        val exception = Exception()
+
+        val responseEntity = exceptionController.handleException(exception)
+        val response = responseEntity.body as ErrorResponse
+
+        assertThat(responseEntity.statusCode.value()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value())
+        assertThat(response.isSuccess).isFalse()
+        assertThat(response.code).isEqualTo("Error.Occurred")
+        assertThat(response.message).isEqualTo("Error.Occurred.message")
+        assertThat(response.description).isEqualTo("Error.Occurred.description(args=[])")
+        assertThat(response.errors.size).isEqualTo(1)
+
+        val errorItem = response.errors[0]
+        assertThat(errorItem.code).isEqualTo("Error.Server")
+        assertThat(errorItem.message).isEqualTo("Error.Server.message")
+        assertThat(errorItem.description).isEqualTo("Error.Server.description(args=[])")
+        assertThat(errorItem.source).isEqualTo("server")
+    }
+
+    @Test
+    @DisplayName("우리 서비스에서 정의한 CustomException 을 받으면 예외 정보를 기반으로 예외처리한다.")
+    fun handleCustomException() {
+        val exception = NullArgumentException("email")
+
+        val responseEntity = exceptionController.handleCustomException(exception)
+        val response = responseEntity.body as ErrorResponse
+
+        assertThat(responseEntity.statusCode.value()).isEqualTo(HttpStatus.BAD_REQUEST.value())
+        assertThat(response.isSuccess).isFalse()
+        assertThat(response.code).isEqualTo("Error.Occurred")
+        assertThat(response.message).isEqualTo("Error.Occurred.message")
+        assertThat(response.description).isEqualTo("Error.Occurred.description(args=[])")
+        assertThat(response.errors.size).isEqualTo(1)
+
+        val errorItem = response.errors[0]
+        assertThat(errorItem.code).isEqualTo(exception.code)
+        assertThat(errorItem.message).isEqualTo("${exception.code}.message")
+        assertThat(errorItem.description).isEqualTo("${exception.code}.description(args=${exception.args})")
+        assertThat(errorItem.source).isEqualTo(exception.source)
+    }
+
+    @Test
+    @DisplayName("ValidationExceptionCollector 을 잘 handle 하는 지 테스트")
+    fun handleValidationExceptionCollectorTest() {
+        val exceptionCollector = ValidationExceptionCollector()
+
+        val exception1 = NullArgumentException("loginId")
+        val exception2 = NullArgumentException("password")
+        exceptionCollector.addCustomExceptionOrThrow(exception1)
+        exceptionCollector.addCustomExceptionOrThrow(exception2)
+
+        val responseEntity = exceptionController.handleValidationExceptionCollector(exceptionCollector)
+        val response = responseEntity.body as ErrorResponse
+
+        assertThat(responseEntity.statusCode.value()).isEqualTo(HttpStatus.BAD_REQUEST.value())
+        assertThat(response.isSuccess).isFalse()
+        assertThat(response.code).isEqualTo("Error.Occurred")
+        assertThat(response.message).isEqualTo("Error.Occurred.message")
+        assertThat(response.description).isEqualTo("Error.Occurred.description(args=[])")
+        assertThat(response.errors.size).isEqualTo(2)
+
+        val errorItem1 = response.errors[0]
+        val errorItem2 = response.errors[1]
+
+        assertThat(errorItem1.code).isEqualTo(exception1.code)
+        assertThat(errorItem1.message).isEqualTo("${exception1.code}.message")
+        assertThat(errorItem1.description).isEqualTo("${exception1.code}.description(args=${exception1.args})")
+        assertThat(errorItem1.source).isEqualTo(exception1.source)
+        assertThat(errorItem2.code).isEqualTo(exception2.code)
+        assertThat(errorItem2.message).isEqualTo("${exception2.code}.message")
+        assertThat(errorItem2.description).isEqualTo("${exception2.code}.description(args=${exception2.args})")
+        assertThat(errorItem2.source).isEqualTo(exception2.source)
+    }
+}

--- a/board-system-external/external-exception-handle/src/test/kotlin/com/ttasjwi/board/system/core/exception/fixture/CustomExceptionFixture.kt
+++ b/board-system-external/external-exception-handle/src/test/kotlin/com/ttasjwi/board/system/core/exception/fixture/CustomExceptionFixture.kt
@@ -1,0 +1,38 @@
+package com.ttasjwi.board.system.core.exception.fixture
+
+import com.ttasjwi.board.system.core.exception.CustomException
+import com.ttasjwi.board.system.core.exception.ErrorStatus
+
+fun customExceptionFixture(
+    status: ErrorStatus = ErrorStatus.INVALID_ARGUMENT,
+    code: String = "Error.Fixture",
+    args: List<Any?> = emptyList(),
+    source: String = "fixtureErrorSource",
+    debugMessage: String = "커스텀 예외 픽스쳐입니다.",
+    cause: Throwable? = null,
+): CustomException {
+    return CustomExceptionFixture(
+        status = status,
+        code = code,
+        args = args,
+        source = source,
+        debugMessage = debugMessage,
+        cause = cause
+    )
+}
+
+internal class CustomExceptionFixture(
+    status: ErrorStatus,
+    code: String,
+    args: List<Any?>,
+    source: String,
+    debugMessage: String,
+    cause: Throwable?
+) : CustomException(
+    status = status,
+    code = code,
+    args = args,
+    source = source,
+    debugMessage = debugMessage,
+    cause = cause
+)

--- a/board-system-external/external-exception-handle/src/test/kotlin/com/ttasjwi/board/system/core/exception/fixture/CustomExceptionFixtureTest.kt
+++ b/board-system-external/external-exception-handle/src/test/kotlin/com/ttasjwi/board/system/core/exception/fixture/CustomExceptionFixtureTest.kt
@@ -1,0 +1,59 @@
+package com.ttasjwi.board.system.core.exception.fixture
+
+import com.ttasjwi.board.system.core.exception.CustomException
+import com.ttasjwi.board.system.core.exception.ErrorStatus
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("CustomExceptionFixture 테스트")
+class CustomExceptionFixtureTest {
+
+    @Test
+    @DisplayName("필드 값을 전달하지 않아도 기본적인 예외 인스턴스가 생성된다.")
+    fun test() {
+        // given
+        // when
+        val exception = customExceptionFixture()
+
+        assertThat(exception).isNotNull
+        assertThat(exception).isInstanceOf(CustomException::class.java)
+        assertThat(exception.status).isNotNull
+        assertThat(exception.code).isNotNull
+        assertThat(exception.args).isNotNull
+        assertThat(exception.source).isNotNull
+        assertThat(exception.debugMessage).isNotNull()
+        assertThat(exception.cause).isNull()
+    }
+
+    @Test
+    @DisplayName("커스텀하게 필드를 지정해서 전달하여 인스턴스를 생성할 수 있다.")
+    fun testCustom() {
+        // given
+        val status = ErrorStatus.INVALID_ARGUMENT
+        val code = "Error.InvalidArgumentFixture"
+        val args = listOf(1, 2)
+        val source = "nickname"
+        val debugMessage = "some debug message fixture"
+        val cause = IllegalArgumentException("some thing is wrong")
+
+        // when
+        val exception = customExceptionFixture(
+            status = status,
+            code = code,
+            args = args,
+            source = source,
+            debugMessage = debugMessage,
+            cause = cause
+        )
+
+        assertThat(exception).isNotNull
+        assertThat(exception).isInstanceOf(CustomException::class.java)
+        assertThat(exception.status).isEqualTo(status)
+        assertThat(exception.code).isEqualTo(code)
+        assertThat(exception.args).containsExactlyElementsOf(args)
+        assertThat(exception.source).isEqualTo(source)
+        assertThat(exception.debugMessage).isEqualTo(debugMessage)
+        assertThat(exception.cause).isEqualTo(cause)
+    }
+}

--- a/board-system-external/external-exception-handle/src/test/kotlin/com/ttasjwi/board/system/core/message/fixture/MessageResolverFixture.kt
+++ b/board-system-external/external-exception-handle/src/test/kotlin/com/ttasjwi/board/system/core/message/fixture/MessageResolverFixture.kt
@@ -1,0 +1,14 @@
+package com.ttasjwi.board.system.core.message.fixture
+
+import com.ttasjwi.board.system.core.message.MessageResolver
+
+class MessageResolverFixture : MessageResolver {
+
+    override fun resolveMessage(code: String): String {
+        return "$code.message"
+    }
+
+    override fun resolveDescription(code: String, args: List<Any?>): String {
+        return "$code.description(args=$args)"
+    }
+}

--- a/board-system-external/external-exception-handle/src/test/kotlin/com/ttasjwi/board/system/core/message/fixture/MessageResolverFixtureTest.kt
+++ b/board-system-external/external-exception-handle/src/test/kotlin/com/ttasjwi/board/system/core/message/fixture/MessageResolverFixtureTest.kt
@@ -1,0 +1,44 @@
+package com.ttasjwi.board.system.core.message.fixture
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("MessageResolverFixture 테스트")
+class MessageResolverFixtureTest {
+
+    private val messageResolver = MessageResolverFixture()
+
+    @Test
+    @DisplayName("resolveMessage: code를 전달하면 code 뒤에 code.message 을 반환한다.")
+    fun testGeneralTitle() {
+        val code = "hello"
+        val title = messageResolver.resolveMessage(code)
+        assertThat(title).isEqualTo("$code.message")
+    }
+
+    @Test
+    @DisplayName("resolveDescription: code와 args를 전달하면 `code.description(args=[args원소들])'을 반환한다.")
+    fun testDescription() {
+        val code = "hello"
+        val args = listOf(1, 2)
+        val description = messageResolver.resolveDescription(code, args)
+        assertThat(description).isEqualTo("$code.description(args=[1, 2])")
+    }
+
+    @Test
+    @DisplayName("resolveDescription: code만 전달하면 `code.description(args=[])'을 반환한다.")
+    fun testDescriptionOnlyCode() {
+        val code = "hello"
+        val description = messageResolver.resolveDescription(code)
+        assertThat(description).isEqualTo("$code.description(args=[])")
+    }
+
+    @Test
+    @DisplayName("resolveDescription: code와 args(빈리스트)를 전달하면 `code.description(args=[])'을 반환한다.")
+    fun testDescriptionWhenArgsNull() {
+        val code = "hello"
+        val description = messageResolver.resolveDescription(code, emptyList())
+        assertThat(description).isEqualTo("$code.description(args=[])")
+    }
+}

--- a/board-system-external/external-message/src/main/resources/message/error-message_en.yml
+++ b/board-system-external/external-message/src/main/resources/message/error-message_en.yml
@@ -1,4 +1,10 @@
 Error:
+  Occurred:
+    message: "Error occurred"
+    description: "Failed to process the request. An error has occurred."
+  Server:
+    message: "Server Error"
+    description: "An unknown error has occurred. If the issue persists, please contact customer support."
   NullArgument:
     message: "Missing required value"
     description: "The field ''{0}'' is required."

--- a/board-system-external/external-message/src/main/resources/message/error-message_ko.yml
+++ b/board-system-external/external-message/src/main/resources/message/error-message_ko.yml
@@ -1,4 +1,10 @@
 Error:
+  Occurred:
+    message: "에러 발생"
+    description: "요청 처리에 실패했습니다. 에러가 발생했습니다."
+  Server:
+    message: "서버 에러"
+    description: "알 수 없는 예러가 발생했습니다. 문제가 지속되면 고객 지원팀에 문의해 주세요."
   NullArgument:
     message: "필수값 누락"
     description: "''{0}''은(는) 필수입니다."

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,4 +15,5 @@ include(
 
     // external : 외부 기술 의존성
     "board-system-external:external-message",
+    "board-system-external:external-exception-handle"
 )


### PR DESCRIPTION
# JIRA 티켓
- [BRD-66]

---

# 작업 내역
- `@RestControllerAdvice`, `@ExceptionHandler` 를 사용하여 예외 처리기 작성
- Filter 앞단에 예외 처리 필터를 두고 HandlerExceptionResolver를 통해 예외 처리 위임을 할 수 있도록 함
- 테스트코드 작성
- 예외메시지 추가 작성

[BRD-66]: https://ttasjwi.atlassian.net/browse/BRD-66?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ