### PR TITLE
Refactor: (BRD-70) 메시지/로케일 획득 인터페이스 분리

### DIFF
--- a/board-system-api/api-deploy/src/main/kotlin/com/ttasjwi/board/system/deploy/api/HealthCheckController.kt
+++ b/board-system-api/api-deploy/src/main/kotlin/com/ttasjwi/board/system/deploy/api/HealthCheckController.kt
@@ -1,6 +1,7 @@
 package com.ttasjwi.board.system.deploy.api
 
 import com.ttasjwi.board.system.core.api.SuccessResponse
+import com.ttasjwi.board.system.core.locale.LocaleManager
 import com.ttasjwi.board.system.core.message.MessageResolver
 import com.ttasjwi.board.system.deploy.config.DeployProperties
 import org.springframework.http.ResponseEntity
@@ -11,16 +12,18 @@ import org.springframework.web.bind.annotation.RestController
 class HealthCheckController(
     private val messageResolver: MessageResolver,
     private val deployProperties: DeployProperties,
+    private val localeManager: LocaleManager,
 ) {
 
     @GetMapping("/api/v1/deploy/health-check")
     fun healthCheck(): ResponseEntity<SuccessResponse<HealthCheckResponse>> {
         val code = "HealthCheck.Success"
+        val locale = localeManager.getCurrentLocale()
         val args = listOf("$.data.profile")
         val response = SuccessResponse(
             code = code,
-            message = messageResolver.resolveMessage(code),
-            description = messageResolver.resolveDescription(code, args),
+            message = messageResolver.resolveMessage(code, locale),
+            description = messageResolver.resolveDescription(code, args, locale),
             data = HealthCheckResponse(
                 profile = deployProperties.profile
             )

--- a/board-system-api/api-deploy/src/test/kotlin/com/ttasjwi/board/system/deploy/api/HealthCheckControllerMiddleTest.kt
+++ b/board-system-api/api-deploy/src/test/kotlin/com/ttasjwi/board/system/deploy/api/HealthCheckControllerMiddleTest.kt
@@ -1,5 +1,6 @@
 package com.ttasjwi.board.system.deploy.api
 
+import com.ttasjwi.board.system.core.locale.fixture.LocaleManagerFixture
 import com.ttasjwi.board.system.core.message.MessageResolver
 import com.ttasjwi.board.system.core.message.fixture.MessageResolverFixture
 import com.ttasjwi.board.system.deploy.config.DeployProperties
@@ -18,6 +19,7 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+import java.util.*
 
 @ActiveProfiles("test")
 @WebMvcTest(controllers = [HealthCheckController::class])
@@ -38,6 +40,11 @@ class HealthCheckControllerMiddleTest {
         fun messageResolverFixture(): MessageResolver {
             return MessageResolverFixture()
         }
+
+        @Bean
+        fun localeManagerFixture(): LocaleManagerFixture {
+            return LocaleManagerFixture()
+        }
     }
 
     @Test
@@ -51,8 +58,8 @@ class HealthCheckControllerMiddleTest {
                 content().contentType(MediaType.APPLICATION_JSON),
                 jsonPath("$.isSuccess").value(true),
                 jsonPath("$.code").value("HealthCheck.Success"),
-                jsonPath("$.message").value("HealthCheck.Success.message"),
-                jsonPath("$.description").value("HealthCheck.Success.description(args=[\$.data.profile])"),
+                jsonPath("$.message").value("HealthCheck.Success.message(locale=${Locale.KOREAN})"),
+                jsonPath("$.description").value("HealthCheck.Success.description(args=[\$.data.profile],locale=${Locale.KOREAN})"),
                 jsonPath("$.data.profile").value("test")
             )
     }

--- a/board-system-api/api-member/src/main/kotlin/com/ttasjwi/board/system/member/api/EmailAvailableController.kt
+++ b/board-system-api/api-member/src/main/kotlin/com/ttasjwi/board/system/member/api/EmailAvailableController.kt
@@ -1,6 +1,7 @@
 package com.ttasjwi.board.system.member.api
 
 import com.ttasjwi.board.system.core.api.SuccessResponse
+import com.ttasjwi.board.system.core.locale.LocaleManager
 import com.ttasjwi.board.system.core.message.MessageResolver
 import com.ttasjwi.board.system.member.application.usecase.EmailAvailableRequest
 import com.ttasjwi.board.system.member.application.usecase.EmailAvailableResult
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController
 class EmailAvailableController(
     private val useCase: EmailAvailableUseCase,
     private val messageResolver: MessageResolver,
+    private val localeManager: LocaleManager,
 ) {
 
     @GetMapping("/api/v1/members/email-available")
@@ -29,17 +31,18 @@ class EmailAvailableController(
 
     private fun makeResponse(result: EmailAvailableResult): SuccessResponse<EmailAvailableResponse> {
         val code = "EmailAvailableCheck.Complete"
+        val locale = localeManager.getCurrentLocale()
         return SuccessResponse(
             code = code,
-            message = messageResolver.resolveMessage(code),
-            description = messageResolver.resolveDescription(code, listOf("$.data.emailAvailable")),
+            message = messageResolver.resolveMessage(code, locale),
+            description = messageResolver.resolveDescription(code, listOf("$.data.emailAvailable"), locale),
             data = EmailAvailableResponse(
                 emailAvailable = EmailAvailableResponse.EmailAvailable(
                     email = result.email,
                     isAvailable = result.isAvailable,
                     reasonCode = result.reasonCode,
-                    message = messageResolver.resolveMessage(result.reasonCode),
-                    description = messageResolver.resolveDescription(result.reasonCode),
+                    message = messageResolver.resolveMessage(result.reasonCode, locale),
+                    description = messageResolver.resolveDescription(result.reasonCode, emptyList(), locale),
                 )
             )
         )

--- a/board-system-api/api-member/src/main/kotlin/com/ttasjwi/board/system/member/api/NicknameAvailableController.kt
+++ b/board-system-api/api-member/src/main/kotlin/com/ttasjwi/board/system/member/api/NicknameAvailableController.kt
@@ -1,6 +1,7 @@
 package com.ttasjwi.board.system.member.api
 
 import com.ttasjwi.board.system.core.api.SuccessResponse
+import com.ttasjwi.board.system.core.locale.LocaleManager
 import com.ttasjwi.board.system.core.message.MessageResolver
 import com.ttasjwi.board.system.member.application.usecase.NicknameAvailableRequest
 import com.ttasjwi.board.system.member.application.usecase.NicknameAvailableResult
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController
 class NicknameAvailableController(
     private val useCase: NicknameAvailableUseCase,
     private val messageResolver: MessageResolver,
+    private val localeManager: LocaleManager,
 ) {
 
     @GetMapping("/api/v1/members/nickname-available")
@@ -29,17 +31,18 @@ class NicknameAvailableController(
 
     private fun makeResponse(result: NicknameAvailableResult): SuccessResponse<NicknameAvailableResponse> {
         val code = "NicknameAvailableCheck.Complete"
+        val locale = localeManager.getCurrentLocale()
         return SuccessResponse(
             code = code,
-            message = messageResolver.resolveMessage(code),
-            description = messageResolver.resolveDescription(code, listOf("$.data.nicknameAvailable")),
+            message = messageResolver.resolveMessage(code, locale),
+            description = messageResolver.resolveDescription(code, listOf("$.data.nicknameAvailable"), locale),
             data = NicknameAvailableResponse(
                 nicknameAvailable = NicknameAvailableResponse.NicknameAvailable(
                     nickname = result.nickname,
                     isAvailable = result.isAvailable,
                     reasonCode = result.reasonCode,
-                    message = messageResolver.resolveMessage(result.reasonCode),
-                    description = messageResolver.resolveDescription(result.reasonCode),
+                    message = messageResolver.resolveMessage(result.reasonCode, locale),
+                    description = messageResolver.resolveDescription(result.reasonCode, emptyList(), locale),
                 )
             )
         )

--- a/board-system-api/api-member/src/main/kotlin/com/ttasjwi/board/system/member/api/UsernameAvailableController.kt
+++ b/board-system-api/api-member/src/main/kotlin/com/ttasjwi/board/system/member/api/UsernameAvailableController.kt
@@ -1,6 +1,7 @@
 package com.ttasjwi.board.system.member.api
 
 import com.ttasjwi.board.system.core.api.SuccessResponse
+import com.ttasjwi.board.system.core.locale.LocaleManager
 import com.ttasjwi.board.system.core.message.MessageResolver
 import com.ttasjwi.board.system.member.application.usecase.UsernameAvailableRequest
 import com.ttasjwi.board.system.member.application.usecase.UsernameAvailableResult
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController
 class UsernameAvailableController(
     private val useCase: UsernameAvailableUseCase,
     private val messageResolver: MessageResolver,
+    private val localeManager: LocaleManager,
 ) {
 
     @GetMapping("/api/v1/members/username-available")
@@ -29,17 +31,18 @@ class UsernameAvailableController(
 
     private fun makeResponse(result: UsernameAvailableResult): SuccessResponse<UsernameAvailableResponse> {
         val code = "UsernameAvailableCheck.Complete"
+        val locale = localeManager.getCurrentLocale()
         return SuccessResponse(
             code = code,
-            message = messageResolver.resolveMessage(code),
-            description = messageResolver.resolveDescription(code, listOf("$.data.usernameAvailable")),
+            message = messageResolver.resolveMessage(code, locale),
+            description = messageResolver.resolveDescription(code, listOf("$.data.usernameAvailable"), locale),
             data = UsernameAvailableResponse(
                 usernameAvailable = UsernameAvailableResponse.UsernameAvailable(
                     username = result.username,
                     isAvailable = result.isAvailable,
                     reasonCode = result.reasonCode,
-                    message = messageResolver.resolveMessage(result.reasonCode),
-                    description = messageResolver.resolveDescription(result.reasonCode),
+                    message = messageResolver.resolveMessage(result.reasonCode, locale),
+                    description = messageResolver.resolveDescription(result.reasonCode, emptyList(), locale),
                 )
             )
         )

--- a/board-system-api/api-member/src/test/kotlin/com/ttasjwi/board/system/member/api/EmailAvailableControllerTest.kt
+++ b/board-system-api/api-member/src/test/kotlin/com/ttasjwi/board/system/member/api/EmailAvailableControllerTest.kt
@@ -1,29 +1,31 @@
 package com.ttasjwi.board.system.member.api
 
 import com.ttasjwi.board.system.core.api.SuccessResponse
-import com.ttasjwi.board.system.core.message.MessageResolver
+import com.ttasjwi.board.system.core.locale.fixture.LocaleManagerFixture
 import com.ttasjwi.board.system.core.message.fixture.MessageResolverFixture
 import com.ttasjwi.board.system.member.application.usecase.EmailAvailableRequest
-import com.ttasjwi.board.system.member.application.usecase.EmailAvailableUseCase
 import com.ttasjwi.board.system.member.application.usecase.fixture.EmailAvailableUseCaseFixture
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
+import java.util.*
 
 @DisplayName("EmailAvailableController 테스트")
 class EmailAvailableControllerTest {
 
     private lateinit var controller: EmailAvailableController
-    private lateinit var useCase: EmailAvailableUseCase
-    private lateinit var messageResolver: MessageResolver
+    private lateinit var useCaseFixture: EmailAvailableUseCaseFixture
+    private lateinit var messageResolverFixture: MessageResolverFixture
+    private lateinit var localeManagerFixture: LocaleManagerFixture
 
     @BeforeEach
     fun setup() {
-        useCase = EmailAvailableUseCaseFixture()
-        messageResolver = MessageResolverFixture()
-        controller = EmailAvailableController(useCase, messageResolver)
+        useCaseFixture = EmailAvailableUseCaseFixture()
+        messageResolverFixture = MessageResolverFixture()
+        localeManagerFixture = LocaleManagerFixture()
+        controller = EmailAvailableController(useCaseFixture, messageResolverFixture, localeManagerFixture)
     }
 
     @Test
@@ -40,15 +42,15 @@ class EmailAvailableControllerTest {
         assertThat(responseEntity.statusCode.value()).isEqualTo(HttpStatus.OK.value())
         assertThat(response.isSuccess).isTrue()
         assertThat(response.code).isEqualTo("EmailAvailableCheck.Complete")
-        assertThat(response.message).isEqualTo("EmailAvailableCheck.Complete.message")
-        assertThat(response.description).isEqualTo("EmailAvailableCheck.Complete.description(args=[$.data.emailAvailable])")
+        assertThat(response.message).isEqualTo("EmailAvailableCheck.Complete.message(locale=${Locale.KOREAN})")
+        assertThat(response.description).isEqualTo("EmailAvailableCheck.Complete.description(args=[$.data.emailAvailable],locale=${Locale.KOREAN})")
 
         val emailAvailable = response.data.emailAvailable
 
         assertThat(emailAvailable.email).isEqualTo(request.email)
         assertThat(emailAvailable.isAvailable).isEqualTo(true)
         assertThat(emailAvailable.reasonCode).isEqualTo("EmailAvailableCheck.Available")
-        assertThat(emailAvailable.message).isEqualTo("EmailAvailableCheck.Available.message")
-        assertThat(emailAvailable.description).isEqualTo("EmailAvailableCheck.Available.description(args=[])")
+        assertThat(emailAvailable.message).isEqualTo("EmailAvailableCheck.Available.message(locale=${Locale.KOREAN})")
+        assertThat(emailAvailable.description).isEqualTo("EmailAvailableCheck.Available.description(args=[],locale=${Locale.KOREAN})")
     }
 }

--- a/board-system-api/api-member/src/test/kotlin/com/ttasjwi/board/system/member/api/NicknameAvailableControllerTest.kt
+++ b/board-system-api/api-member/src/test/kotlin/com/ttasjwi/board/system/member/api/NicknameAvailableControllerTest.kt
@@ -1,29 +1,31 @@
 package com.ttasjwi.board.system.member.api
 
 import com.ttasjwi.board.system.core.api.SuccessResponse
-import com.ttasjwi.board.system.core.message.MessageResolver
+import com.ttasjwi.board.system.core.locale.fixture.LocaleManagerFixture
 import com.ttasjwi.board.system.core.message.fixture.MessageResolverFixture
 import com.ttasjwi.board.system.member.application.usecase.NicknameAvailableRequest
-import com.ttasjwi.board.system.member.application.usecase.NicknameAvailableUseCase
 import com.ttasjwi.board.system.member.application.usecase.fixture.NicknameAvailableUseCaseFixture
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
+import java.util.*
 
 @DisplayName("NicknameAvailableController 테스트")
 class NicknameAvailableControllerTest {
 
     private lateinit var controller: NicknameAvailableController
-    private lateinit var useCase: NicknameAvailableUseCase
-    private lateinit var messageResolver: MessageResolver
+    private lateinit var useCaseFixture: NicknameAvailableUseCaseFixture
+    private lateinit var messageResolverFixture: MessageResolverFixture
+    private lateinit var localeManagerFixture: LocaleManagerFixture
 
     @BeforeEach
     fun setup() {
-        useCase = NicknameAvailableUseCaseFixture()
-        messageResolver = MessageResolverFixture()
-        controller = NicknameAvailableController(useCase, messageResolver)
+        useCaseFixture = NicknameAvailableUseCaseFixture()
+        messageResolverFixture = MessageResolverFixture()
+        localeManagerFixture = LocaleManagerFixture()
+        controller = NicknameAvailableController(useCaseFixture, messageResolverFixture, localeManagerFixture)
     }
 
     @Test
@@ -40,15 +42,15 @@ class NicknameAvailableControllerTest {
         assertThat(responseEntity.statusCode.value()).isEqualTo(HttpStatus.OK.value())
         assertThat(response.isSuccess).isTrue()
         assertThat(response.code).isEqualTo("NicknameAvailableCheck.Complete")
-        assertThat(response.message).isEqualTo("NicknameAvailableCheck.Complete.message")
-        assertThat(response.description).isEqualTo("NicknameAvailableCheck.Complete.description(args=[$.data.nicknameAvailable])")
+        assertThat(response.message).isEqualTo("NicknameAvailableCheck.Complete.message(locale=${Locale.KOREAN})")
+        assertThat(response.description).isEqualTo("NicknameAvailableCheck.Complete.description(args=[$.data.nicknameAvailable],locale=${Locale.KOREAN})")
 
         val nicknameAvailable = response.data.nicknameAvailable
 
         assertThat(nicknameAvailable.nickname).isEqualTo(request.nickname)
         assertThat(nicknameAvailable.isAvailable).isEqualTo(true)
         assertThat(nicknameAvailable.reasonCode).isEqualTo("NicknameAvailableCheck.Available")
-        assertThat(nicknameAvailable.message).isEqualTo("NicknameAvailableCheck.Available.message")
-        assertThat(nicknameAvailable.description).isEqualTo("NicknameAvailableCheck.Available.description(args=[])")
+        assertThat(nicknameAvailable.message).isEqualTo("NicknameAvailableCheck.Available.message(locale=${Locale.KOREAN})")
+        assertThat(nicknameAvailable.description).isEqualTo("NicknameAvailableCheck.Available.description(args=[],locale=${Locale.KOREAN})")
     }
 }

--- a/board-system-api/api-member/src/test/kotlin/com/ttasjwi/board/system/member/api/UsernameAvailableControllerTest.kt
+++ b/board-system-api/api-member/src/test/kotlin/com/ttasjwi/board/system/member/api/UsernameAvailableControllerTest.kt
@@ -1,29 +1,31 @@
 package com.ttasjwi.board.system.member.api
 
 import com.ttasjwi.board.system.core.api.SuccessResponse
-import com.ttasjwi.board.system.core.message.MessageResolver
+import com.ttasjwi.board.system.core.locale.fixture.LocaleManagerFixture
 import com.ttasjwi.board.system.core.message.fixture.MessageResolverFixture
 import com.ttasjwi.board.system.member.application.usecase.UsernameAvailableRequest
-import com.ttasjwi.board.system.member.application.usecase.UsernameAvailableUseCase
 import com.ttasjwi.board.system.member.application.usecase.fixture.UsernameAvailableUseCaseFixture
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
+import java.util.*
 
 @DisplayName("UsernameAvailableController 테스트")
 class UsernameAvailableControllerTest {
 
     private lateinit var controller: UsernameAvailableController
-    private lateinit var useCase: UsernameAvailableUseCase
-    private lateinit var messageResolver: MessageResolver
+    private lateinit var useCaseFixture: UsernameAvailableUseCaseFixture
+    private lateinit var messageResolverFixture: MessageResolverFixture
+    private lateinit var localeManagerFixture: LocaleManagerFixture
 
     @BeforeEach
     fun setup() {
-        useCase = UsernameAvailableUseCaseFixture()
-        messageResolver = MessageResolverFixture()
-        controller = UsernameAvailableController(useCase, messageResolver)
+        useCaseFixture = UsernameAvailableUseCaseFixture()
+        messageResolverFixture = MessageResolverFixture()
+        localeManagerFixture = LocaleManagerFixture()
+        controller = UsernameAvailableController(useCaseFixture, messageResolverFixture, localeManagerFixture)
     }
 
     @Test
@@ -40,15 +42,15 @@ class UsernameAvailableControllerTest {
         assertThat(responseEntity.statusCode.value()).isEqualTo(HttpStatus.OK.value())
         assertThat(response.isSuccess).isTrue()
         assertThat(response.code).isEqualTo("UsernameAvailableCheck.Complete")
-        assertThat(response.message).isEqualTo("UsernameAvailableCheck.Complete.message")
-        assertThat(response.description).isEqualTo("UsernameAvailableCheck.Complete.description(args=[$.data.usernameAvailable])")
+        assertThat(response.message).isEqualTo("UsernameAvailableCheck.Complete.message(locale=${Locale.KOREAN})")
+        assertThat(response.description).isEqualTo("UsernameAvailableCheck.Complete.description(args=[$.data.usernameAvailable],locale=${Locale.KOREAN})")
 
         val usernameAvailable = response.data.usernameAvailable
 
         assertThat(usernameAvailable.username).isEqualTo(request.username)
         assertThat(usernameAvailable.isAvailable).isEqualTo(true)
         assertThat(usernameAvailable.reasonCode).isEqualTo("UsernameAvailableCheck.Available")
-        assertThat(usernameAvailable.message).isEqualTo("UsernameAvailableCheck.Available.message")
-        assertThat(usernameAvailable.description).isEqualTo("UsernameAvailableCheck.Available.description(args=[])")
+        assertThat(usernameAvailable.message).isEqualTo("UsernameAvailableCheck.Available.message(locale=${Locale.KOREAN})")
+        assertThat(usernameAvailable.description).isEqualTo("UsernameAvailableCheck.Available.description(args=[],locale=${Locale.KOREAN})")
     }
 }

--- a/board-system-core/src/main/kotlin/com/ttasjwi/board/system/core/locale/LocaleManager.kt
+++ b/board-system-core/src/main/kotlin/com/ttasjwi/board/system/core/locale/LocaleManager.kt
@@ -1,0 +1,7 @@
+package com.ttasjwi.board.system.core.locale
+
+import java.util.*
+
+interface LocaleManager {
+    fun getCurrentLocale(): Locale
+}

--- a/board-system-core/src/main/kotlin/com/ttasjwi/board/system/core/message/MessageResolver.kt
+++ b/board-system-core/src/main/kotlin/com/ttasjwi/board/system/core/message/MessageResolver.kt
@@ -1,16 +1,19 @@
 package com.ttasjwi.board.system.core.message
 
+import java.util.Locale
+
 interface MessageResolver {
     /**
      * code 에 대응하는 메시지를 찾습니다.
      */
-    fun resolveMessage(code: String): String
+    fun resolveMessage(code: String, locale: Locale): String
 
     /**
      * code 에 대응하는 메시지 설명(description) 을 찾습니다.
      */
     fun resolveDescription(
         code: String,
-        args: List<Any?> = emptyList()
+        args: List<Any?> = emptyList(),
+        locale: Locale,
     ): String
 }

--- a/board-system-core/src/test/kotlin/com/ttasjwi/board/system/core/locale/fixture/LocaleManagerFixtureTest.kt
+++ b/board-system-core/src/test/kotlin/com/ttasjwi/board/system/core/locale/fixture/LocaleManagerFixtureTest.kt
@@ -1,0 +1,35 @@
+package com.ttasjwi.board.system.core.locale.fixture
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.util.*
+
+@DisplayName("LocaleManagerFixture 테스트")
+class LocaleManagerFixtureTest {
+
+    private lateinit var localeManager: LocaleManagerFixture
+
+    @BeforeEach
+    fun setup() {
+        this.localeManager = LocaleManagerFixture()
+    }
+
+    @Test
+    @DisplayName("기본적으로 한국어 로케일을 반환한다.")
+    fun defaultLocale() {
+        val locale = localeManager.getCurrentLocale()
+
+        assertThat(locale).isEqualTo(Locale.KOREAN)
+    }
+
+    @Test
+    @DisplayName("chanageLocale 을 통해 로케일을 변경하고 getCurrentLocale 로 가져올 수 있다")
+    fun changeAndGet() {
+        localeManager.changeLocale(Locale.ENGLISH)
+
+        val locale = localeManager.getCurrentLocale()
+        assertThat(locale).isEqualTo(Locale.ENGLISH)
+    }
+}

--- a/board-system-core/src/test/kotlin/com/ttasjwi/board/system/core/message/fixture/MessageResolverFixtureTest.kt
+++ b/board-system-core/src/test/kotlin/com/ttasjwi/board/system/core/message/fixture/MessageResolverFixtureTest.kt
@@ -3,6 +3,7 @@ package com.ttasjwi.board.system.core.message.fixture
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import java.util.*
 
 @DisplayName("MessageResolverFixture 테스트")
 class MessageResolverFixtureTest {
@@ -10,35 +11,22 @@ class MessageResolverFixtureTest {
     private val messageResolver = MessageResolverFixture()
 
     @Test
-    @DisplayName("resolveMessage: code를 전달하면 code 뒤에 code.message 을 반환한다.")
+    @DisplayName("resolveMessage: code, locale 을 전달하여 메시지를 얻어올 수 있다.")
     fun testGeneralTitle() {
         val code = "hello"
-        val title = messageResolver.resolveMessage(code)
-        assertThat(title).isEqualTo("$code.message")
+        val locale = Locale.KOREAN
+
+        val title = messageResolver.resolveMessage(code, locale)
+        assertThat(title).isEqualTo("$code.message(locale=$locale)")
     }
 
     @Test
-    @DisplayName("resolveDescription: code와 args를 전달하면 `code.description(args=[args원소들])'을 반환한다.")
+    @DisplayName("resolveDescription: code, args, locale 을 전달하여 메시지를 얻어올 수 있다.")
     fun testDescription() {
         val code = "hello"
         val args = listOf(1, 2)
-        val description = messageResolver.resolveDescription(code, args)
-        assertThat(description).isEqualTo("$code.description(args=[1, 2])")
-    }
-
-    @Test
-    @DisplayName("resolveDescription: code만 전달하면 `code.description(args=[])'을 반환한다.")
-    fun testDescriptionOnlyCode() {
-        val code = "hello"
-        val description = messageResolver.resolveDescription(code)
-        assertThat(description).isEqualTo("$code.description(args=[])")
-    }
-
-    @Test
-    @DisplayName("resolveDescription: code와 args(빈리스트)를 전달하면 `code.description(args=[])'을 반환한다.")
-    fun testDescriptionWhenArgsNull() {
-        val code = "hello"
-        val description = messageResolver.resolveDescription(code, emptyList())
-        assertThat(description).isEqualTo("$code.description(args=[])")
+        val locale = Locale.ENGLISH
+        val description = messageResolver.resolveDescription(code, args, locale)
+        assertThat(description).isEqualTo("$code.description(args=[1, 2],locale=$locale)")
     }
 }

--- a/board-system-core/src/testFixtures/kotlin/com/ttasjwi/board/system/core/locale/fixture/LocaleManagerFixture.kt
+++ b/board-system-core/src/testFixtures/kotlin/com/ttasjwi/board/system/core/locale/fixture/LocaleManagerFixture.kt
@@ -1,0 +1,17 @@
+package com.ttasjwi.board.system.core.locale.fixture
+
+import com.ttasjwi.board.system.core.locale.LocaleManager
+import java.util.*
+
+class LocaleManagerFixture(
+    private var locale: Locale = Locale.KOREAN
+) : LocaleManager {
+
+    override fun getCurrentLocale(): Locale {
+        return locale
+    }
+
+    fun changeLocale(locale: Locale) {
+        this.locale = locale
+    }
+}

--- a/board-system-core/src/testFixtures/kotlin/com/ttasjwi/board/system/core/message/fixture/MessageResolverFixture.kt
+++ b/board-system-core/src/testFixtures/kotlin/com/ttasjwi/board/system/core/message/fixture/MessageResolverFixture.kt
@@ -1,14 +1,15 @@
 package com.ttasjwi.board.system.core.message.fixture
 
 import com.ttasjwi.board.system.core.message.MessageResolver
+import java.util.*
 
 class MessageResolverFixture : MessageResolver {
 
-    override fun resolveMessage(code: String): String {
-        return "$code.message"
+    override fun resolveMessage(code: String, locale: Locale): String {
+        return "$code.message(locale=${locale})"
     }
 
-    override fun resolveDescription(code: String, args: List<Any?>): String {
-        return "$code.description(args=$args)"
+    override fun resolveDescription(code: String, args: List<Any?>, locale: Locale): String {
+        return "$code.description(args=$args,locale=$locale)"
     }
 }

--- a/board-system-external/external-exception-handle/src/test/kotlin/com/ttasjwi/board/system/ExceptionApiTestApplication.kt
+++ b/board-system-external/external-exception-handle/src/test/kotlin/com/ttasjwi/board/system/ExceptionApiTestApplication.kt
@@ -1,5 +1,7 @@
 package com.ttasjwi.board.system
 
+import com.ttasjwi.board.system.core.locale.LocaleManager
+import com.ttasjwi.board.system.core.locale.fixture.LocaleManagerFixture
 import com.ttasjwi.board.system.core.message.MessageResolver
 import com.ttasjwi.board.system.core.message.fixture.MessageResolverFixture
 import org.springframework.boot.autoconfigure.SpringBootApplication
@@ -23,6 +25,11 @@ class TestConfig {
     @Bean
     fun messageResolverFixture(): MessageResolver {
         return MessageResolverFixture()
+    }
+
+    @Bean
+    fun localeManagerFixture(): LocaleManager {
+        return LocaleManagerFixture()
     }
 
     /**

--- a/board-system-external/external-exception-handle/src/test/kotlin/com/ttasjwi/board/system/core/exception/WebMvcExceptionHandleTest.kt
+++ b/board-system-external/external-exception-handle/src/test/kotlin/com/ttasjwi/board/system/core/exception/WebMvcExceptionHandleTest.kt
@@ -15,6 +15,7 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+import java.util.*
 
 @ActiveProfiles("test")
 @WebMvcTest(controllers = [ExceptionApiTestController::class])
@@ -50,12 +51,12 @@ class WebMvcExceptionHandleTest {
                 content().contentType(MediaType.APPLICATION_JSON),
                 jsonPath("$.isSuccess").value(false),
                 jsonPath("$.code").value("Error.Occurred"),
-                jsonPath("$.message").value("Error.Occurred.message"),
-                jsonPath("$.description").value("Error.Occurred.description(args=[])"),
+                jsonPath("$.message").value("Error.Occurred.message(locale=${Locale.KOREAN})"),
+                jsonPath("$.description").value("Error.Occurred.description(args=[],locale=${Locale.KOREAN})"),
                 jsonPath("$.data").doesNotExist(),
                 jsonPath("$.errors[0].code").value("Error.Fixture"),
-                jsonPath("$.errors[0].message").value("Error.Fixture.message"),
-                jsonPath("$.errors[0].description").value("Error.Fixture.description(args=[])"),
+                jsonPath("$.errors[0].message").value("Error.Fixture.message(locale=${Locale.KOREAN})"),
+                jsonPath("$.errors[0].description").value("Error.Fixture.description(args=[],locale=${Locale.KOREAN})"),
                 jsonPath("$.errors[0].source").value("filter"),
             )
     }
@@ -71,12 +72,12 @@ class WebMvcExceptionHandleTest {
                 content().contentType(MediaType.APPLICATION_JSON),
                 jsonPath("$.isSuccess").value(false),
                 jsonPath("$.code").value("Error.Occurred"),
-                jsonPath("$.message").value("Error.Occurred.message"),
-                jsonPath("$.description").value("Error.Occurred.description(args=[])"),
+                jsonPath("$.message").value("Error.Occurred.message(locale=${Locale.KOREAN})"),
+                jsonPath("$.description").value("Error.Occurred.description(args=[],locale=${Locale.KOREAN})"),
                 jsonPath("$.data").doesNotExist(),
                 jsonPath("$.errors[0].code").value("Error.Fixture"),
-                jsonPath("$.errors[0].message").value("Error.Fixture.message"),
-                jsonPath("$.errors[0].description").value("Error.Fixture.description(args=[])"),
+                jsonPath("$.errors[0].message").value("Error.Fixture.message(locale=${Locale.KOREAN})"),
+                jsonPath("$.errors[0].description").value("Error.Fixture.description(args=[],locale=${Locale.KOREAN})"),
                 jsonPath("$.errors[0].source").value("controller"),
             )
     }

--- a/board-system-external/external-exception-handle/src/test/kotlin/com/ttasjwi/board/system/core/exception/api/GlobalExceptionControllerTest.kt
+++ b/board-system-external/external-exception-handle/src/test/kotlin/com/ttasjwi/board/system/core/exception/api/GlobalExceptionControllerTest.kt
@@ -3,18 +3,34 @@ package com.ttasjwi.board.system.core.exception.api
 import com.ttasjwi.board.system.core.api.ErrorResponse
 import com.ttasjwi.board.system.core.exception.NullArgumentException
 import com.ttasjwi.board.system.core.exception.ValidationExceptionCollector
+import com.ttasjwi.board.system.core.locale.fixture.LocaleManagerFixture
 import com.ttasjwi.board.system.core.message.fixture.MessageResolverFixture
 import jakarta.servlet.ServletException
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
+import java.util.*
 
 
 @DisplayName("GlobalExceptionController 테스트")
 class GlobalExceptionControllerTest {
 
-    private val exceptionController = GlobalExceptionController(MessageResolverFixture())
+    private lateinit var exceptionController: GlobalExceptionController
+    private lateinit var messageResolverFixture: MessageResolverFixture
+    private lateinit var localeManagerFixture: LocaleManagerFixture
+
+    @BeforeEach
+    fun setup() {
+        messageResolverFixture = MessageResolverFixture()
+        localeManagerFixture = LocaleManagerFixture()
+        exceptionController = GlobalExceptionController(
+            messageResolver = messageResolverFixture,
+            localeManager = localeManagerFixture
+        )
+    }
+
 
     @Test
     @DisplayName("Exception 및 그 자손은 서버 에러로 취급한다.")
@@ -27,14 +43,14 @@ class GlobalExceptionControllerTest {
         assertThat(responseEntity.statusCode.value()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value())
         assertThat(response.isSuccess).isFalse()
         assertThat(response.code).isEqualTo("Error.Occurred")
-        assertThat(response.message).isEqualTo("Error.Occurred.message")
-        assertThat(response.description).isEqualTo("Error.Occurred.description(args=[])")
+        assertThat(response.message).isEqualTo("Error.Occurred.message(locale=${Locale.KOREAN})")
+        assertThat(response.description).isEqualTo("Error.Occurred.description(args=[],locale=${Locale.KOREAN})")
         assertThat(response.errors.size).isEqualTo(1)
 
         val errorItem = response.errors[0]
         assertThat(errorItem.code).isEqualTo("Error.Server")
-        assertThat(errorItem.message).isEqualTo("Error.Server.message")
-        assertThat(errorItem.description).isEqualTo("Error.Server.description(args=[])")
+        assertThat(errorItem.message).isEqualTo("Error.Server.message(locale=${Locale.KOREAN})")
+        assertThat(errorItem.description).isEqualTo("Error.Server.description(args=[],locale=${Locale.KOREAN})")
         assertThat(errorItem.source).isEqualTo("server")
     }
 
@@ -49,14 +65,14 @@ class GlobalExceptionControllerTest {
         assertThat(responseEntity.statusCode.value()).isEqualTo(HttpStatus.BAD_REQUEST.value())
         assertThat(response.isSuccess).isFalse()
         assertThat(response.code).isEqualTo("Error.Occurred")
-        assertThat(response.message).isEqualTo("Error.Occurred.message")
-        assertThat(response.description).isEqualTo("Error.Occurred.description(args=[])")
+        assertThat(response.message).isEqualTo("Error.Occurred.message(locale=${Locale.KOREAN})")
+        assertThat(response.description).isEqualTo("Error.Occurred.description(args=[],locale=${Locale.KOREAN})")
         assertThat(response.errors.size).isEqualTo(1)
 
         val errorItem = response.errors[0]
         assertThat(errorItem.code).isEqualTo(exception.code)
-        assertThat(errorItem.message).isEqualTo("${exception.code}.message")
-        assertThat(errorItem.description).isEqualTo("${exception.code}.description(args=${exception.args})")
+        assertThat(errorItem.message).isEqualTo("${exception.code}.message(locale=${Locale.KOREAN})")
+        assertThat(errorItem.description).isEqualTo("${exception.code}.description(args=${exception.args},locale=${Locale.KOREAN})")
         assertThat(errorItem.source).isEqualTo(exception.source)
     }
 
@@ -64,6 +80,7 @@ class GlobalExceptionControllerTest {
     @DisplayName("NotImplementedError 처리 테스트")
     fun handleNotImplementedError() {
         val e = NotImplementedError()
+
         val servletException = ServletException(e)
 
         val responseEntity = exceptionController.handleException(servletException)
@@ -72,14 +89,14 @@ class GlobalExceptionControllerTest {
         assertThat(responseEntity.statusCode.value()).isEqualTo(HttpStatus.NOT_IMPLEMENTED.value())
         assertThat(response.isSuccess).isFalse()
         assertThat(response.code).isEqualTo("Error.Occurred")
-        assertThat(response.message).isEqualTo("Error.Occurred.message")
-        assertThat(response.description).isEqualTo("Error.Occurred.description(args=[])")
+        assertThat(response.message).isEqualTo("Error.Occurred.message(locale=${Locale.KOREAN})")
+        assertThat(response.description).isEqualTo("Error.Occurred.description(args=[],locale=${Locale.KOREAN})")
         assertThat(response.errors.size).isEqualTo(1)
 
         val errorItem = response.errors[0]
         assertThat(errorItem.code).isEqualTo("Error.NotImplemented")
-        assertThat(errorItem.message).isEqualTo("Error.NotImplemented.message")
-        assertThat(errorItem.description).isEqualTo("Error.NotImplemented.description(args=[])")
+        assertThat(errorItem.message).isEqualTo("Error.NotImplemented.message(locale=${Locale.KOREAN})")
+        assertThat(errorItem.description).isEqualTo("Error.NotImplemented.description(args=[],locale=${Locale.KOREAN})")
         assertThat(errorItem.source).isEqualTo("server")
     }
 
@@ -99,20 +116,20 @@ class GlobalExceptionControllerTest {
         assertThat(responseEntity.statusCode.value()).isEqualTo(HttpStatus.BAD_REQUEST.value())
         assertThat(response.isSuccess).isFalse()
         assertThat(response.code).isEqualTo("Error.Occurred")
-        assertThat(response.message).isEqualTo("Error.Occurred.message")
-        assertThat(response.description).isEqualTo("Error.Occurred.description(args=[])")
+        assertThat(response.message).isEqualTo("Error.Occurred.message(locale=${Locale.KOREAN})")
+        assertThat(response.description).isEqualTo("Error.Occurred.description(args=[],locale=${Locale.KOREAN})")
         assertThat(response.errors.size).isEqualTo(2)
 
         val errorItem1 = response.errors[0]
         val errorItem2 = response.errors[1]
 
         assertThat(errorItem1.code).isEqualTo(exception1.code)
-        assertThat(errorItem1.message).isEqualTo("${exception1.code}.message")
-        assertThat(errorItem1.description).isEqualTo("${exception1.code}.description(args=${exception1.args})")
+        assertThat(errorItem1.message).isEqualTo("${exception1.code}.message(locale=${Locale.KOREAN})")
+        assertThat(errorItem1.description).isEqualTo("${exception1.code}.description(args=${exception1.args},locale=${Locale.KOREAN})")
         assertThat(errorItem1.source).isEqualTo(exception1.source)
         assertThat(errorItem2.code).isEqualTo(exception2.code)
-        assertThat(errorItem2.message).isEqualTo("${exception2.code}.message")
-        assertThat(errorItem2.description).isEqualTo("${exception2.code}.description(args=${exception2.args})")
+        assertThat(errorItem2.message).isEqualTo("${exception2.code}.message(locale=${Locale.KOREAN})")
+        assertThat(errorItem2.description).isEqualTo("${exception2.code}.description(args=${exception2.args},locale=${Locale.KOREAN})")
         assertThat(errorItem2.source).isEqualTo(exception2.source)
     }
 }

--- a/board-system-external/external-message/src/main/kotlin/com/ttasjwi/board/system/core/locale/LocaleManagerImpl.kt
+++ b/board-system-external/external-message/src/main/kotlin/com/ttasjwi/board/system/core/locale/LocaleManagerImpl.kt
@@ -1,0 +1,13 @@
+package com.ttasjwi.board.system.core.locale
+
+import org.springframework.context.i18n.LocaleContextHolder
+import org.springframework.stereotype.Component
+import java.util.*
+
+@Component
+class LocaleManagerImpl : LocaleManager {
+
+    override fun getCurrentLocale(): Locale {
+        return LocaleContextHolder.getLocale()
+    }
+}

--- a/board-system-external/external-message/src/main/kotlin/com/ttasjwi/board/system/core/message/MessageResolverImpl.kt
+++ b/board-system-external/external-message/src/main/kotlin/com/ttasjwi/board/system/core/message/MessageResolverImpl.kt
@@ -2,8 +2,8 @@ package com.ttasjwi.board.system.core.message
 
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.context.MessageSource
-import org.springframework.context.i18n.LocaleContextHolder
 import org.springframework.stereotype.Component
+import java.util.*
 
 @Component
 internal class MessageResolverImpl(
@@ -18,14 +18,14 @@ internal class MessageResolverImpl(
         private const val ERROR_MESSAGE_PREFIX = "Error."
     }
 
-    override fun resolveMessage(code: String): String {
+    override fun resolveMessage(code: String, locale: Locale): String {
         val messageSource = selectMessageSource(code)
-        return messageSource.getMessage("$code.message", null, LocaleContextHolder.getLocale())
+        return messageSource.getMessage("$code.message", null, locale)
     }
 
-    override fun resolveDescription(code: String, args: List<Any?>): String {
+    override fun resolveDescription(code: String, args: List<Any?>, locale: Locale): String {
         val messageSource = selectMessageSource(code)
-        return messageSource.getMessage("$code.description", args.toTypedArray(), LocaleContextHolder.getLocale())
+        return messageSource.getMessage("$code.description", args.toTypedArray(), locale)
     }
 
     private fun selectMessageSource(code: String): MessageSource {

--- a/board-system-external/external-message/src/test/kotlin/com/ttasjwi/board/system/MessageTestController.kt
+++ b/board-system-external/external-message/src/test/kotlin/com/ttasjwi/board/system/MessageTestController.kt
@@ -1,15 +1,16 @@
 package com.ttasjwi.board.system
 
+import com.ttasjwi.board.system.core.locale.LocaleManager
 import com.ttasjwi.board.system.core.message.MessageResolver
 import org.springframework.context.i18n.LocaleContextHolder
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
 
-
 @RestController
 class MessageTestController(
-    private val messageResolver: MessageResolver
+    private val messageResolver: MessageResolver,
+    private val localeManager: LocaleManager,
 ) {
 
     @GetMapping("/api/test")
@@ -18,8 +19,8 @@ class MessageTestController(
 
         val code = "Example"
         val args = listOf(1, 2, 3)
-        val message = messageResolver.resolveMessage(code)
-        val description = messageResolver.resolveDescription(code, args)
+        val message = messageResolver.resolveMessage(code, locale)
+        val description = messageResolver.resolveDescription(code, args, locale)
 
         return ResponseEntity.ok(
             MessageTestResponse(

--- a/board-system-external/external-message/src/test/kotlin/com/ttasjwi/board/system/core/locale/LocaleManagerImplTest.kt
+++ b/board-system-external/external-message/src/test/kotlin/com/ttasjwi/board/system/core/locale/LocaleManagerImplTest.kt
@@ -1,0 +1,28 @@
+package com.ttasjwi.board.system.core.locale
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.context.i18n.LocaleContextHolder
+import java.util.*
+
+@DisplayName("LocaleManagerImpl 테스트")
+class LocaleManagerImplTest {
+
+    private lateinit var localeManager: LocaleManager
+
+    @BeforeEach
+    fun setup() {
+        localeManager = LocaleManagerImpl()
+    }
+
+    @Test
+    @DisplayName("LocaleContextHolder에 저장된 로케일을 반환한다")
+    fun test() {
+        LocaleContextHolder.setLocale(Locale.ENGLISH)
+
+        val locale = localeManager.getCurrentLocale()
+        assertThat(locale).isEqualTo(Locale.ENGLISH)
+    }
+}

--- a/board-system-external/external-message/src/test/kotlin/com/ttasjwi/board/system/core/message/MessageResolverImplTest.kt
+++ b/board-system-external/external-message/src/test/kotlin/com/ttasjwi/board/system/core/message/MessageResolverImplTest.kt
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.context.i18n.LocaleContextHolder
 import org.springframework.test.context.ActiveProfiles
 import java.util.*
 
@@ -19,12 +18,11 @@ class MessageResolverImplTest @Autowired constructor(
     @Test
     @DisplayName("일반 메시지 - 한국어 테스트")
     fun generalMessageKoreanTest() {
-        LocaleContextHolder.setLocale(Locale.KOREAN)
-
         val code = "Example"
+        val locale = Locale.KOREAN
 
-        val message = messageResolver.resolveMessage(code)
-        val description = messageResolver.resolveDescription(code, listOf(1, 2, "야옹"))
+        val message = messageResolver.resolveMessage(code, locale)
+        val description = messageResolver.resolveDescription(code, listOf(1, 2, "야옹"), locale)
 
         assertThat(message).isEqualTo("예제 메시지")
         assertThat(description).isEqualTo("예제 설명(args=1,2,야옹)")
@@ -33,12 +31,11 @@ class MessageResolverImplTest @Autowired constructor(
     @Test
     @DisplayName("일반 메시지 - 영어 테스트")
     fun generalMessageEnglishTest() {
-        LocaleContextHolder.setLocale(Locale.ENGLISH)
-
         val code = "Example"
+        val locale = Locale.ENGLISH
 
-        val message = messageResolver.resolveMessage(code)
-        val description = messageResolver.resolveDescription(code, listOf(1, 2, "nyaa"))
+        val message = messageResolver.resolveMessage(code, locale)
+        val description = messageResolver.resolveDescription(code, listOf(1, 2, "nyaa"), locale)
 
         assertThat(message).isEqualTo("Example Message")
         assertThat(description).isEqualTo("Example Description(args=1,2,nyaa)")
@@ -47,12 +44,11 @@ class MessageResolverImplTest @Autowired constructor(
     @Test
     @DisplayName("에러 메시지 - 한국어 테스트")
     fun errorMessageKoreanTest() {
-        LocaleContextHolder.setLocale(Locale.KOREAN)
-
         val code = "Error.NullArgument"
+        val locale = Locale.KOREAN
 
-        val message = messageResolver.resolveMessage(code)
-        val description = messageResolver.resolveDescription(code, listOf("username"))
+        val message = messageResolver.resolveMessage(code, locale)
+        val description = messageResolver.resolveDescription(code, listOf("username"), locale)
 
         assertThat(message).isEqualTo("필수값 누락")
         assertThat(description).isEqualTo("'username'은(는) 필수입니다.")
@@ -61,12 +57,11 @@ class MessageResolverImplTest @Autowired constructor(
     @Test
     @DisplayName("에러 메시지 - 영어 테스트")
     fun errorMessageEnglishTest() {
-        LocaleContextHolder.setLocale(Locale.ENGLISH)
-
         val code = "Error.NullArgument"
+        val locale = Locale.ENGLISH
 
-        val message = messageResolver.resolveMessage(code)
-        val description = messageResolver.resolveDescription(code, listOf("username"))
+        val message = messageResolver.resolveMessage(code, locale)
+        val description = messageResolver.resolveDescription(code, listOf("username"), locale)
 
         assertThat(message).isEqualTo("Missing required value")
         assertThat(description).isEqualTo("The field 'username' is required.")

--- a/board-system-external/external-message/src/test/kotlin/com/ttasjwi/board/system/core/message/WebMvcLocaleTest.kt
+++ b/board-system-external/external-message/src/test/kotlin/com/ttasjwi/board/system/core/message/WebMvcLocaleTest.kt
@@ -4,6 +4,7 @@ import com.ttasjwi.board.system.MessageTestController
 import com.ttasjwi.board.system.core.config.LocaleConfig
 import com.ttasjwi.board.system.core.config.MessageConfig
 import com.ttasjwi.board.system.core.config.MessageProperties
+import com.ttasjwi.board.system.core.locale.LocaleManagerImpl
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -22,7 +23,7 @@ import java.util.*
 @ActiveProfiles("test")
 @WebMvcTest(controllers = [MessageTestController::class])
 @EnableConfigurationProperties(MessageProperties::class)
-@Import(value = [MessageConfig::class, LocaleConfig::class, MessageResolverImpl::class])
+@Import(value = [MessageConfig::class, LocaleConfig::class, MessageResolverImpl::class, LocaleManagerImpl::class])
 @AutoConfigureMockMvc
 @DisplayName("WebMvc에서 메시지/국제화가 잘 적용되는 지 테스트")
 class WebMvcLocaleTest {


### PR DESCRIPTION
# JIRA 티켓
- [BRD-70]

---

# 배경
```kotlin
package com.ttasjwi.board.system.core.message

interface MessageResolver {
    /**
     * code 에 대응하는 메시지를 찾습니다.
     */
    fun resolveMessage(code: String): String

    /**
     * code 에 대응하는 메시지 설명(description) 을 찾습니다.
     */
    fun resolveDescription(
        code: String,
        args: List<Any?> = emptyList()
    ): String
}

```

- MessageResolver 는 메시지를 획득하기 위한 역할을 담당하는 인터페이스였음

```kotlin
package com.ttasjwi.board.system.core.message

import org.springframework.beans.factory.annotation.Qualifier
import org.springframework.context.MessageSource
import org.springframework.context.i18n.LocaleContextHolder
import org.springframework.stereotype.Component

@Component
internal class MessageResolverImpl(
    @Qualifier("generalMessageSource")
    private val generalMessageSource: MessageSource,

    @Qualifier("errorMessageSource")
    private val errorMessageSource: MessageSource,
) : MessageResolver {

    companion object {
        private const val ERROR_MESSAGE_PREFIX = "Error."
    }

    override fun resolveMessage(code: String): String {
        val messageSource = selectMessageSource(code)
        return messageSource.getMessage("$code.message", null, LocaleContextHolder.getLocale())
    }

    override fun resolveDescription(code: String, args: List<Any?>): String {
        val messageSource = selectMessageSource(code)
        return messageSource.getMessage("$code.description", args.toTypedArray(), LocaleContextHolder.getLocale())
    }

    private fun selectMessageSource(code: String): MessageSource {
        return if (code.startsWith(ERROR_MESSAGE_PREFIX)) {
            errorMessageSource
        } else {
            generalMessageSource
        }
    }
}

```
- 구현체에서 암묵적으로, LocaleContextHolder를 사용하여 로케일을 얻어오고 메시지 구성에 사용해야했음
- 로케일 정보는 스프링 MVC 를 거치면서 LocaleContextHolder 에 넣어지고, 자연스럽게 메시지 구성에 반영될 수 있는 구조였기에 이런 방식은 문제가 없었다.
- 하지만 향후 프로젝트 진행 단계를 거치면서 사용자 HTTP 요청에 기반하지 않은 애플리케이션 입력이 존재할 수 있다. 예를 들어, 사용자 요청을 처리하고 이벤트를 발행한뒤, 별도 스레드에서 이벤트를 구독하여 애플리케이션 로직을 실행하는 경우 LocaleContextHolder를 통해 사용자의 로케일을 얻을 수 없다.
  - 이벤트에 사용자에 로케일 정보를 담고, MessageResolver 에게 로케일 정보를 전달하는 방식으로 로케일 결정을 처리해야한다.

- 결국 사용자의 현재 로케일 정보를 획득하는 역할을 분리하고 MessageResolver와 별개로 사용자의 로케일 정보를 가져오는 역할이 하나 더 필요해진다.

---

# 작업내역
- MessageResolver 에 로케일 파라미터 추가
- MessageResolverImpl 에서 로케일을 결정하던 로직을 별도의 인터페이스로 분리하고 구현체를 따로 작성


[BRD-70]: https://ttasjwi.atlassian.net/browse/BRD-70?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ