### PR TITLE
Fix: (BRD-69) 배포 스크립트 취약성 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,8 +34,6 @@ jobs:
 
       - name: 프로젝트 빌드
         run: |
-          echo ${{ secrets.DEPLOY_CONFIG_BLUE_YML }} | base64 --decode > ./board-system-api/api-deploy/src/main/resources/deploy-config-blue.yml
-          echo ${{ secrets.DEPLOY_CONFIG_GREEN_YML }} | base64 --decode > ./board-system-api/api-deploy/src/main/resources/deploy-config-green.yml
           ./gradlew build
 
       - name: DockerHub 로그인
@@ -117,6 +115,14 @@ jobs:
         run: |
           ssh board-ec2 << 'EOF'
             set -e
+          
+            # 필요한 프로필 파일을 서버로 복사합니다.
+            mkdir -p /home/ec2-user/config/board-system
+            if [ "${{ env.TARGET_UPSTREAM }}" = "blue" ]; then
+              echo "${{ secrets.DEPLOY_CONFIG_BLUE_YML }}" | base64 --decode > /home/ec2-user/config/board-system/deploy-config-blue.yml
+            else
+              echo "${{ secrets.DEPLOY_CONFIG_GREEN_YML }}" | base64 --decode > /home/ec2-user/config/board-system/deploy-config-green.yml
+            fi
             docker pull ${{ secrets.DOCKERHUB_USERNAME }}/board-be:latest
             docker compose -f docker-compose-${{ env.TARGET_UPSTREAM }}.yml up -d
           EOF

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM amazoncorretto:21-alpine3.20-jdk
 ARG JAR_FILE=board-system-container/build/libs/board-system-container.jar
 ARG PROFILES
 COPY ${JAR_FILE} app.jar
-ENTRYPOINT ["java", "-DSpring.profiles.active=${PROFILES}", "-jar", "app.jar"]
+ENTRYPOINT ["sh", "-c", "java -DSpring.profiles.active=${PROFILES} -Dspring.config.location=classpath:/,file:/app/config/board-system/ -jar app.jar"]


### PR DESCRIPTION
# JIRA 티켓
- [BRD-69]

---

# 문제
- 빌드 시점에 설정파일이 포함되어서 빌드되고, Dockerfile 이미지 빌드시점에 포함됨
- Docker 이미지를 제3자가 pull 하면 위험

---

# 해결
- 빌드 스크립트 수정
- Docker 컨테이너 실행 시점(jar 파일 실행 시점)에 설정파일을 가져와서 실행하도록 수정

[BRD-69]: https://ttasjwi.atlassian.net/browse/BRD-69?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ