### PR TITLE
Refactor: (BRD-71)  메시지 획득 방법 일원화

### DIFF
--- a/board-system-api/api-deploy/src/main/kotlin/com/ttasjwi/board/system/deploy/api/HealthCheckController.kt
+++ b/board-system-api/api-deploy/src/main/kotlin/com/ttasjwi/board/system/deploy/api/HealthCheckController.kt
@@ -22,8 +22,8 @@ class HealthCheckController(
         val args = listOf("$.data.profile")
         val response = SuccessResponse(
             code = code,
-            message = messageResolver.resolveMessage(code, locale),
-            description = messageResolver.resolveDescription(code, args, locale),
+            message = messageResolver.resolve("$code.message", locale),
+            description = messageResolver.resolve("$code.description", locale, args),
             data = HealthCheckResponse(
                 profile = deployProperties.profile
             )

--- a/board-system-api/api-deploy/src/test/kotlin/com/ttasjwi/board/system/deploy/api/HealthCheckControllerMiddleTest.kt
+++ b/board-system-api/api-deploy/src/test/kotlin/com/ttasjwi/board/system/deploy/api/HealthCheckControllerMiddleTest.kt
@@ -58,8 +58,8 @@ class HealthCheckControllerMiddleTest {
                 content().contentType(MediaType.APPLICATION_JSON),
                 jsonPath("$.isSuccess").value(true),
                 jsonPath("$.code").value("HealthCheck.Success"),
-                jsonPath("$.message").value("HealthCheck.Success.message(locale=${Locale.KOREAN})"),
-                jsonPath("$.description").value("HealthCheck.Success.description(args=[\$.data.profile],locale=${Locale.KOREAN})"),
+                jsonPath("$.message").value("HealthCheck.Success.message(locale=${Locale.KOREAN},args=[])"),
+                jsonPath("$.description").value("HealthCheck.Success.description(locale=${Locale.KOREAN},args=[\$.data.profile])"),
                 jsonPath("$.data.profile").value("test")
             )
     }

--- a/board-system-api/api-member/src/main/kotlin/com/ttasjwi/board/system/member/api/EmailAvailableController.kt
+++ b/board-system-api/api-member/src/main/kotlin/com/ttasjwi/board/system/member/api/EmailAvailableController.kt
@@ -34,15 +34,15 @@ class EmailAvailableController(
         val locale = localeManager.getCurrentLocale()
         return SuccessResponse(
             code = code,
-            message = messageResolver.resolveMessage(code, locale),
-            description = messageResolver.resolveDescription(code, listOf("$.data.emailAvailable"), locale),
+            message = messageResolver.resolve("$code.message", locale),
+            description = messageResolver.resolve("$code.description", locale, listOf("$.data.emailAvailable")),
             data = EmailAvailableResponse(
                 emailAvailable = EmailAvailableResponse.EmailAvailable(
                     email = result.email,
                     isAvailable = result.isAvailable,
                     reasonCode = result.reasonCode,
-                    message = messageResolver.resolveMessage(result.reasonCode, locale),
-                    description = messageResolver.resolveDescription(result.reasonCode, emptyList(), locale),
+                    message = messageResolver.resolve("${result.reasonCode}.message", locale),
+                    description = messageResolver.resolve("${result.reasonCode}.description", locale),
                 )
             )
         )

--- a/board-system-api/api-member/src/main/kotlin/com/ttasjwi/board/system/member/api/EmailVerificationStartController.kt
+++ b/board-system-api/api-member/src/main/kotlin/com/ttasjwi/board/system/member/api/EmailVerificationStartController.kt
@@ -37,7 +37,7 @@ class EmailVerificationStartController(
         return SuccessResponse(
             code = code,
             message = messageResolver.resolve("$code.message", locale),
-            description = messageResolver.resolve("$code.description", locale, listOf("$.data.emailVerificationStartResult")),
+            description = messageResolver.resolve("$code.description", locale),
             data = EmailVerificationStartResponse(
                 EmailVerificationStartResponse.EmailVerificationStartResult(
                     email = result.email,

--- a/board-system-api/api-member/src/main/kotlin/com/ttasjwi/board/system/member/api/EmailVerificationStartController.kt
+++ b/board-system-api/api-member/src/main/kotlin/com/ttasjwi/board/system/member/api/EmailVerificationStartController.kt
@@ -36,8 +36,8 @@ class EmailVerificationStartController(
         val locale = localeManager.getCurrentLocale()
         return SuccessResponse(
             code = code,
-            message = messageResolver.resolveMessage(code, locale),
-            description = messageResolver.resolveDescription(code, listOf("$.data.emailVerificationStartResult"), locale),
+            message = messageResolver.resolve("$code.message", locale),
+            description = messageResolver.resolve("$code.description", locale, listOf("$.data.emailVerificationStartResult")),
             data = EmailVerificationStartResponse(
                 EmailVerificationStartResponse.EmailVerificationStartResult(
                     email = result.email,

--- a/board-system-api/api-member/src/main/kotlin/com/ttasjwi/board/system/member/api/NicknameAvailableController.kt
+++ b/board-system-api/api-member/src/main/kotlin/com/ttasjwi/board/system/member/api/NicknameAvailableController.kt
@@ -34,15 +34,15 @@ class NicknameAvailableController(
         val locale = localeManager.getCurrentLocale()
         return SuccessResponse(
             code = code,
-            message = messageResolver.resolveMessage(code, locale),
-            description = messageResolver.resolveDescription(code, listOf("$.data.nicknameAvailable"), locale),
+            message = messageResolver.resolve("$code.message", locale),
+            description = messageResolver.resolve("$code.description", locale, listOf("$.data.nicknameAvailable")),
             data = NicknameAvailableResponse(
                 nicknameAvailable = NicknameAvailableResponse.NicknameAvailable(
                     nickname = result.nickname,
                     isAvailable = result.isAvailable,
                     reasonCode = result.reasonCode,
-                    message = messageResolver.resolveMessage(result.reasonCode, locale),
-                    description = messageResolver.resolveDescription(result.reasonCode, emptyList(), locale),
+                    message = messageResolver.resolve("${result.reasonCode}.message", locale),
+                    description = messageResolver.resolve("${result.reasonCode}.description", locale),
                 )
             )
         )

--- a/board-system-api/api-member/src/main/kotlin/com/ttasjwi/board/system/member/api/UsernameAvailableController.kt
+++ b/board-system-api/api-member/src/main/kotlin/com/ttasjwi/board/system/member/api/UsernameAvailableController.kt
@@ -34,15 +34,15 @@ class UsernameAvailableController(
         val locale = localeManager.getCurrentLocale()
         return SuccessResponse(
             code = code,
-            message = messageResolver.resolveMessage(code, locale),
-            description = messageResolver.resolveDescription(code, listOf("$.data.usernameAvailable"), locale),
+            message = messageResolver.resolve("$code.message", locale),
+            description = messageResolver.resolve("$code.description", locale, listOf("$.data.usernameAvailable")),
             data = UsernameAvailableResponse(
                 usernameAvailable = UsernameAvailableResponse.UsernameAvailable(
                     username = result.username,
                     isAvailable = result.isAvailable,
                     reasonCode = result.reasonCode,
-                    message = messageResolver.resolveMessage(result.reasonCode, locale),
-                    description = messageResolver.resolveDescription(result.reasonCode, emptyList(), locale),
+                    message = messageResolver.resolve("${result.reasonCode}.message", locale),
+                    description = messageResolver.resolve("${result.reasonCode}.description", locale),
                 )
             )
         )

--- a/board-system-api/api-member/src/test/kotlin/com/ttasjwi/board/system/member/api/EmailAvailableControllerTest.kt
+++ b/board-system-api/api-member/src/test/kotlin/com/ttasjwi/board/system/member/api/EmailAvailableControllerTest.kt
@@ -42,15 +42,15 @@ class EmailAvailableControllerTest {
         assertThat(responseEntity.statusCode.value()).isEqualTo(HttpStatus.OK.value())
         assertThat(response.isSuccess).isTrue()
         assertThat(response.code).isEqualTo("EmailAvailableCheck.Complete")
-        assertThat(response.message).isEqualTo("EmailAvailableCheck.Complete.message(locale=${Locale.KOREAN})")
-        assertThat(response.description).isEqualTo("EmailAvailableCheck.Complete.description(args=[$.data.emailAvailable],locale=${Locale.KOREAN})")
+        assertThat(response.message).isEqualTo("EmailAvailableCheck.Complete.message(locale=${Locale.KOREAN},args=[])")
+        assertThat(response.description).isEqualTo("EmailAvailableCheck.Complete.description(locale=${Locale.KOREAN},args=[\$.data.emailAvailable])")
 
         val emailAvailable = response.data.emailAvailable
 
         assertThat(emailAvailable.email).isEqualTo(request.email)
         assertThat(emailAvailable.isAvailable).isEqualTo(true)
         assertThat(emailAvailable.reasonCode).isEqualTo("EmailAvailableCheck.Available")
-        assertThat(emailAvailable.message).isEqualTo("EmailAvailableCheck.Available.message(locale=${Locale.KOREAN})")
-        assertThat(emailAvailable.description).isEqualTo("EmailAvailableCheck.Available.description(args=[],locale=${Locale.KOREAN})")
+        assertThat(emailAvailable.message).isEqualTo("EmailAvailableCheck.Available.message(locale=${Locale.KOREAN},args=[])")
+        assertThat(emailAvailable.description).isEqualTo("EmailAvailableCheck.Available.description(locale=${Locale.KOREAN},args=[])")
     }
 }

--- a/board-system-api/api-member/src/test/kotlin/com/ttasjwi/board/system/member/api/EmailVerificationStartControllerTest.kt
+++ b/board-system-api/api-member/src/test/kotlin/com/ttasjwi/board/system/member/api/EmailVerificationStartControllerTest.kt
@@ -48,7 +48,7 @@ class EmailVerificationStartControllerTest {
         assertThat(response.isSuccess).isTrue()
         assertThat(response.code).isEqualTo("EmailVerificationStart.Complete")
         assertThat(response.message).isEqualTo("EmailVerificationStart.Complete.message(locale=${Locale.KOREAN},args=[])")
-        assertThat(response.description).isEqualTo("EmailVerificationStart.Complete.description(locale=${Locale.KOREAN},args=[\$.data.emailVerificationStartResult])")
+        assertThat(response.description).isEqualTo("EmailVerificationStart.Complete.description(locale=${Locale.KOREAN},args=[])")
 
         val emailVerificationStartResult = response.data.emailVerificationStartResult
 

--- a/board-system-api/api-member/src/test/kotlin/com/ttasjwi/board/system/member/api/EmailVerificationStartControllerTest.kt
+++ b/board-system-api/api-member/src/test/kotlin/com/ttasjwi/board/system/member/api/EmailVerificationStartControllerTest.kt
@@ -47,8 +47,8 @@ class EmailVerificationStartControllerTest {
         assertThat(responseEntity.statusCode.value()).isEqualTo(HttpStatus.OK.value())
         assertThat(response.isSuccess).isTrue()
         assertThat(response.code).isEqualTo("EmailVerificationStart.Complete")
-        assertThat(response.message).isEqualTo("EmailVerificationStart.Complete.message(locale=${Locale.KOREAN})")
-        assertThat(response.description).isEqualTo("EmailVerificationStart.Complete.description(args=[$.data.emailVerificationStartResult],locale=${Locale.KOREAN})")
+        assertThat(response.message).isEqualTo("EmailVerificationStart.Complete.message(locale=${Locale.KOREAN},args=[])")
+        assertThat(response.description).isEqualTo("EmailVerificationStart.Complete.description(locale=${Locale.KOREAN},args=[\$.data.emailVerificationStartResult])")
 
         val emailVerificationStartResult = response.data.emailVerificationStartResult
 

--- a/board-system-api/api-member/src/test/kotlin/com/ttasjwi/board/system/member/api/NicknameAvailableControllerTest.kt
+++ b/board-system-api/api-member/src/test/kotlin/com/ttasjwi/board/system/member/api/NicknameAvailableControllerTest.kt
@@ -42,15 +42,15 @@ class NicknameAvailableControllerTest {
         assertThat(responseEntity.statusCode.value()).isEqualTo(HttpStatus.OK.value())
         assertThat(response.isSuccess).isTrue()
         assertThat(response.code).isEqualTo("NicknameAvailableCheck.Complete")
-        assertThat(response.message).isEqualTo("NicknameAvailableCheck.Complete.message(locale=${Locale.KOREAN})")
-        assertThat(response.description).isEqualTo("NicknameAvailableCheck.Complete.description(args=[$.data.nicknameAvailable],locale=${Locale.KOREAN})")
+        assertThat(response.message).isEqualTo("NicknameAvailableCheck.Complete.message(locale=${Locale.KOREAN},args=[])")
+        assertThat(response.description).isEqualTo("NicknameAvailableCheck.Complete.description(locale=${Locale.KOREAN},args=[\$.data.nicknameAvailable])")
 
         val nicknameAvailable = response.data.nicknameAvailable
 
         assertThat(nicknameAvailable.nickname).isEqualTo(request.nickname)
         assertThat(nicknameAvailable.isAvailable).isEqualTo(true)
         assertThat(nicknameAvailable.reasonCode).isEqualTo("NicknameAvailableCheck.Available")
-        assertThat(nicknameAvailable.message).isEqualTo("NicknameAvailableCheck.Available.message(locale=${Locale.KOREAN})")
-        assertThat(nicknameAvailable.description).isEqualTo("NicknameAvailableCheck.Available.description(args=[],locale=${Locale.KOREAN})")
+        assertThat(nicknameAvailable.message).isEqualTo("NicknameAvailableCheck.Available.message(locale=${Locale.KOREAN},args=[])")
+        assertThat(nicknameAvailable.description).isEqualTo("NicknameAvailableCheck.Available.description(locale=${Locale.KOREAN},args=[])")
     }
 }

--- a/board-system-api/api-member/src/test/kotlin/com/ttasjwi/board/system/member/api/UsernameAvailableControllerTest.kt
+++ b/board-system-api/api-member/src/test/kotlin/com/ttasjwi/board/system/member/api/UsernameAvailableControllerTest.kt
@@ -42,15 +42,15 @@ class UsernameAvailableControllerTest {
         assertThat(responseEntity.statusCode.value()).isEqualTo(HttpStatus.OK.value())
         assertThat(response.isSuccess).isTrue()
         assertThat(response.code).isEqualTo("UsernameAvailableCheck.Complete")
-        assertThat(response.message).isEqualTo("UsernameAvailableCheck.Complete.message(locale=${Locale.KOREAN})")
-        assertThat(response.description).isEqualTo("UsernameAvailableCheck.Complete.description(args=[$.data.usernameAvailable],locale=${Locale.KOREAN})")
+        assertThat(response.message).isEqualTo("UsernameAvailableCheck.Complete.message(locale=${Locale.KOREAN},args=[])")
+        assertThat(response.description).isEqualTo("UsernameAvailableCheck.Complete.description(locale=${Locale.KOREAN},args=[\$.data.usernameAvailable])")
 
         val usernameAvailable = response.data.usernameAvailable
 
         assertThat(usernameAvailable.username).isEqualTo(request.username)
         assertThat(usernameAvailable.isAvailable).isEqualTo(true)
         assertThat(usernameAvailable.reasonCode).isEqualTo("UsernameAvailableCheck.Available")
-        assertThat(usernameAvailable.message).isEqualTo("UsernameAvailableCheck.Available.message(locale=${Locale.KOREAN})")
-        assertThat(usernameAvailable.description).isEqualTo("UsernameAvailableCheck.Available.description(args=[],locale=${Locale.KOREAN})")
+        assertThat(usernameAvailable.message).isEqualTo("UsernameAvailableCheck.Available.message(locale=${Locale.KOREAN},args=[])")
+        assertThat(usernameAvailable.description).isEqualTo("UsernameAvailableCheck.Available.description(locale=${Locale.KOREAN},args=[])")
     }
 }

--- a/board-system-core/src/main/kotlin/com/ttasjwi/board/system/core/message/MessageResolver.kt
+++ b/board-system-core/src/main/kotlin/com/ttasjwi/board/system/core/message/MessageResolver.kt
@@ -6,14 +6,5 @@ interface MessageResolver {
     /**
      * code 에 대응하는 메시지를 찾습니다.
      */
-    fun resolveMessage(code: String, locale: Locale): String
-
-    /**
-     * code 에 대응하는 메시지 설명(description) 을 찾습니다.
-     */
-    fun resolveDescription(
-        code: String,
-        args: List<Any?> = emptyList(),
-        locale: Locale,
-    ): String
+    fun resolve(code: String, locale: Locale, args: List<Any?> = emptyList()): String
 }

--- a/board-system-core/src/test/kotlin/com/ttasjwi/board/system/core/message/fixture/MessageResolverFixtureTest.kt
+++ b/board-system-core/src/test/kotlin/com/ttasjwi/board/system/core/message/fixture/MessageResolverFixtureTest.kt
@@ -11,22 +11,22 @@ class MessageResolverFixtureTest {
     private val messageResolver = MessageResolverFixture()
 
     @Test
-    @DisplayName("resolveMessage: code, locale 을 전달하여 메시지를 얻어올 수 있다.")
-    fun testGeneralTitle() {
+    @DisplayName("resolve: code, locale 만 전달하여 메시지를 얻어올 수 있다.")
+    fun test1() {
         val code = "hello"
         val locale = Locale.KOREAN
 
-        val title = messageResolver.resolveMessage(code, locale)
-        assertThat(title).isEqualTo("$code.message(locale=$locale)")
+        val title = messageResolver.resolve(code, locale)
+        assertThat(title).isEqualTo("$code(locale=$locale,args=[])")
     }
 
     @Test
-    @DisplayName("resolveDescription: code, args, locale 을 전달하여 메시지를 얻어올 수 있다.")
-    fun testDescription() {
+    @DisplayName("resolve: code, locale, args 를 전달하여 메시지를 얻어올 수 있다.")
+    fun test2() {
         val code = "hello"
-        val args = listOf(1, 2)
         val locale = Locale.ENGLISH
-        val description = messageResolver.resolveDescription(code, args, locale)
-        assertThat(description).isEqualTo("$code.description(args=[1, 2],locale=$locale)")
+        val args = listOf(1, 2)
+        val description = messageResolver.resolve(code, locale, args)
+        assertThat(description).isEqualTo("$code(locale=$locale,args=[1, 2])")
     }
 }

--- a/board-system-core/src/testFixtures/kotlin/com/ttasjwi/board/system/core/message/fixture/MessageResolverFixture.kt
+++ b/board-system-core/src/testFixtures/kotlin/com/ttasjwi/board/system/core/message/fixture/MessageResolverFixture.kt
@@ -5,11 +5,7 @@ import java.util.*
 
 class MessageResolverFixture : MessageResolver {
 
-    override fun resolveMessage(code: String, locale: Locale): String {
-        return "$code.message(locale=${locale})"
-    }
-
-    override fun resolveDescription(code: String, args: List<Any?>, locale: Locale): String {
-        return "$code.description(args=$args,locale=$locale)"
+    override fun resolve(code: String, locale: Locale, args: List<Any?>): String {
+        return "$code(locale=$locale,args=$args)"
     }
 }

--- a/board-system-event/event-consumer-member/src/main/kotlin/com/ttasjwi/board/system/member/event/consumer/EmailVerificationStartedEventConsumer.kt
+++ b/board-system-event/event-consumer-member/src/main/kotlin/com/ttasjwi/board/system/member/event/consumer/EmailVerificationStartedEventConsumer.kt
@@ -18,8 +18,8 @@ class EmailVerificationStartedEventConsumer(
     fun handleEmailVerificationStartedEvent(event: EmailVerificationStartedEvent) {
         emailSendUseCase.sendEmail(
             address = event.data.email,
-            subject = messageResolver.resolveMessage("EmailVerification.subject", event.data.locale),
-            content = messageResolver.resolveDescription("EmailVerification.content", listOf(event.data.code), event.data.locale),
+            subject = messageResolver.resolve("EmailVerification.subject", event.data.locale),
+            content = messageResolver.resolve("EmailVerification.content", event.data.locale, listOf(event.data.code)),
         )
     }
 }

--- a/board-system-external/external-exception-handle/src/main/kotlin/com/ttasjwi/board/system/core/exception/api/GlobalExceptionController.kt
+++ b/board-system-external/external-exception-handle/src/main/kotlin/com/ttasjwi/board/system/core/exception/api/GlobalExceptionController.kt
@@ -90,8 +90,8 @@ internal class GlobalExceptionController(
             .body(
                 ErrorResponse(
                     code = commonCode,
-                    message = messageResolver.resolveMessage(code = commonCode, locale = locale),
-                    description = messageResolver.resolveDescription(code = commonCode, locale = locale),
+                    message = messageResolver.resolve("$commonCode.message", locale),
+                    description = messageResolver.resolve("$commonCode.description", locale),
                     errors = errorItems
                 )
             )
@@ -105,8 +105,8 @@ internal class GlobalExceptionController(
         val locale = localeManager.getCurrentLocale()
         return ErrorResponse.ErrorItem(
             code = code,
-            message = messageResolver.resolveMessage(code, locale),
-            description = messageResolver.resolveDescription(code, args, locale),
+            message = messageResolver.resolve("$code.message", locale),
+            description = messageResolver.resolve("$code.description", locale, args),
             source = source
         )
     }

--- a/board-system-external/external-exception-handle/src/test/kotlin/com/ttasjwi/board/system/core/exception/WebMvcExceptionHandleTest.kt
+++ b/board-system-external/external-exception-handle/src/test/kotlin/com/ttasjwi/board/system/core/exception/WebMvcExceptionHandleTest.kt
@@ -51,12 +51,12 @@ class WebMvcExceptionHandleTest {
                 content().contentType(MediaType.APPLICATION_JSON),
                 jsonPath("$.isSuccess").value(false),
                 jsonPath("$.code").value("Error.Occurred"),
-                jsonPath("$.message").value("Error.Occurred.message(locale=${Locale.KOREAN})"),
-                jsonPath("$.description").value("Error.Occurred.description(args=[],locale=${Locale.KOREAN})"),
+                jsonPath("$.message").value("Error.Occurred.message(locale=${Locale.KOREAN},args=[])"),
+                jsonPath("$.description").value("Error.Occurred.description(locale=${Locale.KOREAN},args=[])"),
                 jsonPath("$.data").doesNotExist(),
                 jsonPath("$.errors[0].code").value("Error.Fixture"),
-                jsonPath("$.errors[0].message").value("Error.Fixture.message(locale=${Locale.KOREAN})"),
-                jsonPath("$.errors[0].description").value("Error.Fixture.description(args=[],locale=${Locale.KOREAN})"),
+                jsonPath("$.errors[0].message").value("Error.Fixture.message(locale=${Locale.KOREAN},args=[])"),
+                jsonPath("$.errors[0].description").value("Error.Fixture.description(locale=${Locale.KOREAN},args=[])"),
                 jsonPath("$.errors[0].source").value("filter"),
             )
     }
@@ -72,12 +72,12 @@ class WebMvcExceptionHandleTest {
                 content().contentType(MediaType.APPLICATION_JSON),
                 jsonPath("$.isSuccess").value(false),
                 jsonPath("$.code").value("Error.Occurred"),
-                jsonPath("$.message").value("Error.Occurred.message(locale=${Locale.KOREAN})"),
-                jsonPath("$.description").value("Error.Occurred.description(args=[],locale=${Locale.KOREAN})"),
+                jsonPath("$.message").value("Error.Occurred.message(locale=${Locale.KOREAN},args=[])"),
+                jsonPath("$.description").value("Error.Occurred.description(locale=${Locale.KOREAN},args=[])"),
                 jsonPath("$.data").doesNotExist(),
                 jsonPath("$.errors[0].code").value("Error.Fixture"),
-                jsonPath("$.errors[0].message").value("Error.Fixture.message(locale=${Locale.KOREAN})"),
-                jsonPath("$.errors[0].description").value("Error.Fixture.description(args=[],locale=${Locale.KOREAN})"),
+                jsonPath("$.errors[0].message").value("Error.Fixture.message(locale=${Locale.KOREAN},args=[])"),
+                jsonPath("$.errors[0].description").value("Error.Fixture.description(locale=${Locale.KOREAN},args=[])"),
                 jsonPath("$.errors[0].source").value("controller"),
             )
     }

--- a/board-system-external/external-exception-handle/src/test/kotlin/com/ttasjwi/board/system/core/exception/api/GlobalExceptionControllerTest.kt
+++ b/board-system-external/external-exception-handle/src/test/kotlin/com/ttasjwi/board/system/core/exception/api/GlobalExceptionControllerTest.kt
@@ -43,14 +43,14 @@ class GlobalExceptionControllerTest {
         assertThat(responseEntity.statusCode.value()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value())
         assertThat(response.isSuccess).isFalse()
         assertThat(response.code).isEqualTo("Error.Occurred")
-        assertThat(response.message).isEqualTo("Error.Occurred.message(locale=${Locale.KOREAN})")
-        assertThat(response.description).isEqualTo("Error.Occurred.description(args=[],locale=${Locale.KOREAN})")
+        assertThat(response.message).isEqualTo("Error.Occurred.message(locale=${Locale.KOREAN},args=[])")
+        assertThat(response.description).isEqualTo("Error.Occurred.description(locale=${Locale.KOREAN},args=[])")
         assertThat(response.errors.size).isEqualTo(1)
 
         val errorItem = response.errors[0]
         assertThat(errorItem.code).isEqualTo("Error.Server")
-        assertThat(errorItem.message).isEqualTo("Error.Server.message(locale=${Locale.KOREAN})")
-        assertThat(errorItem.description).isEqualTo("Error.Server.description(args=[],locale=${Locale.KOREAN})")
+        assertThat(errorItem.message).isEqualTo("Error.Server.message(locale=${Locale.KOREAN},args=[])")
+        assertThat(errorItem.description).isEqualTo("Error.Server.description(locale=${Locale.KOREAN},args=[])")
         assertThat(errorItem.source).isEqualTo("server")
     }
 
@@ -65,14 +65,14 @@ class GlobalExceptionControllerTest {
         assertThat(responseEntity.statusCode.value()).isEqualTo(HttpStatus.BAD_REQUEST.value())
         assertThat(response.isSuccess).isFalse()
         assertThat(response.code).isEqualTo("Error.Occurred")
-        assertThat(response.message).isEqualTo("Error.Occurred.message(locale=${Locale.KOREAN})")
-        assertThat(response.description).isEqualTo("Error.Occurred.description(args=[],locale=${Locale.KOREAN})")
+        assertThat(response.message).isEqualTo("Error.Occurred.message(locale=${Locale.KOREAN},args=[])")
+        assertThat(response.description).isEqualTo("Error.Occurred.description(locale=${Locale.KOREAN},args=[])")
         assertThat(response.errors.size).isEqualTo(1)
 
         val errorItem = response.errors[0]
         assertThat(errorItem.code).isEqualTo(exception.code)
-        assertThat(errorItem.message).isEqualTo("${exception.code}.message(locale=${Locale.KOREAN})")
-        assertThat(errorItem.description).isEqualTo("${exception.code}.description(args=${exception.args},locale=${Locale.KOREAN})")
+        assertThat(errorItem.message).isEqualTo("${exception.code}.message(locale=${Locale.KOREAN},args=[])")
+        assertThat(errorItem.description).isEqualTo("${exception.code}.description(locale=${Locale.KOREAN},args=${exception.args})")
         assertThat(errorItem.source).isEqualTo(exception.source)
     }
 
@@ -89,14 +89,14 @@ class GlobalExceptionControllerTest {
         assertThat(responseEntity.statusCode.value()).isEqualTo(HttpStatus.NOT_IMPLEMENTED.value())
         assertThat(response.isSuccess).isFalse()
         assertThat(response.code).isEqualTo("Error.Occurred")
-        assertThat(response.message).isEqualTo("Error.Occurred.message(locale=${Locale.KOREAN})")
-        assertThat(response.description).isEqualTo("Error.Occurred.description(args=[],locale=${Locale.KOREAN})")
+        assertThat(response.message).isEqualTo("Error.Occurred.message(locale=${Locale.KOREAN},args=[])")
+        assertThat(response.description).isEqualTo("Error.Occurred.description(locale=${Locale.KOREAN},args=[])")
         assertThat(response.errors.size).isEqualTo(1)
 
         val errorItem = response.errors[0]
         assertThat(errorItem.code).isEqualTo("Error.NotImplemented")
-        assertThat(errorItem.message).isEqualTo("Error.NotImplemented.message(locale=${Locale.KOREAN})")
-        assertThat(errorItem.description).isEqualTo("Error.NotImplemented.description(args=[],locale=${Locale.KOREAN})")
+        assertThat(errorItem.message).isEqualTo("Error.NotImplemented.message(locale=${Locale.KOREAN},args=[])")
+        assertThat(errorItem.description).isEqualTo("Error.NotImplemented.description(locale=${Locale.KOREAN},args=[])")
         assertThat(errorItem.source).isEqualTo("server")
     }
 
@@ -116,20 +116,20 @@ class GlobalExceptionControllerTest {
         assertThat(responseEntity.statusCode.value()).isEqualTo(HttpStatus.BAD_REQUEST.value())
         assertThat(response.isSuccess).isFalse()
         assertThat(response.code).isEqualTo("Error.Occurred")
-        assertThat(response.message).isEqualTo("Error.Occurred.message(locale=${Locale.KOREAN})")
-        assertThat(response.description).isEqualTo("Error.Occurred.description(args=[],locale=${Locale.KOREAN})")
+        assertThat(response.message).isEqualTo("Error.Occurred.message(locale=${Locale.KOREAN},args=[])")
+        assertThat(response.description).isEqualTo("Error.Occurred.description(locale=${Locale.KOREAN},args=[])")
         assertThat(response.errors.size).isEqualTo(2)
 
         val errorItem1 = response.errors[0]
         val errorItem2 = response.errors[1]
 
         assertThat(errorItem1.code).isEqualTo(exception1.code)
-        assertThat(errorItem1.message).isEqualTo("${exception1.code}.message(locale=${Locale.KOREAN})")
-        assertThat(errorItem1.description).isEqualTo("${exception1.code}.description(args=${exception1.args},locale=${Locale.KOREAN})")
+        assertThat(errorItem1.message).isEqualTo("${exception1.code}.message(locale=${Locale.KOREAN},args=[])")
+        assertThat(errorItem1.description).isEqualTo("${exception1.code}.description(locale=${Locale.KOREAN},args=${exception1.args})")
         assertThat(errorItem1.source).isEqualTo(exception1.source)
         assertThat(errorItem2.code).isEqualTo(exception2.code)
-        assertThat(errorItem2.message).isEqualTo("${exception2.code}.message(locale=${Locale.KOREAN})")
-        assertThat(errorItem2.description).isEqualTo("${exception2.code}.description(args=${exception2.args},locale=${Locale.KOREAN})")
+        assertThat(errorItem2.message).isEqualTo("${exception2.code}.message(locale=${Locale.KOREAN},args=[])")
+        assertThat(errorItem2.description).isEqualTo("${exception2.code}.description(locale=${Locale.KOREAN},args=${exception2.args})")
         assertThat(errorItem2.source).isEqualTo(exception2.source)
     }
 }

--- a/board-system-external/external-message/src/main/kotlin/com/ttasjwi/board/system/core/message/MessageResolverImpl.kt
+++ b/board-system-external/external-message/src/main/kotlin/com/ttasjwi/board/system/core/message/MessageResolverImpl.kt
@@ -18,14 +18,9 @@ internal class MessageResolverImpl(
         private const val ERROR_MESSAGE_PREFIX = "Error."
     }
 
-    override fun resolveMessage(code: String, locale: Locale): String {
+    override fun resolve(code: String, locale: Locale, args: List<Any?>): String {
         val messageSource = selectMessageSource(code)
-        return messageSource.getMessage("$code.message", null, locale)
-    }
-
-    override fun resolveDescription(code: String, args: List<Any?>, locale: Locale): String {
-        val messageSource = selectMessageSource(code)
-        return messageSource.getMessage("$code.description", args.toTypedArray(), locale)
+        return messageSource.getMessage(code, args.toTypedArray(), locale)
     }
 
     private fun selectMessageSource(code: String): MessageSource {

--- a/board-system-external/external-message/src/main/resources/message/general-message_en.yml
+++ b/board-system-external/external-message/src/main/resources/message/general-message_en.yml
@@ -47,3 +47,13 @@ NicknameAvailableCheck:
   Taken:
     message: "Nickname is already in use"
     description: "This nickname is already taken."
+
+EmailVerificationStart:
+  Complete:
+    message: "Email verification started"
+    description: "Email verification has started. Please refer to the code sent to your email."
+
+EmailVerification:
+  subject: "Your Email Verification Code"
+  content: "Email Verification Code: {0}"
+

--- a/board-system-external/external-message/src/main/resources/message/general-message_ko.yml
+++ b/board-system-external/external-message/src/main/resources/message/general-message_ko.yml
@@ -47,3 +47,12 @@ NicknameAvailableCheck:
   Taken:
     message: "사용 중인 닉네임"
     description: "이미 사용 중인 닉네임입니다."
+
+EmailVerificationStart:
+  Complete:
+    message: "이메일인증 시작됨"
+    description: "이메일 인증이 시작됐습니다. 귀하의 이메일로 보내진 코드를 참고하세요."
+
+EmailVerification:
+  subject: "이메일인증 코드입니다"
+  content: "이메일인증 코드: {0}"

--- a/board-system-external/external-message/src/test/kotlin/com/ttasjwi/board/system/MessageTestController.kt
+++ b/board-system-external/external-message/src/test/kotlin/com/ttasjwi/board/system/MessageTestController.kt
@@ -2,7 +2,6 @@ package com.ttasjwi.board.system
 
 import com.ttasjwi.board.system.core.locale.LocaleManager
 import com.ttasjwi.board.system.core.message.MessageResolver
-import org.springframework.context.i18n.LocaleContextHolder
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
@@ -15,12 +14,12 @@ class MessageTestController(
 
     @GetMapping("/api/test")
     fun test(): ResponseEntity<MessageTestResponse> {
-        val locale = LocaleContextHolder.getLocale()
+        val locale = localeManager.getCurrentLocale()
 
         val code = "Example"
         val args = listOf(1, 2, 3)
-        val message = messageResolver.resolveMessage(code, locale)
-        val description = messageResolver.resolveDescription(code, args, locale)
+        val message = messageResolver.resolve("$code.message", locale)
+        val description = messageResolver.resolve("$code.description", locale, args)
 
         return ResponseEntity.ok(
             MessageTestResponse(

--- a/board-system-external/external-message/src/test/kotlin/com/ttasjwi/board/system/core/message/MessageResolverImplTest.kt
+++ b/board-system-external/external-message/src/test/kotlin/com/ttasjwi/board/system/core/message/MessageResolverImplTest.kt
@@ -21,8 +21,8 @@ class MessageResolverImplTest @Autowired constructor(
         val code = "Example"
         val locale = Locale.KOREAN
 
-        val message = messageResolver.resolveMessage(code, locale)
-        val description = messageResolver.resolveDescription(code, listOf(1, 2, "야옹"), locale)
+        val message = messageResolver.resolve("$code.message", locale)
+        val description = messageResolver.resolve("$code.description", locale, listOf(1, 2, "야옹"))
 
         assertThat(message).isEqualTo("예제 메시지")
         assertThat(description).isEqualTo("예제 설명(args=1,2,야옹)")
@@ -34,8 +34,8 @@ class MessageResolverImplTest @Autowired constructor(
         val code = "Example"
         val locale = Locale.ENGLISH
 
-        val message = messageResolver.resolveMessage(code, locale)
-        val description = messageResolver.resolveDescription(code, listOf(1, 2, "nyaa"), locale)
+        val message = messageResolver.resolve("$code.message", locale)
+        val description = messageResolver.resolve("$code.description", locale, listOf(1, 2, "nyaa"))
 
         assertThat(message).isEqualTo("Example Message")
         assertThat(description).isEqualTo("Example Description(args=1,2,nyaa)")
@@ -47,8 +47,8 @@ class MessageResolverImplTest @Autowired constructor(
         val code = "Error.NullArgument"
         val locale = Locale.KOREAN
 
-        val message = messageResolver.resolveMessage(code, locale)
-        val description = messageResolver.resolveDescription(code, listOf("username"), locale)
+        val message = messageResolver.resolve("$code.message", locale)
+        val description = messageResolver.resolve("$code.description", locale, listOf("username"))
 
         assertThat(message).isEqualTo("필수값 누락")
         assertThat(description).isEqualTo("'username'은(는) 필수입니다.")
@@ -60,8 +60,8 @@ class MessageResolverImplTest @Autowired constructor(
         val code = "Error.NullArgument"
         val locale = Locale.ENGLISH
 
-        val message = messageResolver.resolveMessage(code, locale)
-        val description = messageResolver.resolveDescription(code, listOf("username"), locale)
+        val message = messageResolver.resolve("$code.message", locale)
+        val description = messageResolver.resolve("$code.description", locale, listOf("username"))
 
         assertThat(message).isEqualTo("Missing required value")
         assertThat(description).isEqualTo("The field 'username' is required.")


### PR DESCRIPTION
# JIRA 티켓
- [BRD-71]

---

# 작업 내역
```kotlin
package com.ttasjwi.board.system.core.message

import java.util.Locale

interface MessageResolver {
    /**
     * code 에 대응하는 메시지를 찾습니다.
     */
    fun resolveMessage(code: String, locale: Locale): String = resolve(code, emptyList(), locale)

    /**
     * code 에 대응하는 메시지 설명(description) 을 찾습니다.
     */
    fun resolveDescription(
        code: String,
        locale: Locale,
        args: List<Any?>,
    ): String
}
```
- 기존엔 메시지 획득을 message, description 두 가지 획득만을 염두해뒀음

```kotlin
package com.ttasjwi.board.system.core.message

import java.util.Locale

interface MessageResolver {
    /**
     * code 에 대응하는 메시지를 찾습니다.
     */
    fun resolve(code: String, locale: Locale, args: List<Any?> = emptyList()): String
}
```
- 그러나 "xxx.code", "xxx.message" 말고도 "xxx.title", "xxx.content" 등 다양한 종류의 메시지 획득이 필요한 경우도 생길 듯 하다. 그래서 사용자측에서 원하는 코드를 구체적으로 지정하게 해서 한가지 방식으로 메시지를 획득할 수 있도록 변경함

```yaml
EmailVerificationStart:
  Complete:
    message: "이메일인증 시작됨"
    description: "이메일 인증이 시작됐습니다. 귀하의 이메일로 보내진 코드를 참고하세요."

EmailVerification:
  subject: "이메일인증 코드입니다"
  content: "이메일인증 코드: {0}"
```
- 추가적으로, 이메일 인증 시작 API 기능의 메시지 파일이 누락되어있어서 이 역시 수정함


[BRD-71]: https://ttasjwi.atlassian.net/browse/BRD-71?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ