### PR TITLE
Feature: (BRD-43) 이메일 인증 시작 API 구현

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -132,6 +132,7 @@ jobs:
           
             # 필요한 프로필 파일을 서버로 복사합니다.
             echo "${{ secrets.DB_CONFIG_PRODUCTION_YML }}" | base64 --decode > /home/ec2-user/config/board-system/db-config-production.yml
+            echo "${{ secrets.EMAIL_SEND_CONFIG_PRODUCTIONSECRET_YML }}" | base64 --decode > /home/ec2-user/config/board-system/email-send-config-productionSecret.yml
           
             if [ "${{ env.TARGET_UPSTREAM }}" = "blue" ]; then
               echo "${{ secrets.DEPLOY_CONFIG_BLUE_YML }}" | base64 --decode > /home/ec2-user/config/board-system/deploy-config-blue.yml

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ build/
 board-system-api/api-deploy/src/main/resources/deploy-config-blue.yml
 board-system-api/api-deploy/src/main/resources/deploy-config-green.yml
 board-system-external/external-db/src/main/resources/db-config-production.yml
+board-system-external/external-email-sender/src/main/resources/email-send-config-localSecret.yml
+board-system-external/external-email-sender/src/main/resources/email-send-config-productionSecret.yml
 
 ### STS ###
 .apt_generated

--- a/board-system-api/api-member/src/main/kotlin/com/ttasjwi/board/system/member/api/EmailVerificationStartController.kt
+++ b/board-system-api/api-member/src/main/kotlin/com/ttasjwi/board/system/member/api/EmailVerificationStartController.kt
@@ -8,6 +8,7 @@ import com.ttasjwi.board.system.member.application.usecase.EmailVerificationStar
 import com.ttasjwi.board.system.member.application.usecase.EmailVerificationStartUseCase
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
 import java.time.ZonedDateTime
 
@@ -19,7 +20,7 @@ class EmailVerificationStartController(
 ) {
 
     @PostMapping("/api/v1/members/email-verification/start")
-    fun startEmailVerification(request: EmailVerificationStartRequest): ResponseEntity<SuccessResponse<EmailVerificationStartResponse>> {
+    fun startEmailVerification(@RequestBody request: EmailVerificationStartRequest): ResponseEntity<SuccessResponse<EmailVerificationStartResponse>> {
         // 애플리케이션 서비스에 요청 처리를 위임
         val result = useCase.startEmailVerification(request)
 

--- a/board-system-api/api-member/src/main/kotlin/com/ttasjwi/board/system/member/api/EmailVerificationStartController.kt
+++ b/board-system-api/api-member/src/main/kotlin/com/ttasjwi/board/system/member/api/EmailVerificationStartController.kt
@@ -1,26 +1,58 @@
 package com.ttasjwi.board.system.member.api
 
 import com.ttasjwi.board.system.core.api.SuccessResponse
+import com.ttasjwi.board.system.core.locale.LocaleManager
+import com.ttasjwi.board.system.core.message.MessageResolver
+import com.ttasjwi.board.system.member.application.usecase.EmailVerificationStartRequest
+import com.ttasjwi.board.system.member.application.usecase.EmailVerificationStartResult
+import com.ttasjwi.board.system.member.application.usecase.EmailVerificationStartUseCase
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RestController
 import java.time.ZonedDateTime
 
 @RestController
-class EmailVerificationStartController {
+class EmailVerificationStartController(
+    private val useCase: EmailVerificationStartUseCase,
+    private val messageResolver: MessageResolver,
+    private val localeManager: LocaleManager,
+) {
 
     @PostMapping("/api/v1/members/email-verification/start")
-    fun startEmailVerification(): ResponseEntity<SuccessResponse<EmailVerificationStartResponse>> {
-        TODO("Not yet implemented")
+    fun startEmailVerification(request: EmailVerificationStartRequest): ResponseEntity<SuccessResponse<EmailVerificationStartResponse>> {
+        // 애플리케이션 서비스에 요청 처리를 위임
+        val result = useCase.startEmailVerification(request)
+
+        // 처리 결과로부터 응답 메시지 가공
+        val response = makeResponse(result)
+
+        // 200 상태코드와 함께 HTTP 응답
+        return ResponseEntity.ok(response)
+    }
+
+    private fun makeResponse(result: EmailVerificationStartResult): SuccessResponse<EmailVerificationStartResponse> {
+        val code = "EmailVerificationStart.Complete"
+        val locale = localeManager.getCurrentLocale()
+        return SuccessResponse(
+            code = code,
+            message = messageResolver.resolveMessage(code, locale),
+            description = messageResolver.resolveDescription(code, listOf("$.data.emailVerificationStartResult"), locale),
+            data = EmailVerificationStartResponse(
+                EmailVerificationStartResponse.EmailVerificationStartResult(
+                    email = result.email,
+                    codeExpiresAt = result.codeExpiresAt
+                )
+            )
+        )
     }
 }
 
 data class EmailVerificationStartResponse(
-    val verificationStartedResult: VerificationStartedResult
+    val emailVerificationStartResult: EmailVerificationStartResult
 ) {
 
-    data class VerificationStartedResult(
+    data class EmailVerificationStartResult(
         val email: String,
-        val codeExpiresAt: ZonedDateTime
+        val codeExpiresAt: ZonedDateTime,
     )
 }

--- a/board-system-api/api-member/src/test/kotlin/com/ttasjwi/board/system/member/api/EmailVerificationStartControllerTest.kt
+++ b/board-system-api/api-member/src/test/kotlin/com/ttasjwi/board/system/member/api/EmailVerificationStartControllerTest.kt
@@ -1,27 +1,58 @@
 package com.ttasjwi.board.system.member.api
 
-import org.junit.jupiter.api.Assertions.*
+import com.ttasjwi.board.system.core.api.SuccessResponse
+import com.ttasjwi.board.system.core.locale.fixture.LocaleManagerFixture
+import com.ttasjwi.board.system.core.message.fixture.MessageResolverFixture
+import com.ttasjwi.board.system.core.time.fixture.timeFixture
+import com.ttasjwi.board.system.member.application.usecase.EmailVerificationStartRequest
+import com.ttasjwi.board.system.member.application.usecase.fixture.EmailVerificationStartUseCaseFixture
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
+import org.springframework.http.HttpStatus
+import java.util.*
 
 @DisplayName("EmailVerificationStartController 테스트")
 class EmailVerificationStartControllerTest {
 
-    private lateinit var emailVerificationStartController: EmailVerificationStartController
+    private lateinit var controller: EmailVerificationStartController
+    private lateinit var useCaseFixture: EmailVerificationStartUseCaseFixture
+    private lateinit var messageResolverFixture: MessageResolverFixture
+    private lateinit var localeManagerFixture: LocaleManagerFixture
 
     @BeforeEach
     fun setup() {
-        emailVerificationStartController = EmailVerificationStartController()
+        useCaseFixture = EmailVerificationStartUseCaseFixture()
+        messageResolverFixture = MessageResolverFixture()
+        localeManagerFixture = LocaleManagerFixture()
+        controller = EmailVerificationStartController(
+            useCase = useCaseFixture,
+            messageResolver = messageResolverFixture,
+            localeManager = localeManagerFixture
+        )
     }
 
     @Test
-    @DisplayName("이 api는 현재 미구현 상태이다.")
+    @DisplayName("유즈케이스를 호출하고 그 결과를 기반으로 200 코드와 함께 응답을 반환한다.")
     fun test() {
         // given
+        val request = EmailVerificationStartRequest(email = "hello@gmail.com")
+
         // when
+        val responseEntity = controller.startEmailVerification(request)
+        val response = responseEntity.body as SuccessResponse<EmailVerificationStartResponse>
+
         // then
-        assertThrows<NotImplementedError> { emailVerificationStartController.startEmailVerification() }
+        assertThat(responseEntity.statusCode.value()).isEqualTo(HttpStatus.OK.value())
+        assertThat(response.isSuccess).isTrue()
+        assertThat(response.code).isEqualTo("EmailVerificationStart.Complete")
+        assertThat(response.message).isEqualTo("EmailVerificationStart.Complete.message(locale=${Locale.KOREAN})")
+        assertThat(response.description).isEqualTo("EmailVerificationStart.Complete.description(args=[$.data.emailVerificationStartResult],locale=${Locale.KOREAN})")
+
+        val emailVerificationStartResult = response.data.emailVerificationStartResult
+
+        assertThat(emailVerificationStartResult.email).isEqualTo(request.email)
+        assertThat(emailVerificationStartResult.codeExpiresAt).isEqualTo(timeFixture())
     }
 }

--- a/board-system-application/application-member/src/main/kotlin/com/ttasjwi/board/system/member/application/dto/EmailVerificationStartCommand.kt
+++ b/board-system-application/application-member/src/main/kotlin/com/ttasjwi/board/system/member/application/dto/EmailVerificationStartCommand.kt
@@ -1,0 +1,11 @@
+package com.ttasjwi.board.system.member.application.dto
+
+import com.ttasjwi.board.system.member.domain.model.Email
+import java.time.ZonedDateTime
+import java.util.*
+
+internal data class EmailVerificationStartCommand(
+    val email: Email,
+    val currenTime: ZonedDateTime,
+    val locale: Locale,
+)

--- a/board-system-application/application-member/src/main/kotlin/com/ttasjwi/board/system/member/application/mapper/EmailVerificationStartCommandMapper.kt
+++ b/board-system-application/application-member/src/main/kotlin/com/ttasjwi/board/system/member/application/mapper/EmailVerificationStartCommandMapper.kt
@@ -1,0 +1,44 @@
+package com.ttasjwi.board.system.member.application.mapper
+
+import com.ttasjwi.board.system.core.annotation.component.ApplicationCommandMapper
+import com.ttasjwi.board.system.core.exception.NullArgumentException
+import com.ttasjwi.board.system.core.locale.LocaleManager
+import com.ttasjwi.board.system.core.time.TimeManager
+import com.ttasjwi.board.system.logging.getLogger
+import com.ttasjwi.board.system.member.application.dto.EmailVerificationStartCommand
+import com.ttasjwi.board.system.member.application.usecase.EmailVerificationStartRequest
+import com.ttasjwi.board.system.member.domain.service.EmailCreator
+
+@ApplicationCommandMapper
+internal class EmailVerificationStartCommandMapper(
+    private val emailCreator: EmailCreator,
+    private val localeManager: LocaleManager,
+    private val timeManager: TimeManager,
+) {
+
+    companion object {
+        private val log = getLogger(EmailVerificationStartCommandMapper::class.java)
+    }
+
+    fun mapToCommand(request: EmailVerificationStartRequest): EmailVerificationStartCommand {
+        log.info { "요청이 유효한지 확인합니다." }
+
+        if (request.email == null) {
+            val e = NullArgumentException("email")
+            log.warn(e)
+            throw e
+        }
+        val email = emailCreator.create(request.email).getOrElse {
+            log.warn(it)
+            throw it
+        }
+        log.info { "입력값이 유효합니다. (email = ${request.email})" }
+
+        return EmailVerificationStartCommand(
+            email = email,
+            currenTime = timeManager.now(),
+            locale = localeManager.getCurrentLocale(),
+        )
+    }
+
+}

--- a/board-system-application/application-member/src/main/kotlin/com/ttasjwi/board/system/member/application/processor/EmailVerificationStartProcessor.kt
+++ b/board-system-application/application-member/src/main/kotlin/com/ttasjwi/board/system/member/application/processor/EmailVerificationStartProcessor.kt
@@ -1,0 +1,38 @@
+package com.ttasjwi.board.system.member.application.processor
+
+import com.ttasjwi.board.system.core.annotation.component.ApplicationProcessor
+import com.ttasjwi.board.system.logging.getLogger
+import com.ttasjwi.board.system.member.application.dto.EmailVerificationStartCommand
+import com.ttasjwi.board.system.member.domain.event.EmailVerificationStartedEvent
+import com.ttasjwi.board.system.member.domain.service.EmailVerificationAppender
+import com.ttasjwi.board.system.member.domain.service.EmailVerificationCreator
+import com.ttasjwi.board.system.member.domain.service.EmailVerificationEventCreator
+
+@ApplicationProcessor
+internal class EmailVerificationStartProcessor(
+    private val emailVerificationCreator: EmailVerificationCreator,
+    private val emailVerificationAppender: EmailVerificationAppender,
+    private val emailVerificationEventCreator: EmailVerificationEventCreator,
+) {
+
+    companion object {
+        private val log = getLogger(EmailVerificationStartProcessor::class.java)
+    }
+
+    fun startEmailVerification(command: EmailVerificationStartCommand): EmailVerificationStartedEvent {
+        log.info{ "이메일 인증을 시작합니다" }
+
+        val emailVerification = emailVerificationCreator.create(command.email, command.currenTime)
+
+        emailVerificationAppender.append(
+            emailVerification = emailVerification,
+            expiresAt = emailVerification.codeExpiresAt
+        )
+
+        val event = emailVerificationEventCreator.onVerificationStarted(emailVerification, command.locale)
+
+        log.info{ "'이메일 인증됨' 이벤트 생성됨.(email=${event.data.email}"}
+
+        return event
+    }
+}

--- a/board-system-application/application-member/src/main/kotlin/com/ttasjwi/board/system/member/application/service/EmailSendApplicationService.kt
+++ b/board-system-application/application-member/src/main/kotlin/com/ttasjwi/board/system/member/application/service/EmailSendApplicationService.kt
@@ -1,0 +1,18 @@
+package com.ttasjwi.board.system.member.application.service
+
+import com.ttasjwi.board.system.core.annotation.component.ApplicationService
+import com.ttasjwi.board.system.member.application.usecase.EmailSendUseCase
+import com.ttasjwi.board.system.member.domain.service.EmailCreator
+import com.ttasjwi.board.system.member.domain.service.EmailSender
+
+@ApplicationService
+internal class EmailSendApplicationService(
+    private val emailCreator: EmailCreator,
+    private val emailSender: EmailSender,
+) : EmailSendUseCase {
+
+    override fun sendEmail(address: String, subject: String, content: String) {
+        val email = emailCreator.create(address).getOrThrow()
+        emailSender.send(email, subject, content)
+    }
+}

--- a/board-system-application/application-member/src/main/kotlin/com/ttasjwi/board/system/member/application/service/EmailVerificationStartApplicationService.kt
+++ b/board-system-application/application-member/src/main/kotlin/com/ttasjwi/board/system/member/application/service/EmailVerificationStartApplicationService.kt
@@ -1,14 +1,52 @@
 package com.ttasjwi.board.system.member.application.service
 
 import com.ttasjwi.board.system.core.annotation.component.ApplicationService
+import com.ttasjwi.board.system.core.application.TransactionRunner
+import com.ttasjwi.board.system.logging.getLogger
+import com.ttasjwi.board.system.member.application.mapper.EmailVerificationStartCommandMapper
+import com.ttasjwi.board.system.member.application.processor.EmailVerificationStartProcessor
 import com.ttasjwi.board.system.member.application.usecase.EmailVerificationStartRequest
 import com.ttasjwi.board.system.member.application.usecase.EmailVerificationStartResult
 import com.ttasjwi.board.system.member.application.usecase.EmailVerificationStartUseCase
+import com.ttasjwi.board.system.member.domain.event.EmailVerificationStartedEvent
+import com.ttasjwi.board.system.member.domain.service.EmailVerificationStartedEventPublisher
 
 @ApplicationService
-internal class EmailVerificationStartApplicationService : EmailVerificationStartUseCase{
+internal class EmailVerificationStartApplicationService(
+    private val commandMapper: EmailVerificationStartCommandMapper,
+    private val processor: EmailVerificationStartProcessor,
+    private val transactionRunner: TransactionRunner,
+    private val eventPublisher: EmailVerificationStartedEventPublisher
+) : EmailVerificationStartUseCase {
+
+    companion object {
+        private val log = getLogger(EmailVerificationStartApplicationService::class.java)
+    }
 
     override fun startEmailVerification(request: EmailVerificationStartRequest): EmailVerificationStartResult {
-        TODO("Not yet implemented")
+        log.info{ "이메일 인증 시작 요청을 받았습니다."}
+
+        // 유효성 검사를 거쳐서 명령으로 변환
+        val command = commandMapper.mapToCommand(request)
+
+        // 프로세서에 위임
+        val event = transactionRunner.run {
+            processor.startEmailVerification(command)
+        }
+
+        // 이벤트 발행
+        eventPublisher.publishEvent(event)
+
+        log.info{ "이메일 인증 시작됨 (email = ${event.data.email}"}
+
+        // 처리 결과로 가공, 반환
+        return makeResult(event)
+    }
+
+    private fun makeResult(event: EmailVerificationStartedEvent): EmailVerificationStartResult {
+        return EmailVerificationStartResult(
+            email = event.data.email,
+            codeExpiresAt = event.data.codeExpiresAt,
+        )
     }
 }

--- a/board-system-application/application-member/src/main/kotlin/com/ttasjwi/board/system/member/application/usecase/EmailSendUseCase.kt
+++ b/board-system-application/application-member/src/main/kotlin/com/ttasjwi/board/system/member/application/usecase/EmailSendUseCase.kt
@@ -1,0 +1,5 @@
+package com.ttasjwi.board.system.member.application.usecase
+
+interface EmailSendUseCase {
+    fun sendEmail(address: String, subject: String, content: String)
+}

--- a/board-system-application/application-member/src/test/kotlin/com/ttasjwi/board/system/member/application/mapper/EmailVerificationStartCommandMapperTest.kt
+++ b/board-system-application/application-member/src/test/kotlin/com/ttasjwi/board/system/member/application/mapper/EmailVerificationStartCommandMapperTest.kt
@@ -1,0 +1,73 @@
+package com.ttasjwi.board.system.member.application.mapper
+
+import com.ttasjwi.board.system.core.exception.CustomException
+import com.ttasjwi.board.system.core.exception.NullArgumentException
+import com.ttasjwi.board.system.core.locale.fixture.LocaleManagerFixture
+import com.ttasjwi.board.system.core.time.fixture.TimeManagerFixture
+import com.ttasjwi.board.system.core.time.fixture.timeFixture
+import com.ttasjwi.board.system.member.application.usecase.EmailVerificationStartRequest
+import com.ttasjwi.board.system.member.domain.model.fixture.emailFixture
+import com.ttasjwi.board.system.member.domain.service.fixture.EmailCreatorFixture
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.*
+import java.util.*
+
+@DisplayName("EmailVerificationStartCommandMapper: EmailVerificationStartRequest 를 EmailVerificationStartCommand 로 변환한다")
+class EmailVerificationStartCommandMapperTest {
+
+    private lateinit var commandMapper: EmailVerificationStartCommandMapper
+    private lateinit var emailCreatorFixture: EmailCreatorFixture
+    private lateinit var localeManagerFixture: LocaleManagerFixture
+    private lateinit var timeManagerFixture: TimeManagerFixture
+
+    @BeforeEach
+    fun setup() {
+        emailCreatorFixture = EmailCreatorFixture()
+        localeManagerFixture = LocaleManagerFixture()
+        timeManagerFixture = TimeManagerFixture()
+        commandMapper = EmailVerificationStartCommandMapper(
+            emailCreator = emailCreatorFixture,
+            timeManager = timeManagerFixture,
+            localeManager = localeManagerFixture,
+        )
+    }
+
+    @Nested
+    @DisplayName("mapToCommand: 사용자 요청을 애플리케이션 명령으로 변환한다.")
+    inner class MapToCommand {
+
+        @Test
+        @DisplayName("이메일이 누락되면 예외가 발생한다")
+        fun testNullEmail() {
+            val request = EmailVerificationStartRequest(email = null)
+
+            val exception = assertThrows<NullArgumentException> { commandMapper.mapToCommand(request) }
+            assertThat(exception.source).isEqualTo("email")
+        }
+
+        @Test
+        @DisplayName("이메일이 형식이 유효하지 않으면 예외가 발생한다")
+        fun testInvalidFormatEmail() {
+            val request = EmailVerificationStartRequest(email = EmailCreatorFixture.ERROR_EMAIL)
+
+            val exception = assertThrows<CustomException> { commandMapper.mapToCommand(request) }
+            assertThat(exception.debugMessage).isEqualTo("이메일 포맷 예외 - 픽스쳐")
+        }
+
+        @Test
+        @DisplayName("이메일 포맷이 유효할 경우 -> 성공")
+        fun testSuccess() {
+            localeManagerFixture.changeLocale(Locale.ENGLISH)
+            timeManagerFixture.changeCurrentTime(timeFixture(minute=3))
+
+            val request = EmailVerificationStartRequest(email = "hello@gmail.com")
+
+            val command = commandMapper.mapToCommand(request)
+
+            assertThat(command).isNotNull
+            assertThat(command.email).isEqualTo(emailFixture("hello@gmail.com"))
+            assertThat(command.locale).isEqualTo(Locale.ENGLISH)
+            assertThat(command.currenTime).isEqualTo(timeFixture(minute=3))
+        }
+    }
+}

--- a/board-system-application/application-member/src/test/kotlin/com/ttasjwi/board/system/member/application/processor/EmailVerificationStartProcessorTest.kt
+++ b/board-system-application/application-member/src/test/kotlin/com/ttasjwi/board/system/member/application/processor/EmailVerificationStartProcessorTest.kt
@@ -1,0 +1,67 @@
+package com.ttasjwi.board.system.member.application.processor
+
+import com.ttasjwi.board.system.core.time.fixture.timeFixture
+import com.ttasjwi.board.system.member.application.dto.EmailVerificationStartCommand
+import com.ttasjwi.board.system.member.domain.model.fixture.emailFixture
+import com.ttasjwi.board.system.member.domain.service.fixture.EmailVerificationCreatorFixture
+import com.ttasjwi.board.system.member.domain.service.fixture.EmailVerificationEventCreatorFixture
+import com.ttasjwi.board.system.member.domain.service.fixture.EmailVerificationStorageFixture
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.util.*
+
+@DisplayName("EmailVerificationStartProcessor: 이메일 인증 시작에 필요한 사전 작업 처리를 담당하는 처리자")
+class EmailVerificationStartProcessorTest {
+
+    private lateinit var processor: EmailVerificationStartProcessor
+    private lateinit var emailVerificationCreatorFixture: EmailVerificationCreatorFixture
+    private lateinit var emailVerificationStorageFixture: EmailVerificationStorageFixture
+    private lateinit var emailVerificationEventCreatorFixture: EmailVerificationEventCreatorFixture
+
+    @BeforeEach
+    fun setup() {
+        emailVerificationCreatorFixture = EmailVerificationCreatorFixture()
+        emailVerificationStorageFixture = EmailVerificationStorageFixture()
+        emailVerificationEventCreatorFixture = EmailVerificationEventCreatorFixture()
+        processor = EmailVerificationStartProcessor(
+            emailVerificationCreator = emailVerificationCreatorFixture,
+            emailVerificationAppender = emailVerificationStorageFixture,
+            emailVerificationEventCreator = emailVerificationEventCreatorFixture,
+        )
+    }
+
+    @Test
+    @DisplayName("이메일인증을 생성하고, 저장하고, 이벤트를 생성하여 반환한다.")
+    fun testSuccess() {
+
+        // given
+        val command = EmailVerificationStartCommand(
+            email = emailFixture("hell@gmail.com"),
+            currenTime = timeFixture(minute =3),
+            locale = Locale.KOREAN
+        )
+
+        // when
+        val event = processor.startEmailVerification(command)
+
+        // then
+        val findEmailVerification = emailVerificationStorageFixture.findByEmailOrNull(command.email)!!
+        val data = event.data
+
+        assertThat(findEmailVerification.email.value).isEqualTo(data.email)
+        assertThat(findEmailVerification.code).isEqualTo("code")
+        assertThat(findEmailVerification.codeCreatedAt).isEqualTo(command.currenTime)
+        assertThat(findEmailVerification.codeExpiresAt).isEqualTo(command.currenTime.plusMinutes(5))
+        assertThat(findEmailVerification.verifiedAt).isNull()
+        assertThat(findEmailVerification.verificationExpiresAt).isNull()
+
+        assertThat(event.occurredAt).isEqualTo(findEmailVerification.codeCreatedAt)
+        assertThat(data.email).isEqualTo(findEmailVerification.email.value)
+        assertThat(data.code).isEqualTo(findEmailVerification.code)
+        assertThat(data.codeCreatedAt).isEqualTo(findEmailVerification.codeCreatedAt)
+        assertThat(data.codeExpiresAt).isEqualTo(findEmailVerification.codeExpiresAt)
+    }
+
+}

--- a/board-system-application/application-member/src/test/kotlin/com/ttasjwi/board/system/member/application/processor/NicknameAvailableProcessorTest.kt
+++ b/board-system-application/application-member/src/test/kotlin/com/ttasjwi/board/system/member/application/processor/NicknameAvailableProcessorTest.kt
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-@DisplayName("NicknameAvailableQueryMapper: NicknameAvailableRequest 를 NicknameAvailableQuery 로 변환한다")
+@DisplayName("NicknameAvailableProcessor: 닉네임이 사용가능한 지 여부를 실질적으로 확인하는 처리자")
 class NicknameAvailableProcessorTest {
 
     private lateinit var processor: NicknameAvailableProcessor

--- a/board-system-application/application-member/src/test/kotlin/com/ttasjwi/board/system/member/application/service/EmailSendApplicationServiceTest.kt
+++ b/board-system-application/application-member/src/test/kotlin/com/ttasjwi/board/system/member/application/service/EmailSendApplicationServiceTest.kt
@@ -1,0 +1,30 @@
+package com.ttasjwi.board.system.member.application.service
+
+import com.ttasjwi.board.system.member.domain.service.fixture.EmailCreatorFixture
+import com.ttasjwi.board.system.member.domain.service.fixture.EmailSenderFixture
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("EmailSendApplicationService 테스트")
+class EmailSendApplicationServiceTest {
+
+    private lateinit var emailSendApplicationService: EmailSendApplicationService
+
+    @BeforeEach
+    fun setup() {
+        emailSendApplicationService = EmailSendApplicationService(
+            emailCreator = EmailCreatorFixture(),
+            emailSender = EmailSenderFixture()
+        )
+    }
+
+    @Test
+    @DisplayName("sendEmail : 도메인서비스를 통해 이메일 발송을 위임")
+    fun test() {
+        val email = "hello@gmail.com"
+        val subject = "제목"
+        val content = "본문"
+        emailSendApplicationService.sendEmail(email, subject, content)
+    }
+}

--- a/board-system-application/application-member/src/test/kotlin/com/ttasjwi/board/system/member/application/service/EmailVerificationStartApplicationServiceTest.kt
+++ b/board-system-application/application-member/src/test/kotlin/com/ttasjwi/board/system/member/application/service/EmailVerificationStartApplicationServiceTest.kt
@@ -1,0 +1,52 @@
+package com.ttasjwi.board.system.member.application.service
+
+import com.ttasjwi.board.system.core.application.fixture.TransactionRunnerFixture
+import com.ttasjwi.board.system.core.locale.fixture.LocaleManagerFixture
+import com.ttasjwi.board.system.core.time.fixture.TimeManagerFixture
+import com.ttasjwi.board.system.core.time.fixture.timeFixture
+import com.ttasjwi.board.system.member.application.mapper.EmailVerificationStartCommandMapper
+import com.ttasjwi.board.system.member.application.processor.EmailVerificationStartProcessor
+import com.ttasjwi.board.system.member.application.usecase.EmailVerificationStartRequest
+import com.ttasjwi.board.system.member.domain.service.fixture.*
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("EmailVerificationStartApplicationService: 이메일 인증 시작을 수행하는 애플리케이션 서비스")
+class EmailVerificationStartApplicationServiceTest {
+
+    private lateinit var applicationService: EmailVerificationStartApplicationService
+    private lateinit var timeManagerFixture: TimeManagerFixture
+
+    @BeforeEach
+    fun setup() {
+        timeManagerFixture = TimeManagerFixture()
+        applicationService = EmailVerificationStartApplicationService(
+            commandMapper = EmailVerificationStartCommandMapper(
+                emailCreator = EmailCreatorFixture(),
+                localeManager = LocaleManagerFixture(),
+                timeManager = timeManagerFixture
+            ),
+            processor = EmailVerificationStartProcessor(
+                emailVerificationCreator = EmailVerificationCreatorFixture(),
+                emailVerificationAppender = EmailVerificationStorageFixture(),
+                emailVerificationEventCreator = EmailVerificationEventCreatorFixture()
+            ),
+            transactionRunner = TransactionRunnerFixture(),
+            eventPublisher = EmailVerificationStartedEventPublisherFixture()
+        )
+    }
+
+    @Test
+    @DisplayName("이메일 인증 시작절차에 들어가고, 그 결과를 반환한다.")
+    fun test() {
+        timeManagerFixture.changeCurrentTime(timeFixture(minute = 3))
+        val request = EmailVerificationStartRequest("hello@gmail.com")
+
+        val result = applicationService.startEmailVerification(request)
+
+        assertThat(result.email).isEqualTo("hello@gmail.com")
+        assertThat(result.codeExpiresAt).isEqualTo(timeFixture(minute = 8))
+    }
+}

--- a/board-system-application/application-member/src/test/kotlin/com/ttasjwi/board/system/member/application/usecase/fixture/EmailSendUseCaseFixtureTest.kt
+++ b/board-system-application/application-member/src/test/kotlin/com/ttasjwi/board/system/member/application/usecase/fixture/EmailSendUseCaseFixtureTest.kt
@@ -1,0 +1,21 @@
+package com.ttasjwi.board.system.member.application.usecase.fixture
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("EmailSendUseCase 픽스쳐 테스트")
+class EmailSendUseCaseFixtureTest {
+
+    private lateinit var emailSendUseCaseFixture: EmailSendUseCaseFixture
+
+    @BeforeEach
+    fun setup() {
+        emailSendUseCaseFixture = EmailSendUseCaseFixture()
+    }
+
+    @Test
+    fun sendEmail() {
+        emailSendUseCaseFixture.sendEmail("ttasjwi@gmail.com", "제목", "내용")
+    }
+}

--- a/board-system-application/application-member/src/test/kotlin/com/ttasjwi/board/system/member/application/usecase/fixture/EmailVerificationStartUseCaseFixtureTest.kt
+++ b/board-system-application/application-member/src/test/kotlin/com/ttasjwi/board/system/member/application/usecase/fixture/EmailVerificationStartUseCaseFixtureTest.kt
@@ -1,0 +1,30 @@
+package com.ttasjwi.board.system.member.application.usecase.fixture
+
+import com.ttasjwi.board.system.member.application.usecase.EmailVerificationStartRequest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("EmailVerificationStartUseCase 픽스쳐 테스트")
+class EmailVerificationStartUseCaseFixtureTest {
+
+    private lateinit var useCaseFixture: EmailVerificationStartUseCaseFixture
+
+    @BeforeEach
+    fun setup() {
+        useCaseFixture = EmailVerificationStartUseCaseFixture()
+    }
+
+    @Test
+    @DisplayName("요청 email 값과 동일한 email, 그리고 임의로 지정한 코드 만료시간을 반환한다")
+    fun test() {
+        val request = EmailVerificationStartRequest(
+            email = "hello@gmail.com",
+        )
+        val result = useCaseFixture.startEmailVerification(request)
+
+        assertThat(result.email).isEqualTo(request.email)
+        assertThat(result.codeExpiresAt).isNotNull
+    }
+}

--- a/board-system-application/application-member/src/testFixtures/kotlin/com/ttasjwi/board/system/member/application/usecase/fixture/EmailSendUseCaseFixture.kt
+++ b/board-system-application/application-member/src/testFixtures/kotlin/com/ttasjwi/board/system/member/application/usecase/fixture/EmailSendUseCaseFixture.kt
@@ -1,0 +1,21 @@
+package com.ttasjwi.board.system.member.application.usecase.fixture
+
+import com.ttasjwi.board.system.logging.getLogger
+import com.ttasjwi.board.system.member.application.usecase.EmailSendUseCase
+
+class EmailSendUseCaseFixture : EmailSendUseCase {
+
+    private val log = getLogger(EmailSendUseCaseFixture::class.java)
+
+    override fun sendEmail(address: String, subject: String, content: String) {
+        log.info {
+            """
+            이메일 발송됨(유즈케이스 픽스쳐)
+            - email= $address
+            - subject = $subject
+            - content = $content
+            -----------------------------------------------------------------------------------------------------------
+        """.trimIndent()
+        }
+    }
+}

--- a/board-system-application/application-member/src/testFixtures/kotlin/com/ttasjwi/board/system/member/application/usecase/fixture/EmailVerificationStartUseCaseFixture.kt
+++ b/board-system-application/application-member/src/testFixtures/kotlin/com/ttasjwi/board/system/member/application/usecase/fixture/EmailVerificationStartUseCaseFixture.kt
@@ -1,0 +1,16 @@
+package com.ttasjwi.board.system.member.application.usecase.fixture
+
+import com.ttasjwi.board.system.core.time.fixture.timeFixture
+import com.ttasjwi.board.system.member.application.usecase.EmailVerificationStartRequest
+import com.ttasjwi.board.system.member.application.usecase.EmailVerificationStartResult
+import com.ttasjwi.board.system.member.application.usecase.EmailVerificationStartUseCase
+
+class EmailVerificationStartUseCaseFixture : EmailVerificationStartUseCase {
+
+    override fun startEmailVerification(request: EmailVerificationStartRequest): EmailVerificationStartResult {
+        return EmailVerificationStartResult(
+            email = request.email!!,
+            codeExpiresAt = timeFixture()
+        )
+    }
+}

--- a/board-system-container/build.gradle.kts
+++ b/board-system-container/build.gradle.kts
@@ -6,6 +6,10 @@ dependencies {
     implementation(project(":board-system-api:api-member"))
     implementation(project(":board-system-api:api-deploy"))
 
+    // event
+    implementation(project(":board-system-event:event-publisher-member"))
+    implementation(project(":board-system-event:event-consumer-member"))
+
     // external
     implementation(project(":board-system-external:external-message"))
     implementation(project(":board-system-external:external-db"))

--- a/board-system-container/build.gradle.kts
+++ b/board-system-container/build.gradle.kts
@@ -10,6 +10,14 @@ dependencies {
     implementation(project(":board-system-event:event-publisher-member"))
     implementation(project(":board-system-event:event-consumer-member"))
 
+    // application
+    implementation(project(":board-system-application:application-core"))
+    implementation(project(":board-system-application:application-member"))
+
+    // domain
+    implementation(project(":board-system-domain:domain-core"))
+    implementation(project(":board-system-domain:domain-member"))
+
     // external
     implementation(project(":board-system-external:external-message"))
     implementation(project(":board-system-external:external-db"))

--- a/board-system-container/src/main/kotlin/com/ttasjwi/board/system/Main.kt
+++ b/board-system-container/src/main/kotlin/com/ttasjwi/board/system/Main.kt
@@ -6,7 +6,9 @@ import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.FilterType
+import org.springframework.scheduling.annotation.EnableAsync
 
+@EnableAsync
 @ConfigurationPropertiesScan
 @ComponentScan(
     includeFilters = [ComponentScan.Filter(

--- a/board-system-container/src/main/resources/application.yml
+++ b/board-system-container/src/main/resources/application.yml
@@ -3,11 +3,12 @@ spring:
   profiles:
     active: local
     group:
-      local: local
-      blue: blue, production
-      green: green, production
+      local: local, localSecret
+      blue: blue, production, productionSecret
+      green: green, production, productionSecret
   config:
     import:
       - db-config.yml
+      - email-send-config.yml
       - deploy-config.yml
       - message-config.yml

--- a/board-system-container/src/test/kotlin/com/ttasjwi/board/system/MainTests.kt
+++ b/board-system-container/src/test/kotlin/com/ttasjwi/board/system/MainTests.kt
@@ -1,12 +1,17 @@
 package com.ttasjwi.board.system
 
+import com.ttasjwi.board.system.member.domain.service.EmailSender
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.ActiveProfiles
 
 @ActiveProfiles("test")
 @SpringBootTest
 class MainTests {
+
+    @MockBean
+    private lateinit var emailSender: EmailSender
 
     @Test
     fun contextLoads() {

--- a/board-system-core/src/main/kotlin/com/ttasjwi/board/system/core/time/impl/TimeManagerImpl.kt
+++ b/board-system-core/src/main/kotlin/com/ttasjwi/board/system/core/time/impl/TimeManagerImpl.kt
@@ -8,6 +8,6 @@ import java.time.ZonedDateTime
 class TimeManagerImpl : TimeManager {
 
     override fun now(): ZonedDateTime {
-        TODO("Not yet implemented")
+        return ZonedDateTime.now()
     }
 }

--- a/board-system-core/src/test/kotlin/com/ttasjwi/board/system/core/time/fixture/TimeManagerFixtureTest.kt
+++ b/board-system-core/src/test/kotlin/com/ttasjwi/board/system/core/time/fixture/TimeManagerFixtureTest.kt
@@ -1,0 +1,38 @@
+package com.ttasjwi.board.system.core.time.fixture
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("TimeManagerFixture 테스트")
+class TimeManagerFixtureTest {
+
+    private lateinit var timeManagerFixture: TimeManagerFixture
+
+    @Test
+    @DisplayName("생성자 디폴트 파라미터 테스트")
+    fun defaultTest() {
+        timeManagerFixture = TimeManagerFixture()
+
+        val currentTime = timeManagerFixture.now()
+        assertThat(currentTime).isEqualTo(timeFixture())
+    }
+
+    @Test
+    @DisplayName("생성자로 시간 지정했을 때 테스트")
+    fun constructorTest() {
+        timeManagerFixture = TimeManagerFixture(timeFixture(minute = 3))
+        val currentTime = timeManagerFixture.now()
+        assertThat(currentTime).isEqualTo(timeFixture(minute = 3))
+    }
+
+    @Test
+    @DisplayName("changeCurrentTime 으로 시간 변경 후 테스트")
+    fun changeTest() {
+        timeManagerFixture = TimeManagerFixture()
+
+        timeManagerFixture.changeCurrentTime(timeFixture(minute=5))
+        val currentTime = timeManagerFixture.now()
+        assertThat(currentTime).isEqualTo(timeFixture(minute=5))
+    }
+}

--- a/board-system-core/src/test/kotlin/com/ttasjwi/board/system/core/time/impl/TimeManagerImplTest.kt
+++ b/board-system-core/src/test/kotlin/com/ttasjwi/board/system/core/time/impl/TimeManagerImplTest.kt
@@ -1,0 +1,29 @@
+package com.ttasjwi.board.system.core.time.impl
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("TimeManagerImpl 테스트")
+class TimeManagerImplTest {
+
+    private lateinit var timeManager: TimeManagerImpl
+
+    @BeforeEach
+    fun setup() {
+        timeManager = TimeManagerImpl()
+    }
+
+    /**
+     * TimeManagerImpl 내부구현은 사실상 Java API ZonedDateTime.now() 를 사용한 것인데
+     * 이것을 테스트하는 것은 Java API 에 대한 신뢰성을 테스트하는 별 의미없는 행위가 되므로
+     * 형식상의 테스트만 작성함
+     */
+    @Test
+    @DisplayName("작동하는 지 테스트")
+    fun test() {
+        val currentTime = timeManager.now()
+        assertThat(currentTime).isNotNull()
+    }
+}

--- a/board-system-core/src/testFixtures/kotlin/com/ttasjwi/board/system/core/time/fixture/TimeManagerFixture.kt
+++ b/board-system-core/src/testFixtures/kotlin/com/ttasjwi/board/system/core/time/fixture/TimeManagerFixture.kt
@@ -1,0 +1,17 @@
+package com.ttasjwi.board.system.core.time.fixture
+
+import com.ttasjwi.board.system.core.time.TimeManager
+import java.time.ZonedDateTime
+
+class TimeManagerFixture(
+    private var currentTime: ZonedDateTime = timeFixture()
+): TimeManager {
+
+    override fun now(): ZonedDateTime {
+        return currentTime
+    }
+
+    fun changeCurrentTime(currentTime: ZonedDateTime) {
+        this.currentTime = currentTime
+    }
+}

--- a/board-system-domain/domain-core/src/main/kotlin/com/ttasjwi/board/system/core/domain/event/DomainEventPublisher.kt
+++ b/board-system-domain/domain-core/src/main/kotlin/com/ttasjwi/board/system/core/domain/event/DomainEventPublisher.kt
@@ -1,0 +1,5 @@
+package com.ttasjwi.board.system.core.domain.event
+
+interface DomainEventPublisher<T: DomainEvent<*>> {
+    fun publishEvent(event: T)
+}

--- a/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/event/EmailVerificationStartedEvent.kt
+++ b/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/event/EmailVerificationStartedEvent.kt
@@ -2,15 +2,18 @@ package com.ttasjwi.board.system.member.domain.event
 
 import com.ttasjwi.board.system.core.domain.event.DomainEvent
 import java.time.ZonedDateTime
+import java.util.*
 
-class EmailVerificationStartedEvent(
+class EmailVerificationStartedEvent
+internal constructor(
     email: String,
     code: String,
     codeCreatedAt: ZonedDateTime,
     codeExpiresAt: ZonedDateTime,
+    locale: Locale,
 ) : DomainEvent<EmailVerificationStartedEvent.Data>(
     occurredAt = codeCreatedAt,
-    data = Data(email, code, codeCreatedAt, codeExpiresAt)
+    data = Data(email, code, codeCreatedAt, codeExpiresAt, locale)
 ) {
 
     class Data(
@@ -18,5 +21,6 @@ class EmailVerificationStartedEvent(
         val code: String,
         val codeCreatedAt: ZonedDateTime,
         val codeExpiresAt: ZonedDateTime,
+        val locale: Locale
     )
 }

--- a/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/event/EmailVerificationStartedEvent.kt
+++ b/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/event/EmailVerificationStartedEvent.kt
@@ -1,6 +1,7 @@
 package com.ttasjwi.board.system.member.domain.event
 
 import com.ttasjwi.board.system.core.domain.event.DomainEvent
+import com.ttasjwi.board.system.member.domain.model.EmailVerification
 import java.time.ZonedDateTime
 import java.util.*
 
@@ -23,4 +24,17 @@ internal constructor(
         val codeExpiresAt: ZonedDateTime,
         val locale: Locale
     )
+
+    companion object {
+
+        internal fun create(emailVerification: EmailVerification, locale: Locale): EmailVerificationStartedEvent {
+            return EmailVerificationStartedEvent(
+                email = emailVerification.email.value,
+                code = emailVerification.code,
+                codeCreatedAt = emailVerification.codeCreatedAt,
+                codeExpiresAt = emailVerification.codeExpiresAt,
+                locale = locale
+            )
+        }
+    }
 }

--- a/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/event/EmailVerifiedEvent.kt
+++ b/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/event/EmailVerifiedEvent.kt
@@ -1,20 +1,32 @@
 package com.ttasjwi.board.system.member.domain.event
 
 import com.ttasjwi.board.system.core.domain.event.DomainEvent
+import com.ttasjwi.board.system.member.domain.model.EmailVerification
 import java.time.ZonedDateTime
 
 class EmailVerifiedEvent(
     email: String,
     verifiedAt: ZonedDateTime,
     verificationExpiresAt: ZonedDateTime,
-): DomainEvent<EmailVerifiedEvent.Data>(
+) : DomainEvent<EmailVerifiedEvent.Data>(
     occurredAt = verifiedAt,
     data = Data(email, verifiedAt, verificationExpiresAt)
 ) {
 
-    class Data (
+    class Data(
         val email: String,
         val verifiedAt: ZonedDateTime,
         val verificationExpiresAt: ZonedDateTime,
     )
+
+    companion object {
+
+        internal fun create(emailVerification: EmailVerification): EmailVerifiedEvent {
+            return EmailVerifiedEvent(
+                email = emailVerification.email.value,
+                verifiedAt = emailVerification.verifiedAt!!,
+                verificationExpiresAt = emailVerification.verificationExpiresAt!!
+            )
+        }
+    }
 }

--- a/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/model/EmailVerification.kt
+++ b/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/model/EmailVerification.kt
@@ -1,6 +1,7 @@
 package com.ttasjwi.board.system.member.domain.model
 
 import java.time.ZonedDateTime
+import java.util.UUID
 
 class EmailVerification
 internal constructor(
@@ -21,6 +22,9 @@ internal constructor(
 
     companion object {
 
+        internal const val CODE_LENGTH = 6
+        internal const val CODE_VALIDITY_MINUTE = 5L
+
         fun restore(
             email: String,
             code: String,
@@ -36,6 +40,15 @@ internal constructor(
                 codeExpiresAt = codeExpiresAt,
                 verifiedAt = verifiedAt,
                 verificationExpiresAt = verificationExpiresAt
+            )
+        }
+
+        internal fun create(email: Email, currentTime: ZonedDateTime): EmailVerification {
+            return EmailVerification(
+                email = email,
+                code = UUID.randomUUID().toString().substring(startIndex = 0, endIndex = CODE_LENGTH),
+                codeCreatedAt = currentTime,
+                codeExpiresAt = currentTime.plusMinutes(CODE_VALIDITY_MINUTE)
             )
         }
     }

--- a/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/service/EmailSender.kt
+++ b/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/service/EmailSender.kt
@@ -8,5 +8,5 @@ interface EmailSender {
         address: Email,
         subject: String,
         content: String
-    ): Result<Unit>
+    )
 }

--- a/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/service/EmailVerificationEventCreator.kt
+++ b/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/service/EmailVerificationEventCreator.kt
@@ -3,9 +3,10 @@ package com.ttasjwi.board.system.member.domain.service
 import com.ttasjwi.board.system.member.domain.event.EmailVerificationStartedEvent
 import com.ttasjwi.board.system.member.domain.event.EmailVerifiedEvent
 import com.ttasjwi.board.system.member.domain.model.EmailVerification
+import java.util.*
 
 interface EmailVerificationEventCreator {
 
-    fun onVerificationStarted(emailVerification: EmailVerification): EmailVerificationStartedEvent
+    fun onVerificationStarted(emailVerification: EmailVerification, locale: Locale): EmailVerificationStartedEvent
     fun onVerified(emailVerification: EmailVerification): EmailVerifiedEvent
 }

--- a/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/service/EmailVerificationEventPublishers.kt
+++ b/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/service/EmailVerificationEventPublishers.kt
@@ -1,0 +1,6 @@
+package com.ttasjwi.board.system.member.domain.service
+
+import com.ttasjwi.board.system.core.domain.event.DomainEventPublisher
+import com.ttasjwi.board.system.member.domain.event.EmailVerificationStartedEvent
+
+interface EmailVerificationStartedEventPublisher : DomainEventPublisher<EmailVerificationStartedEvent>

--- a/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/service/impl/EmailVerificationEventCreatorImpl.kt
+++ b/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/service/impl/EmailVerificationEventCreatorImpl.kt
@@ -5,11 +5,15 @@ import com.ttasjwi.board.system.member.domain.event.EmailVerificationStartedEven
 import com.ttasjwi.board.system.member.domain.event.EmailVerifiedEvent
 import com.ttasjwi.board.system.member.domain.model.EmailVerification
 import com.ttasjwi.board.system.member.domain.service.EmailVerificationEventCreator
+import java.util.*
 
 @DomainService
 internal class EmailVerificationEventCreatorImpl : EmailVerificationEventCreator {
 
-    override fun onVerificationStarted(emailVerification: EmailVerification): EmailVerificationStartedEvent {
+    override fun onVerificationStarted(
+        emailVerification: EmailVerification,
+        locale: Locale
+    ): EmailVerificationStartedEvent {
         TODO("Not yet implemented")
     }
 

--- a/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/service/impl/EmailVerificationEventCreatorImpl.kt
+++ b/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/service/impl/EmailVerificationEventCreatorImpl.kt
@@ -14,10 +14,10 @@ internal class EmailVerificationEventCreatorImpl : EmailVerificationEventCreator
         emailVerification: EmailVerification,
         locale: Locale
     ): EmailVerificationStartedEvent {
-        TODO("Not yet implemented")
+        return EmailVerificationStartedEvent.create(emailVerification, locale)
     }
 
     override fun onVerified(emailVerification: EmailVerification): EmailVerifiedEvent {
-        TODO("Not yet implemented")
+        return EmailVerifiedEvent.create(emailVerification)
     }
 }

--- a/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/service/impl/EmailverificationCreatorImpl.kt
+++ b/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/service/impl/EmailverificationCreatorImpl.kt
@@ -10,6 +10,6 @@ import java.time.ZonedDateTime
 internal class EmailverificationCreatorImpl : EmailVerificationCreator {
 
     override fun create(email: Email, currentTime: ZonedDateTime): EmailVerification {
-        TODO("Not yet implemented")
+        return EmailVerification.create(email, currentTime)
     }
 }

--- a/board-system-domain/domain-member/src/test/kotlin/com/ttasjwi/board/system/member/domain/event/fixture/EmailVerificationStartedEventFixtureTest.kt
+++ b/board-system-domain/domain-member/src/test/kotlin/com/ttasjwi/board/system/member/domain/event/fixture/EmailVerificationStartedEventFixtureTest.kt
@@ -4,6 +4,7 @@ import com.ttasjwi.board.system.core.time.fixture.timeFixture
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import java.util.*
 
 @DisplayName("EmailVerificationStartedEventFixture 테스트")
 class EmailVerificationStartedEventFixtureTest {
@@ -19,6 +20,7 @@ class EmailVerificationStartedEventFixtureTest {
         assertThat(data.code).isNotNull()
         assertThat(data.codeCreatedAt).isNotNull()
         assertThat(data.codeExpiresAt).isNotNull()
+        assertThat(data.locale).isEqualTo(Locale.KOREAN)
     }
 
     @Test
@@ -28,12 +30,14 @@ class EmailVerificationStartedEventFixtureTest {
         val code = "54321"
         val codeCreatedAt = timeFixture(minute = 5)
         val codeExpiresAt = timeFixture(minute = 10)
+        val locale = Locale.ENGLISH
 
         val event = emailVerificationStartedEventFixture(
             email = email,
             code = code,
             codeCreatedAt = codeCreatedAt,
-            codeExpiresAt = codeExpiresAt
+            codeExpiresAt = codeExpiresAt,
+            locale = locale
         )
         val data = event.data
 
@@ -42,5 +46,6 @@ class EmailVerificationStartedEventFixtureTest {
         assertThat(data.code).isEqualTo(code)
         assertThat(data.codeCreatedAt).isEqualTo(codeCreatedAt)
         assertThat(data.codeExpiresAt).isEqualTo(codeExpiresAt)
+        assertThat(data.locale).isEqualTo(locale)
     }
 }

--- a/board-system-domain/domain-member/src/test/kotlin/com/ttasjwi/board/system/member/domain/service/fixture/EmailSenderFixtureTest.kt
+++ b/board-system-domain/domain-member/src/test/kotlin/com/ttasjwi/board/system/member/domain/service/fixture/EmailSenderFixtureTest.kt
@@ -1,0 +1,23 @@
+package com.ttasjwi.board.system.member.domain.service.fixture
+
+import com.ttasjwi.board.system.member.domain.model.fixture.emailFixture
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("EmailSender 픽스쳐 테스트")
+class EmailSenderFixtureTest {
+
+    private lateinit var emailSenderFixture: EmailSenderFixture
+
+    @BeforeEach
+    fun setup() {
+        emailSenderFixture = EmailSenderFixture()
+    }
+
+    @Test
+    @DisplayName("동작 테스트")
+    fun send() {
+        emailSenderFixture.send(emailFixture("ttasjwi@gmail.com"), "제목", "내용")
+    }
+}

--- a/board-system-domain/domain-member/src/test/kotlin/com/ttasjwi/board/system/member/domain/service/fixture/EmailVerificationCreatorFixtureTest.kt
+++ b/board-system-domain/domain-member/src/test/kotlin/com/ttasjwi/board/system/member/domain/service/fixture/EmailVerificationCreatorFixtureTest.kt
@@ -1,0 +1,39 @@
+package com.ttasjwi.board.system.member.domain.service.fixture
+
+import com.ttasjwi.board.system.core.time.fixture.timeFixture
+import com.ttasjwi.board.system.member.domain.model.fixture.emailFixture
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("EmailVerificationCreator 픽스쳐 테스트")
+class EmailVerificationCreatorFixtureTest {
+
+    private lateinit var emailVerificationCreatorFixture: EmailVerificationCreatorFixture
+
+    @BeforeEach
+    fun setup() {
+        emailVerificationCreatorFixture = EmailVerificationCreatorFixture()
+    }
+
+    @Test
+    @DisplayName("Create: 이메일 인증을 생성한다")
+    fun testCode() {
+        val email = emailFixture("soso@gmail.com")
+        val currentTime = timeFixture(minute = 0)
+
+        val emailVerification = emailVerificationCreatorFixture.create(
+            email = email,
+            currentTime = currentTime
+        )
+
+        assertThat(emailVerification.email).isEqualTo(email)
+        assertThat(emailVerification.code).isEqualTo("code")
+        assertThat(emailVerification.codeCreatedAt).isEqualTo(currentTime)
+        assertThat(emailVerification.codeExpiresAt).isEqualTo(timeFixture(minute = 5))
+        assertThat(emailVerification.verifiedAt).isNull()
+        assertThat(emailVerification.verificationExpiresAt).isNull()
+
+    }
+}

--- a/board-system-domain/domain-member/src/test/kotlin/com/ttasjwi/board/system/member/domain/service/fixture/EmailVerificationEventCreatorFixtureTest.kt
+++ b/board-system-domain/domain-member/src/test/kotlin/com/ttasjwi/board/system/member/domain/service/fixture/EmailVerificationEventCreatorFixtureTest.kt
@@ -1,0 +1,54 @@
+package com.ttasjwi.board.system.member.domain.service.fixture
+
+import com.ttasjwi.board.system.member.domain.model.fixture.emailVerificationFixtureNotVerified
+import com.ttasjwi.board.system.member.domain.model.fixture.emailVerificationFixtureVerified
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.util.*
+
+@DisplayName("EmailVerificationEventCreator 픽스쳐 테스트")
+class EmailVerificationEventCreatorFixtureTest {
+
+    private lateinit var emailVerificationEventCreatorFixture: EmailVerificationEventCreatorFixture
+
+    @BeforeEach
+    fun setup() {
+        emailVerificationEventCreatorFixture = EmailVerificationEventCreatorFixture()
+    }
+
+    @Test
+    @DisplayName("OnVerificationStarted: 이메일 인증 시작됨 이벤트를 생성한다")
+    fun testOnVerificationStarted() {
+        val emailVerification = emailVerificationFixtureNotVerified()
+        val locale = Locale.ENGLISH
+
+        val event = emailVerificationEventCreatorFixture.onVerificationStarted(
+            emailVerification = emailVerification,
+            locale = locale
+        )
+        val data = event.data
+
+        assertThat(event.occurredAt).isEqualTo(emailVerification.codeCreatedAt)
+        assertThat(data.email).isEqualTo(emailVerification.email.value)
+        assertThat(data.code).isEqualTo(emailVerification.code)
+        assertThat(data.codeCreatedAt).isEqualTo(emailVerification.codeCreatedAt)
+        assertThat(data.codeExpiresAt).isEqualTo(emailVerification.codeExpiresAt)
+        assertThat(data.locale).isEqualTo(locale)
+    }
+
+    @Test
+    @DisplayName("OnVerified: 이메일 인증됨 이벤트를 생성한다")
+    fun testOnVerified() {
+        val emailVerification = emailVerificationFixtureVerified()
+
+        val event = emailVerificationEventCreatorFixture.onVerified(emailVerification)
+        val data = event.data
+
+        assertThat(event.occurredAt).isEqualTo(emailVerification.verifiedAt)
+        assertThat(data.email).isEqualTo(emailVerification.email.value)
+        assertThat(data.verifiedAt).isEqualTo(emailVerification.verifiedAt)
+        assertThat(data.verificationExpiresAt).isEqualTo(emailVerification.verificationExpiresAt)
+    }
+}

--- a/board-system-domain/domain-member/src/test/kotlin/com/ttasjwi/board/system/member/domain/service/fixture/EmailVerificationStartedEventPublisherFixtureTest.kt
+++ b/board-system-domain/domain-member/src/test/kotlin/com/ttasjwi/board/system/member/domain/service/fixture/EmailVerificationStartedEventPublisherFixtureTest.kt
@@ -1,0 +1,24 @@
+package com.ttasjwi.board.system.member.domain.service.fixture
+
+import com.ttasjwi.board.system.member.domain.event.fixture.emailVerificationStartedEventFixture
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("EmailVerificationStartedEventPublisher 픽스쳐 테스트")
+class EmailVerificationStartedEventPublisherFixtureTest {
+
+    private lateinit var eventPublisherFixture: EmailVerificationStartedEventPublisherFixture
+
+    @BeforeEach
+    fun setup() {
+        eventPublisherFixture = EmailVerificationStartedEventPublisherFixture()
+    }
+
+    @Test
+    @DisplayName("호출이 잘 되는 지 테스트")
+    fun test() {
+        val event = emailVerificationStartedEventFixture()
+        eventPublisherFixture.publishEvent(event)
+    }
+}

--- a/board-system-domain/domain-member/src/test/kotlin/com/ttasjwi/board/system/member/domain/service/fixture/EmailVerificationStorageFixtureTest.kt
+++ b/board-system-domain/domain-member/src/test/kotlin/com/ttasjwi/board/system/member/domain/service/fixture/EmailVerificationStorageFixtureTest.kt
@@ -1,0 +1,56 @@
+package com.ttasjwi.board.system.member.domain.service.fixture
+
+import com.ttasjwi.board.system.core.time.fixture.timeFixture
+import com.ttasjwi.board.system.member.domain.model.fixture.emailFixture
+import com.ttasjwi.board.system.member.domain.model.fixture.emailVerificationFixtureVerified
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("EmailVerificationStorageFixture(Appender, Finder) 테스트")
+class EmailVerificationStorageFixtureTest {
+
+    private lateinit var emailVerificationStorageFixture: EmailVerificationStorageFixture
+
+    @BeforeEach
+    fun setup() {
+        emailVerificationStorageFixture = EmailVerificationStorageFixture()
+    }
+
+    @Test
+    @DisplayName("이메일 인증을 저장하고 이메일로 다시 찾을 수 있다")
+    fun appendAndFind() {
+        val emailVerification = emailVerificationFixtureVerified()
+        emailVerificationStorageFixture.append(emailVerification, timeFixture())
+
+        val findEmailVerification = emailVerificationStorageFixture.findByEmailOrNull(emailVerification.email)!!
+
+        assertThat(findEmailVerification.email).isEqualTo(emailVerification.email)
+        assertThat(findEmailVerification.code).isEqualTo(emailVerification.code)
+        assertThat(findEmailVerification.codeCreatedAt).isEqualTo(emailVerification.codeCreatedAt)
+        assertThat(findEmailVerification.codeExpiresAt).isEqualTo(emailVerification.codeExpiresAt)
+        assertThat(findEmailVerification.verifiedAt).isEqualTo(emailVerification.verifiedAt)
+        assertThat(findEmailVerification.verificationExpiresAt).isEqualTo(emailVerification.verificationExpiresAt)
+    }
+
+    @Test
+    @DisplayName("이메일 인증을 찾지 못 했다면 null 이 반환된다")
+    fun notFoundNull() {
+        val findEmailVerification = emailVerificationStorageFixture.findByEmailOrNull(emailFixture("bye@gmail.com"))
+        assertThat(findEmailVerification).isNull()
+    }
+
+    @Test
+    @DisplayName("remove 테스트")
+    fun remove() {
+        val emailVerification = emailVerificationFixtureVerified()
+        emailVerificationStorageFixture.append(emailVerification, timeFixture())
+
+        emailVerificationStorageFixture.removeByEmail(emailVerification.email)
+
+        val findEmailVerification = emailVerificationStorageFixture.findByEmailOrNull(emailVerification.email)
+        assertThat(findEmailVerification).isNull()
+    }
+
+}

--- a/board-system-domain/domain-member/src/test/kotlin/com/ttasjwi/board/system/member/domain/service/impl/EmailVerificationCreatorImplTest.kt
+++ b/board-system-domain/domain-member/src/test/kotlin/com/ttasjwi/board/system/member/domain/service/impl/EmailVerificationCreatorImplTest.kt
@@ -1,0 +1,40 @@
+package com.ttasjwi.board.system.member.domain.service.impl
+
+import com.ttasjwi.board.system.core.time.fixture.timeFixture
+import com.ttasjwi.board.system.member.domain.model.EmailVerification
+import com.ttasjwi.board.system.member.domain.model.fixture.emailFixture
+import com.ttasjwi.board.system.member.domain.service.EmailVerificationCreator
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("EmailVerificationCreatorImpl 테스트")
+class EmailVerificationCreatorImplTest {
+
+    private lateinit var emailVerificationCreator: EmailVerificationCreator
+
+    @BeforeEach
+    fun setup() {
+        emailVerificationCreator = EmailverificationCreatorImpl()
+    }
+
+    @Test
+    @DisplayName("Create: 이메일 인증을 생성한다")
+    fun testCode() {
+        val email = emailFixture("soso@gmail.com")
+        val currentTime = timeFixture(minute = 0)
+
+        val emailVerification = emailVerificationCreator.create(
+            email = email,
+            currentTime = currentTime
+        )
+
+        assertThat(emailVerification.email).isEqualTo(email)
+        assertThat(emailVerification.code.length).isEqualTo(EmailVerification.CODE_LENGTH)
+        assertThat(emailVerification.codeCreatedAt).isEqualTo(currentTime)
+        assertThat(emailVerification.codeExpiresAt).isEqualTo(currentTime.plusMinutes(EmailVerification.CODE_VALIDITY_MINUTE))
+        assertThat(emailVerification.verifiedAt).isNull()
+        assertThat(emailVerification.verificationExpiresAt).isNull()
+    }
+}

--- a/board-system-domain/domain-member/src/test/kotlin/com/ttasjwi/board/system/member/domain/service/impl/EmailVerificationEventCreatorImplTest.kt
+++ b/board-system-domain/domain-member/src/test/kotlin/com/ttasjwi/board/system/member/domain/service/impl/EmailVerificationEventCreatorImplTest.kt
@@ -1,0 +1,51 @@
+package com.ttasjwi.board.system.member.domain.service.impl
+
+import com.ttasjwi.board.system.member.domain.model.fixture.emailVerificationFixtureNotVerified
+import com.ttasjwi.board.system.member.domain.model.fixture.emailVerificationFixtureVerified
+import com.ttasjwi.board.system.member.domain.service.EmailVerificationEventCreator
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.util.*
+
+@DisplayName("EmailVerificationEventCreatorImpl 테스트")
+class EmailVerificationEventCreatorImplTest {
+
+    private lateinit var emailVerificationEventCreator: EmailVerificationEventCreator
+
+    @BeforeEach
+    fun setup() {
+        emailVerificationEventCreator = EmailVerificationEventCreatorImpl()
+    }
+
+    @Test
+    @DisplayName("onVerificationStarted = 이메일인증 시작됨 이벤트를 생성한다")
+    fun testOnVerificationStarted() {
+        val emailVerification = emailVerificationFixtureNotVerified()
+        val locale = Locale.ENGLISH
+
+        val event = emailVerificationEventCreator.onVerificationStarted(emailVerification, locale)
+        val data = event.data
+
+        assertThat(event.occurredAt).isEqualTo(emailVerification.codeCreatedAt)
+        assertThat(data.email).isEqualTo(emailVerification.email.value)
+        assertThat(data.code).isEqualTo(emailVerification.code)
+        assertThat(data.codeCreatedAt).isEqualTo(emailVerification.codeCreatedAt)
+        assertThat(data.codeExpiresAt).isEqualTo(emailVerification.codeExpiresAt)
+    }
+
+    @Test
+    @DisplayName("onVerified: 이메일 인증됨 이벤트를 생성한다")
+    fun testOnVerified() {
+        val emailVerification = emailVerificationFixtureVerified()
+
+        val event = emailVerificationEventCreator.onVerified(emailVerification)
+        val data = event.data
+
+        assertThat(event.occurredAt).isEqualTo(emailVerification.verifiedAt)
+        assertThat(data.email).isEqualTo(emailVerification.email.value)
+        assertThat(data.verifiedAt).isEqualTo(emailVerification.verifiedAt)
+        assertThat(data.verificationExpiresAt).isEqualTo(emailVerification.verificationExpiresAt)
+    }
+}

--- a/board-system-domain/domain-member/src/testFixtures/kotlin/com/ttasjwi/board/system/member/domain/event/fixture/EmailVerificationStartedEventFixture.kt
+++ b/board-system-domain/domain-member/src/testFixtures/kotlin/com/ttasjwi/board/system/member/domain/event/fixture/EmailVerificationStartedEventFixture.kt
@@ -3,17 +3,20 @@ package com.ttasjwi.board.system.member.domain.event.fixture
 import com.ttasjwi.board.system.core.time.fixture.timeFixture
 import com.ttasjwi.board.system.member.domain.event.EmailVerificationStartedEvent
 import java.time.ZonedDateTime
+import java.util.*
 
 fun emailVerificationStartedEventFixture(
     email: String = "hello@gmail.com",
     code: String = "code12345",
     codeCreatedAt: ZonedDateTime = timeFixture(minute = 0),
     codeExpiresAt: ZonedDateTime = codeCreatedAt.plusMinutes(5),
+    locale: Locale = Locale.KOREAN,
 ): EmailVerificationStartedEvent {
     return EmailVerificationStartedEvent(
         email = email,
         code = code,
         codeCreatedAt = codeCreatedAt,
         codeExpiresAt = codeExpiresAt,
+        locale = locale,
     )
 }

--- a/board-system-domain/domain-member/src/testFixtures/kotlin/com/ttasjwi/board/system/member/domain/service/fixture/EmailSenderFixture.kt
+++ b/board-system-domain/domain-member/src/testFixtures/kotlin/com/ttasjwi/board/system/member/domain/service/fixture/EmailSenderFixture.kt
@@ -1,0 +1,22 @@
+package com.ttasjwi.board.system.member.domain.service.fixture
+
+import com.ttasjwi.board.system.logging.getLogger
+import com.ttasjwi.board.system.member.domain.model.Email
+import com.ttasjwi.board.system.member.domain.service.EmailSender
+
+class EmailSenderFixture : EmailSender {
+
+    companion object {
+        private val log = getLogger(EmailSenderFixture::class.java)
+    }
+
+    override fun send(address: Email, subject: String, content: String) {
+        log.info{"""
+            이메일 발송됨(도메인서비스 픽스쳐)!
+            - email= ${address.value}
+            - subject = $subject
+            - content = $content
+            -----------------------------------------------------------------------------------------------------------
+        """.trimIndent()}
+    }
+}

--- a/board-system-domain/domain-member/src/testFixtures/kotlin/com/ttasjwi/board/system/member/domain/service/fixture/EmailVerificationCreatorFixture.kt
+++ b/board-system-domain/domain-member/src/testFixtures/kotlin/com/ttasjwi/board/system/member/domain/service/fixture/EmailVerificationCreatorFixture.kt
@@ -1,0 +1,19 @@
+package com.ttasjwi.board.system.member.domain.service.fixture
+
+import com.ttasjwi.board.system.member.domain.model.Email
+import com.ttasjwi.board.system.member.domain.model.EmailVerification
+import com.ttasjwi.board.system.member.domain.model.fixture.emailVerificationFixtureNotVerified
+import com.ttasjwi.board.system.member.domain.service.EmailVerificationCreator
+import java.time.ZonedDateTime
+
+class EmailVerificationCreatorFixture : EmailVerificationCreator {
+
+    override fun create(email: Email, currentTime: ZonedDateTime): EmailVerification {
+        return emailVerificationFixtureNotVerified(
+            email = email.value,
+            code = "code",
+            codeCreatedAt = currentTime,
+            codeExpiresAt = currentTime.plusMinutes(5),
+        )
+    }
+}

--- a/board-system-domain/domain-member/src/testFixtures/kotlin/com/ttasjwi/board/system/member/domain/service/fixture/EmailVerificationEventCreatorFixture.kt
+++ b/board-system-domain/domain-member/src/testFixtures/kotlin/com/ttasjwi/board/system/member/domain/service/fixture/EmailVerificationEventCreatorFixture.kt
@@ -15,6 +15,7 @@ class EmailVerificationEventCreatorFixture : EmailVerificationEventCreator {
             email = emailVerification.email.value,
             code = emailVerification.code,
             codeCreatedAt = emailVerification.codeCreatedAt,
+            codeExpiresAt = emailVerification.codeExpiresAt,
             locale = locale,
         )
     }

--- a/board-system-domain/domain-member/src/testFixtures/kotlin/com/ttasjwi/board/system/member/domain/service/fixture/EmailVerificationEventCreatorFixture.kt
+++ b/board-system-domain/domain-member/src/testFixtures/kotlin/com/ttasjwi/board/system/member/domain/service/fixture/EmailVerificationEventCreatorFixture.kt
@@ -1,0 +1,29 @@
+package com.ttasjwi.board.system.member.domain.service.fixture
+
+import com.ttasjwi.board.system.member.domain.event.EmailVerificationStartedEvent
+import com.ttasjwi.board.system.member.domain.event.EmailVerifiedEvent
+import com.ttasjwi.board.system.member.domain.event.fixture.emailVerificationStartedEventFixture
+import com.ttasjwi.board.system.member.domain.event.fixture.emailVerifiedEventFixture
+import com.ttasjwi.board.system.member.domain.model.EmailVerification
+import com.ttasjwi.board.system.member.domain.service.EmailVerificationEventCreator
+import java.util.Locale
+
+class EmailVerificationEventCreatorFixture : EmailVerificationEventCreator {
+
+    override fun onVerificationStarted(emailVerification: EmailVerification, locale: Locale): EmailVerificationStartedEvent {
+        return emailVerificationStartedEventFixture(
+            email = emailVerification.email.value,
+            code = emailVerification.code,
+            codeCreatedAt = emailVerification.codeCreatedAt,
+            locale = locale,
+        )
+    }
+
+    override fun onVerified(emailVerification: EmailVerification): EmailVerifiedEvent {
+        return emailVerifiedEventFixture(
+            email = emailVerification.email.value,
+            verifiedAt = emailVerification.verifiedAt!!,
+            verificationExpiresAt = emailVerification.verificationExpiresAt!!,
+        )
+    }
+}

--- a/board-system-domain/domain-member/src/testFixtures/kotlin/com/ttasjwi/board/system/member/domain/service/fixture/EmailVerificationStartedEventPublisherFixture.kt
+++ b/board-system-domain/domain-member/src/testFixtures/kotlin/com/ttasjwi/board/system/member/domain/service/fixture/EmailVerificationStartedEventPublisherFixture.kt
@@ -1,0 +1,16 @@
+package com.ttasjwi.board.system.member.domain.service.fixture
+
+import com.ttasjwi.board.system.logging.getLogger
+import com.ttasjwi.board.system.member.domain.event.EmailVerificationStartedEvent
+import com.ttasjwi.board.system.member.domain.service.EmailVerificationStartedEventPublisher
+
+class EmailVerificationStartedEventPublisherFixture : EmailVerificationStartedEventPublisher {
+
+    companion object {
+        private val log = getLogger(EmailVerificationStartedEventPublisherFixture::class.java)
+    }
+
+    override fun publishEvent(event: EmailVerificationStartedEvent) {
+        log.info{ "(픽스쳐) '이메일인증 시작됨' 이벤트 발행 (email = ${event.data.email})" }
+    }
+}

--- a/board-system-domain/domain-member/src/testFixtures/kotlin/com/ttasjwi/board/system/member/domain/service/fixture/EmailVerificationStorageFixture.kt
+++ b/board-system-domain/domain-member/src/testFixtures/kotlin/com/ttasjwi/board/system/member/domain/service/fixture/EmailVerificationStorageFixture.kt
@@ -1,0 +1,24 @@
+package com.ttasjwi.board.system.member.domain.service.fixture
+
+import com.ttasjwi.board.system.member.domain.model.Email
+import com.ttasjwi.board.system.member.domain.model.EmailVerification
+import com.ttasjwi.board.system.member.domain.service.EmailVerificationAppender
+import com.ttasjwi.board.system.member.domain.service.EmailVerificationFinder
+import java.time.ZonedDateTime
+
+class EmailVerificationStorageFixture : EmailVerificationAppender, EmailVerificationFinder  {
+
+    private val store: MutableMap<Email, EmailVerification> = mutableMapOf()
+
+    override fun append(emailVerification: EmailVerification, expiresAt: ZonedDateTime) {
+        store[emailVerification.email] = emailVerification
+    }
+
+    override fun removeByEmail(email: Email) {
+        store.remove(email)
+    }
+
+    override fun findByEmailOrNull(email: Email): EmailVerification? {
+        return store[email]
+    }
+}

--- a/board-system-event/event-consumer-member/build.gradle.kts
+++ b/board-system-event/event-consumer-member/build.gradle.kts
@@ -1,0 +1,5 @@
+dependencies {
+    implementation(Dependencies.SPRING_BOOT_STARTER.fullName)
+    implementation(project(":board-system-domain:domain-member"))
+    implementation(project(":board-system-domain:domain-core"))
+}

--- a/board-system-event/event-consumer-member/build.gradle.kts
+++ b/board-system-event/event-consumer-member/build.gradle.kts
@@ -1,5 +1,9 @@
 dependencies {
     implementation(Dependencies.SPRING_BOOT_STARTER.fullName)
+    implementation(project(":board-system-application:application-member"))
     implementation(project(":board-system-domain:domain-member"))
     implementation(project(":board-system-domain:domain-core"))
+
+    testImplementation(testFixtures(project(":board-system-application:application-member")))
+    testImplementation(testFixtures(project(":board-system-domain:domain-member")))
 }

--- a/board-system-event/event-consumer-member/src/main/kotlin/com/ttasjwi/board/system/member/event/consumer/EmailVerificationStartedEventConsumer.kt
+++ b/board-system-event/event-consumer-member/src/main/kotlin/com/ttasjwi/board/system/member/event/consumer/EmailVerificationStartedEventConsumer.kt
@@ -1,0 +1,14 @@
+package com.ttasjwi.board.system.member.event.consumer
+
+import com.ttasjwi.board.system.member.domain.event.EmailVerificationStartedEvent
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+
+@Component
+class EmailVerificationStartedEventConsumer {
+
+    @EventListener(EmailVerificationStartedEvent::class)
+    fun handleEmailVerificationStartedEvent(event: EmailVerificationStartedEvent) {
+        TODO("not implemented")
+    }
+}

--- a/board-system-event/event-consumer-member/src/main/kotlin/com/ttasjwi/board/system/member/event/consumer/EmailVerificationStartedEventConsumer.kt
+++ b/board-system-event/event-consumer-member/src/main/kotlin/com/ttasjwi/board/system/member/event/consumer/EmailVerificationStartedEventConsumer.kt
@@ -1,14 +1,25 @@
 package com.ttasjwi.board.system.member.event.consumer
 
+import com.ttasjwi.board.system.core.message.MessageResolver
+import com.ttasjwi.board.system.member.application.usecase.EmailSendUseCase
 import com.ttasjwi.board.system.member.domain.event.EmailVerificationStartedEvent
 import org.springframework.context.event.EventListener
+import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
 
 @Component
-class EmailVerificationStartedEventConsumer {
+class EmailVerificationStartedEventConsumer(
+    private val emailSendUseCase: EmailSendUseCase,
+    private val messageResolver: MessageResolver,
+) {
 
+    @Async
     @EventListener(EmailVerificationStartedEvent::class)
     fun handleEmailVerificationStartedEvent(event: EmailVerificationStartedEvent) {
-        TODO("not implemented")
+        emailSendUseCase.sendEmail(
+            address = event.data.email,
+            subject = messageResolver.resolveMessage("EmailVerification.subject", event.data.locale),
+            content = messageResolver.resolveDescription("EmailVerification.content", listOf(event.data.code), event.data.locale),
+        )
     }
 }

--- a/board-system-event/event-consumer-member/src/test/kotlin/com/ttasjwi/board/system/member/event/consumer/EmailVerificationStartedEventConsumerTest.kt
+++ b/board-system-event/event-consumer-member/src/test/kotlin/com/ttasjwi/board/system/member/event/consumer/EmailVerificationStartedEventConsumerTest.kt
@@ -1,0 +1,31 @@
+package com.ttasjwi.board.system.member.event.consumer
+
+import com.ttasjwi.board.system.core.message.fixture.MessageResolverFixture
+import com.ttasjwi.board.system.member.application.usecase.fixture.EmailSendUseCaseFixture
+import com.ttasjwi.board.system.member.domain.event.fixture.emailVerificationStartedEventFixture
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+class EmailVerificationStartedEventConsumerTest {
+
+    private lateinit var emailVerificationStartedEventConsumer: EmailVerificationStartedEventConsumer
+
+    @BeforeEach
+    fun setup() {
+        emailVerificationStartedEventConsumer = EmailVerificationStartedEventConsumer(
+            emailSendUseCase = EmailSendUseCaseFixture(),
+            messageResolver = MessageResolverFixture()
+        )
+    }
+
+    @Test
+    @DisplayName("동작 테스트")
+    fun test() {
+        val event = emailVerificationStartedEventFixture(
+            email = "jello@gmail.com",
+            code = "code"
+        )
+        emailVerificationStartedEventConsumer.handleEmailVerificationStartedEvent(event)
+    }
+}

--- a/board-system-event/event-publisher-member/build.gradle.kts
+++ b/board-system-event/event-publisher-member/build.gradle.kts
@@ -1,0 +1,5 @@
+dependencies {
+    implementation(Dependencies.SPRING_BOOT_STARTER.fullName)
+    implementation(project(":board-system-domain:domain-member"))
+    implementation(project(":board-system-domain:domain-core"))
+}

--- a/board-system-event/event-publisher-member/build.gradle.kts
+++ b/board-system-event/event-publisher-member/build.gradle.kts
@@ -2,4 +2,7 @@ dependencies {
     implementation(Dependencies.SPRING_BOOT_STARTER.fullName)
     implementation(project(":board-system-domain:domain-member"))
     implementation(project(":board-system-domain:domain-core"))
+
+    testImplementation(testFixtures(project(":board-system-domain:domain-core")))
+    testImplementation(testFixtures(project(":board-system-domain:domain-member")))
 }

--- a/board-system-event/event-publisher-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/service/impl/EmailVerificationStartedEventPublisherImpl.kt
+++ b/board-system-event/event-publisher-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/service/impl/EmailVerificationStartedEventPublisherImpl.kt
@@ -1,0 +1,13 @@
+package com.ttasjwi.board.system.member.domain.service.impl
+
+import com.ttasjwi.board.system.member.domain.event.EmailVerificationStartedEvent
+import com.ttasjwi.board.system.member.domain.service.EmailVerificationStartedEventPublisher
+import org.springframework.stereotype.Component
+
+@Component
+class EmailVerificationStartedEventPublisherImpl : EmailVerificationStartedEventPublisher {
+
+    override fun publishEvent(event: EmailVerificationStartedEvent) {
+        TODO("not implemented")
+    }
+}

--- a/board-system-event/event-publisher-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/service/impl/EmailVerificationStartedEventPublisherImpl.kt
+++ b/board-system-event/event-publisher-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/service/impl/EmailVerificationStartedEventPublisherImpl.kt
@@ -1,13 +1,22 @@
 package com.ttasjwi.board.system.member.domain.service.impl
 
+import com.ttasjwi.board.system.logging.getLogger
 import com.ttasjwi.board.system.member.domain.event.EmailVerificationStartedEvent
 import com.ttasjwi.board.system.member.domain.service.EmailVerificationStartedEventPublisher
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
 
 @Component
-class EmailVerificationStartedEventPublisherImpl : EmailVerificationStartedEventPublisher {
+class EmailVerificationStartedEventPublisherImpl(
+    private val applicationEventPublisher: ApplicationEventPublisher
+) : EmailVerificationStartedEventPublisher {
+
+    companion object {
+        private val log = getLogger(EmailVerificationStartedEventPublisherImpl::class.java)
+    }
 
     override fun publishEvent(event: EmailVerificationStartedEvent) {
-        TODO("not implemented")
+        applicationEventPublisher.publishEvent(event)
+        log.info{ "이메일 인증 시작됨 내부이벤트 발행" }
     }
 }

--- a/board-system-event/event-publisher-member/src/test/kotlin/com/ttasjwi/board/system/MemberEventPublisherTestApplication.kt
+++ b/board-system-event/event-publisher-member/src/test/kotlin/com/ttasjwi/board/system/MemberEventPublisherTestApplication.kt
@@ -1,0 +1,11 @@
+package com.ttasjwi.board.system
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+@SpringBootApplication
+class MemberEventPublisherTestApplication
+
+fun main(args: Array<String>) {
+    runApplication<MemberEventPublisherTestApplication>(*args)
+}

--- a/board-system-event/event-publisher-member/src/test/kotlin/com/ttasjwi/board/system/member/domain/service/impl/EmailVerificationStartedEventPublisherImplTest.kt
+++ b/board-system-event/event-publisher-member/src/test/kotlin/com/ttasjwi/board/system/member/domain/service/impl/EmailVerificationStartedEventPublisherImplTest.kt
@@ -1,0 +1,25 @@
+package com.ttasjwi.board.system.member.domain.service.impl
+
+import com.ttasjwi.board.system.member.domain.event.fixture.emailVerificationStartedEventFixture
+import com.ttasjwi.board.system.member.domain.service.EmailVerificationStartedEventPublisher
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Profile
+
+@SpringBootTest
+@Profile(value = ["test"])
+@DisplayName("EmailVerificationStartedEventPublisherImpl: 이메일인증 시작됨 이벤트 발행자")
+class EmailVerificationStartedEventPublisherImplTest @Autowired constructor(
+    private val emailVerificationStartedEventPublisher: EmailVerificationStartedEventPublisher
+) {
+
+    @Test
+    @DisplayName("이벤트 발행이 실행되는 지 확인")
+    fun test() {
+        val event = emailVerificationStartedEventFixture()
+        emailVerificationStartedEventPublisher.publishEvent(event)
+    }
+
+}

--- a/board-system-external/external-email-sender/build.gradle.kts
+++ b/board-system-external/external-email-sender/build.gradle.kts
@@ -1,4 +1,8 @@
 dependencies {
-    implementation(project(":board-system-domain:domain-core"))
+    implementation(Dependencies.SPRING_BOOT_MAIL.fullName)
     implementation(project(":board-system-domain:domain-member"))
+    implementation(project(":board-system-domain:domain-core"))
+
+    testImplementation(testFixtures(project(":board-system-domain:domain-member")))
+    testImplementation(testFixtures(project(":board-system-domain:domain-core")))
 }

--- a/board-system-external/external-email-sender/src/main/kotlin/com/ttasjwi/board/system/member/domain/external/EmailSenderImpl.kt
+++ b/board-system-external/external-email-sender/src/main/kotlin/com/ttasjwi/board/system/member/domain/external/EmailSenderImpl.kt
@@ -1,13 +1,22 @@
 package com.ttasjwi.board.system.member.domain.external
 
-import com.ttasjwi.board.system.core.annotation.component.AppComponent
 import com.ttasjwi.board.system.member.domain.model.Email
 import com.ttasjwi.board.system.member.domain.service.EmailSender
+import org.springframework.mail.SimpleMailMessage
+import org.springframework.mail.javamail.JavaMailSender
+import org.springframework.stereotype.Component
 
-@AppComponent
-class EmailSenderImpl : EmailSender {
+@Component
+class EmailSenderImpl(
+    private val javaMailSender: JavaMailSender
+) : EmailSender {
 
-    override fun send(address: Email, subject: String, content: String): Result<Unit> {
-        TODO("Not yet implemented")
+    override fun send(address: Email, subject: String, content: String) {
+        val message = SimpleMailMessage()
+        message.subject = subject
+        message.setTo(address.value)
+        message.text = content
+
+        javaMailSender.send(message)
     }
 }

--- a/board-system-external/external-email-sender/src/main/resources/email-send-config.yml
+++ b/board-system-external/external-email-sender/src/main/resources/email-send-config.yml
@@ -1,0 +1,17 @@
+spring:
+  config:
+    activate:
+      on-profile: localSecret
+    import:
+      - email-send-config-localSecret.yml
+
+---
+
+spring:
+  config:
+    activate:
+      on-profile: productionSecret
+    import:
+      - file:/app/config/board-system/email-send-config-productionSecret.yml
+
+---

--- a/board-system-external/external-email-sender/src/test/kotlin/com/ttasjwi/board/system/EmailSenderTestApplication.kt
+++ b/board-system-external/external-email-sender/src/test/kotlin/com/ttasjwi/board/system/EmailSenderTestApplication.kt
@@ -1,0 +1,11 @@
+package com.ttasjwi.board.system
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+@SpringBootApplication
+class EmailSenderTestApplication
+
+fun main(args: Array<String>) {
+    runApplication<EmailSenderTestApplication>(*args)
+}

--- a/board-system-external/external-email-sender/src/test/kotlin/com/ttasjwi/board/system/member/domain/external/EmailSenderImplManualTest.kt
+++ b/board-system-external/external-email-sender/src/test/kotlin/com/ttasjwi/board/system/member/domain/external/EmailSenderImplManualTest.kt
@@ -1,0 +1,26 @@
+package com.ttasjwi.board.system.member.domain.external
+
+import com.ttasjwi.board.system.member.domain.model.fixture.emailFixture
+import com.ttasjwi.board.system.member.domain.service.EmailSender
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+
+@Disabled // 수동테스트 용이므로, 로컬에서 수동테스트를 하고 싶다면 이 부분을 주석처리
+@SpringBootTest
+@DisplayName("EmailSenderImpl 수동 테스트")
+class EmailSenderImplManualTest @Autowired constructor(
+    private val emailSender: EmailSender
+) {
+
+    @Test
+    @DisplayName("이메일이 전송되어 잘 보내져야한다.")
+    fun test() {
+        val email = emailFixture("ttasjwi920@gmail.com")
+        val subject = "테스트 이메일"
+        val content = "땃쥐에게 이메일이 갔어요!"
+        emailSender.send(email, subject, content)
+    }
+}

--- a/board-system-external/external-email-sender/src/test/resources/application.yml
+++ b/board-system-external/external-email-sender/src/test/resources/application.yml
@@ -1,0 +1,11 @@
+spring:
+  application:
+    name: email-send-test-application
+  profiles:
+    active: test
+    group:
+      test: localSecret
+  config:
+    import: email-send-config.yml
+
+---

--- a/board-system-external/external-redis/build.gradle.kts
+++ b/board-system-external/external-redis/build.gradle.kts
@@ -1,4 +1,7 @@
 dependencies {
     implementation(project(":board-system-domain:domain-core"))
     implementation(project(":board-system-domain:domain-member"))
+
+    testFixturesImplementation(testFixtures(project(":board-system-domain:domain-core")))
+    testFixturesImplementation(testFixtures(project(":board-system-domain:domain-member")))
 }

--- a/board-system-external/external-redis/src/main/kotlin/com/ttasjwi/board/system/member/domain/service/impl/EmailVerificationStorage.kt
+++ b/board-system-external/external-redis/src/main/kotlin/com/ttasjwi/board/system/member/domain/service/impl/EmailVerificationStorage.kt
@@ -1,4 +1,4 @@
-package com.ttasjwi.board.system.member.domain.external.redis
+package com.ttasjwi.board.system.member.domain.service.impl
 
 import com.ttasjwi.board.system.core.annotation.component.AppComponent
 import com.ttasjwi.board.system.member.domain.model.Email
@@ -6,19 +6,22 @@ import com.ttasjwi.board.system.member.domain.model.EmailVerification
 import com.ttasjwi.board.system.member.domain.service.EmailVerificationAppender
 import com.ttasjwi.board.system.member.domain.service.EmailVerificationFinder
 import java.time.ZonedDateTime
+import java.util.concurrent.ConcurrentHashMap
 
 @AppComponent
 internal class EmailVerificationStorage : EmailVerificationAppender, EmailVerificationFinder {
 
+    private val store: MutableMap<Email, EmailVerification> = ConcurrentHashMap()
+
     override fun append(emailVerification: EmailVerification, expiresAt: ZonedDateTime) {
-        TODO("Not yet implemented")
+        store[emailVerification.email] = emailVerification
     }
 
     override fun removeByEmail(email: Email) {
-        TODO("Not yet implemented")
+        store.remove(email)
     }
 
     override fun findByEmailOrNull(email: Email): EmailVerification? {
-        TODO("Not yet implemented")
+        return store[email]
     }
 }

--- a/board-system-external/external-redis/src/test/kotlin/com/ttasjwi/board/system/member/domain/service/impl/EmailVerificationStorageTest.kt
+++ b/board-system-external/external-redis/src/test/kotlin/com/ttasjwi/board/system/member/domain/service/impl/EmailVerificationStorageTest.kt
@@ -1,0 +1,56 @@
+package com.ttasjwi.board.system.member.domain.service.impl
+
+import com.ttasjwi.board.system.core.time.fixture.timeFixture
+import com.ttasjwi.board.system.member.domain.model.fixture.emailFixture
+import com.ttasjwi.board.system.member.domain.model.fixture.emailVerificationFixtureVerified
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("EmailVerificationStorage(Appender, Finder) 테스트")
+class EmailVerificationStorageTest {
+
+    private lateinit var emailVerificationStorage: EmailVerificationStorage
+
+    @BeforeEach
+    fun setup() {
+        emailVerificationStorage = EmailVerificationStorage()
+    }
+
+    @Test
+    @DisplayName("이메일 인증을 저장하고 이메일로 다시 찾을 수 있다")
+    fun appendAndFind() {
+        val emailVerification = emailVerificationFixtureVerified()
+        emailVerificationStorage.append(emailVerification, timeFixture())
+
+        val findEmailVerification = emailVerificationStorage.findByEmailOrNull(emailVerification.email)!!
+
+        assertThat(findEmailVerification.email).isEqualTo(emailVerification.email)
+        assertThat(findEmailVerification.code).isEqualTo(emailVerification.code)
+        assertThat(findEmailVerification.codeCreatedAt).isEqualTo(emailVerification.codeCreatedAt)
+        assertThat(findEmailVerification.codeExpiresAt).isEqualTo(emailVerification.codeExpiresAt)
+        assertThat(findEmailVerification.verifiedAt).isEqualTo(emailVerification.verifiedAt)
+        assertThat(findEmailVerification.verificationExpiresAt).isEqualTo(emailVerification.verificationExpiresAt)
+    }
+
+    @Test
+    @DisplayName("이메일 인증을 찾지 못 했다면 null 이 반환된다")
+    fun notFoundNull() {
+        val findEmailVerification = emailVerificationStorage.findByEmailOrNull(emailFixture("bye@gmail.com"))
+        assertThat(findEmailVerification).isNull()
+    }
+
+    @Test
+    @DisplayName("remove 테스트")
+    fun remove() {
+        val emailVerification = emailVerificationFixtureVerified()
+        emailVerificationStorage.append(emailVerification, timeFixture())
+
+        emailVerificationStorage.removeByEmail(emailVerification.email)
+
+        val findEmailVerification = emailVerificationStorage.findByEmailOrNull(emailVerification.email)
+        assertThat(findEmailVerification).isNull()
+    }
+
+}

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -13,8 +13,8 @@ enum class Dependencies(
     // spring
     SPRING_BOOT_STARTER(groupId = "org.springframework.boot", artifactId = "spring-boot-starter"),
     SPRING_BOOT_WEB(groupId = "org.springframework.boot", artifactId = "spring-boot-starter-web"),
-
     SPRING_BOOT_DATA_JPA(groupId = "org.springframework.boot", artifactId = "spring-boot-starter-data-jpa"),
+    SPRING_BOOT_MAIL(groupId = "org.springframework.boot", artifactId = "spring-boot-starter-mail"),
     SPRING_BOOT_TEST(groupId = "org.springframework.boot", artifactId = "spring-boot-starter-test"),
 
     // p6spy

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,6 +22,10 @@ include(
     "board-system-domain:domain-core",
     "board-system-domain:domain-member",
 
+    // event
+    "board-system-event:event-publisher-member",
+    "board-system-event:event-consumer-member",
+
     // external : 외부 기술 의존성
     "board-system-external:external-message",
     "board-system-external:external-db",


### PR DESCRIPTION
# JIRA 티켓
- [BRD-43]

---

# 구현 기능
- 이메일 인증 시작 API, 애플리케이션 서비스, 도메인 기능구현(단, 이메일 인증은 메모리에 저장하는 방식으로 구현)
  - 이후 Redis 연동방식으로 이메일 인증 저장기능 구현 예정
- 이메일 발송 기능(이메일 인증 시작됨 이벤트 발행 -> 이메일 인증 시작됨 이벤트 구독[비동기] -> 이메일 발송)

# 한계
- 이메일 인증이 메모리에 저장됨 
  -  TTL 기능이 있고, 애플리케이션과 별도로 관리되는 외부 저장소가 필요 -> 레디스 사용 예정
- 애플리케이션 내부에서 이벤트가 발행되고 구독되기 전에, 애플리케이션이 종료되면?
  - 이런 경우를 해결하려면 전문적으로 이벤트를 통합적으로 수집하는 외부 시스템(예: 카프카) 이 필요함
 


[BRD-43]: https://ttasjwi.atlassian.net/browse/BRD-43?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ