### PR TITLE
Feature: (BRD-45) 회원가입 API 구현

### DIFF
--- a/board-system-api/api-member/src/main/kotlin/com/ttasjwi/board/system/member/api/RegisterMemberController.kt
+++ b/board-system-api/api-member/src/main/kotlin/com/ttasjwi/board/system/member/api/RegisterMemberController.kt
@@ -1,17 +1,54 @@
 package com.ttasjwi.board.system.member.api
 
 import com.ttasjwi.board.system.core.api.SuccessResponse
+import com.ttasjwi.board.system.core.locale.LocaleManager
+import com.ttasjwi.board.system.core.message.MessageResolver
+import com.ttasjwi.board.system.member.application.usecase.RegisterMemberRequest
+import com.ttasjwi.board.system.member.application.usecase.RegisterMemberResult
+import com.ttasjwi.board.system.member.application.usecase.RegisterMemberUseCase
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
 import java.time.ZonedDateTime
 
 @RestController
-class RegisterMemberController {
+class RegisterMemberController(
+    private val useCase: RegisterMemberUseCase,
+    private val messageResolver: MessageResolver,
+    private val localeManager: LocaleManager,
+) {
 
     @PostMapping("/api/v1/members")
-    fun register(): ResponseEntity<SuccessResponse<RegisterMemberResponse>> {
-        TODO("Not yet implemented")
+    fun register(@RequestBody request: RegisterMemberRequest): ResponseEntity<SuccessResponse<RegisterMemberResponse>> {
+        // 애플리케이션 서비스에 요청 처리를 위임
+        val result = useCase.register(request)
+
+        // 처리 결과로부터 응답 메시지 가공
+        val response = makeResponse(result)
+
+        // 200 상태코드와 함께 HTTP 응답
+        return ResponseEntity.ok(response)
+    }
+
+    private fun makeResponse(result: RegisterMemberResult): SuccessResponse<RegisterMemberResponse> {
+        val code = "RegisterMember.Complete"
+        val locale = localeManager.getCurrentLocale()
+        return SuccessResponse(
+            code = code,
+            message = messageResolver.resolve("$code.message", locale),
+            description = messageResolver.resolve("$code.description", locale),
+            data = RegisterMemberResponse(
+                registeredMember = RegisterMemberResponse.RegisteredMember(
+                    memberId = result.memberId,
+                    email = result.email,
+                    username = result.username,
+                    nickname = result.nickname,
+                    role = result.role,
+                    registeredAt = result.registeredAt
+                )
+            )
+        )
     }
 }
 

--- a/board-system-api/api-member/src/test/kotlin/com/ttasjwi/board/system/member/api/RegisterMemberControllerTest.kt
+++ b/board-system-api/api-member/src/test/kotlin/com/ttasjwi/board/system/member/api/RegisterMemberControllerTest.kt
@@ -1,26 +1,66 @@
 package com.ttasjwi.board.system.member.api
 
+import com.ttasjwi.board.system.core.api.SuccessResponse
+import com.ttasjwi.board.system.core.locale.fixture.LocaleManagerFixture
+import com.ttasjwi.board.system.core.message.fixture.MessageResolverFixture
+import com.ttasjwi.board.system.member.application.usecase.RegisterMemberRequest
+import com.ttasjwi.board.system.member.application.usecase.fixture.RegisterMemberUseCaseFixture
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
+import org.springframework.http.HttpStatus
+import java.util.*
 
 @DisplayName("RegisterMemberController 테스트")
 class RegisterMemberControllerTest {
 
-    private lateinit var registerMemberController: RegisterMemberController
+    private lateinit var controller: RegisterMemberController
+    private lateinit var useCaseFixture: RegisterMemberUseCaseFixture
+    private lateinit var messageResolverFixture: MessageResolverFixture
+    private lateinit var localeManagerFixture: LocaleManagerFixture
 
     @BeforeEach
     fun setup() {
-        registerMemberController = RegisterMemberController()
+        useCaseFixture = RegisterMemberUseCaseFixture()
+        messageResolverFixture = MessageResolverFixture()
+        localeManagerFixture = LocaleManagerFixture()
+        controller = RegisterMemberController(
+            useCase = useCaseFixture,
+            messageResolver = messageResolverFixture,
+            localeManager = localeManagerFixture
+        )
     }
 
     @Test
-    @DisplayName("이 api는 현재 미구현 상태이다.")
+    @DisplayName("유즈케이스를 호출하고 그 결과를 기반으로 200 코드와 함께 응답을 반환한다.")
     fun test() {
         // given
+        val request = RegisterMemberRequest(
+            email = "test@test.com",
+            password = "1111",
+            username = "testuser",
+            nickname = "testnick"
+        )
+
         // when
+        val responseEntity = controller.register(request)
+        val response = responseEntity.body as SuccessResponse<RegisterMemberResponse>
+
         // then
-        assertThrows<NotImplementedError> { registerMemberController.register() }
+        assertThat(responseEntity.statusCode.value()).isEqualTo(HttpStatus.OK.value())
+        assertThat(response.isSuccess).isTrue()
+        assertThat(response.code).isEqualTo("RegisterMember.Complete")
+        assertThat(response.message).isEqualTo("RegisterMember.Complete.message(locale=${Locale.KOREAN},args=[])")
+        assertThat(response.description).isEqualTo("RegisterMember.Complete.description(locale=${Locale.KOREAN},args=[])")
+
+        val registeredMember = response.data.registeredMember
+
+        assertThat(registeredMember.memberId).isNotNull()
+        assertThat(registeredMember.email).isEqualTo(request.email)
+        assertThat(registeredMember.username).isEqualTo(request.username)
+        assertThat(registeredMember.nickname).isEqualTo(request.nickname)
+        assertThat(registeredMember.role).isNotNull()
+        assertThat(registeredMember.registeredAt).isNotNull()
     }
 }

--- a/board-system-application/application-member/src/main/kotlin/com/ttasjwi/board/system/member/application/dto/RegisterMemberCommand.kt
+++ b/board-system-application/application-member/src/main/kotlin/com/ttasjwi/board/system/member/application/dto/RegisterMemberCommand.kt
@@ -1,0 +1,15 @@
+package com.ttasjwi.board.system.member.application.dto
+
+import com.ttasjwi.board.system.member.domain.model.Email
+import com.ttasjwi.board.system.member.domain.model.Nickname
+import com.ttasjwi.board.system.member.domain.model.RawPassword
+import com.ttasjwi.board.system.member.domain.model.Username
+import java.time.ZonedDateTime
+
+internal data class RegisterMemberCommand(
+    val email: Email,
+    val rawPassword: RawPassword,
+    val username: Username,
+    val nickname: Nickname,
+    val currentTime: ZonedDateTime,
+)

--- a/board-system-application/application-member/src/main/kotlin/com/ttasjwi/board/system/member/application/exception/DuplicateMemberEmailException.kt
+++ b/board-system-application/application-member/src/main/kotlin/com/ttasjwi/board/system/member/application/exception/DuplicateMemberEmailException.kt
@@ -1,0 +1,14 @@
+package com.ttasjwi.board.system.member.application.exception
+
+import com.ttasjwi.board.system.core.exception.CustomException
+import com.ttasjwi.board.system.core.exception.ErrorStatus
+
+class DuplicateMemberEmailException(
+    email: String,
+) : CustomException(
+    status = ErrorStatus.CONFLICT,
+    code = "Error.DuplicateMemberEmail",
+    args = listOf(email),
+    source = "email",
+    debugMessage = "중복되는 이메일의 회원이 존재합니다.(email=${email})"
+)

--- a/board-system-application/application-member/src/main/kotlin/com/ttasjwi/board/system/member/application/exception/DuplicateMemberNicknameException.kt
+++ b/board-system-application/application-member/src/main/kotlin/com/ttasjwi/board/system/member/application/exception/DuplicateMemberNicknameException.kt
@@ -1,0 +1,14 @@
+package com.ttasjwi.board.system.member.application.exception
+
+import com.ttasjwi.board.system.core.exception.CustomException
+import com.ttasjwi.board.system.core.exception.ErrorStatus
+
+class DuplicateMemberNicknameException(
+    nickname: String,
+) : CustomException(
+    status = ErrorStatus.CONFLICT,
+    code = "Error.DuplicateMemberNickname",
+    args = listOf(nickname),
+    source = "nickname",
+    debugMessage = "중복되는 닉네임의 회원이 존재합니다.(nickname=${nickname})"
+)

--- a/board-system-application/application-member/src/main/kotlin/com/ttasjwi/board/system/member/application/exception/DuplicateMemberUsernameException.kt
+++ b/board-system-application/application-member/src/main/kotlin/com/ttasjwi/board/system/member/application/exception/DuplicateMemberUsernameException.kt
@@ -1,0 +1,14 @@
+package com.ttasjwi.board.system.member.application.exception
+
+import com.ttasjwi.board.system.core.exception.CustomException
+import com.ttasjwi.board.system.core.exception.ErrorStatus
+
+class DuplicateMemberUsernameException(
+    username: String,
+) : CustomException(
+    status = ErrorStatus.CONFLICT,
+    code = "Error.DuplicateMemberUsername",
+    args = listOf(username),
+    source = "username",
+    debugMessage = "중복되는 사용자 아이디(username)의 회원이 존재합니다.(username=${username})"
+)

--- a/board-system-application/application-member/src/main/kotlin/com/ttasjwi/board/system/member/application/mapper/RegisterMemberCommandMapper.kt
+++ b/board-system-application/application-member/src/main/kotlin/com/ttasjwi/board/system/member/application/mapper/RegisterMemberCommandMapper.kt
@@ -1,0 +1,108 @@
+package com.ttasjwi.board.system.member.application.mapper
+
+import com.ttasjwi.board.system.core.annotation.component.ApplicationCommandMapper
+import com.ttasjwi.board.system.core.exception.NullArgumentException
+import com.ttasjwi.board.system.core.exception.ValidationExceptionCollector
+import com.ttasjwi.board.system.core.time.TimeManager
+import com.ttasjwi.board.system.logging.getLogger
+import com.ttasjwi.board.system.member.application.dto.RegisterMemberCommand
+import com.ttasjwi.board.system.member.application.usecase.RegisterMemberRequest
+import com.ttasjwi.board.system.member.domain.model.Email
+import com.ttasjwi.board.system.member.domain.model.Nickname
+import com.ttasjwi.board.system.member.domain.model.RawPassword
+import com.ttasjwi.board.system.member.domain.model.Username
+import com.ttasjwi.board.system.member.domain.service.EmailCreator
+import com.ttasjwi.board.system.member.domain.service.NicknameCreator
+import com.ttasjwi.board.system.member.domain.service.PasswordManager
+import com.ttasjwi.board.system.member.domain.service.UsernameCreator
+
+@ApplicationCommandMapper
+internal class RegisterMemberCommandMapper(
+    private val emailCreator: EmailCreator,
+    private val passwordManager: PasswordManager,
+    private val usernameCreator: UsernameCreator,
+    private val nicknameCreator: NicknameCreator,
+    private val timeManager: TimeManager,
+) {
+    companion object {
+        private val log = getLogger(RegisterMemberCommandMapper::class.java)
+    }
+
+    fun mapToCommand(request: RegisterMemberRequest): RegisterMemberCommand {
+        log.info { "요청 입력값이 유효한 지 확인합니다." }
+        val exceptionCollector = ValidationExceptionCollector()
+
+        val email = getEmail(request.email, exceptionCollector)
+        val rawPassword = getRawPassword(request.password, exceptionCollector)
+        val username = getUsername(request.username, exceptionCollector)
+        val nickname = getNickname(request.nickname, exceptionCollector)
+
+        exceptionCollector.throwIfNotEmpty()
+
+        log.info { "요청 입력값들은 유효합니다." }
+
+        return RegisterMemberCommand(
+            email = email!!,
+            rawPassword = rawPassword!!,
+            username = username!!,
+            nickname = nickname!!,
+            currentTime = timeManager.now()
+        )
+    }
+
+    private fun getEmail(email: String?, exceptionCollector: ValidationExceptionCollector): Email? {
+        if (email == null) {
+            log.warn { "이메일이 누락됐습니다." }
+            exceptionCollector.addCustomExceptionOrThrow(NullArgumentException("email"))
+            return null
+        }
+        return emailCreator.create(email)
+            .getOrElse {
+                log.warn(it)
+                exceptionCollector.addCustomExceptionOrThrow(it)
+                return null
+            }
+    }
+
+    private fun getRawPassword(password: String?, exceptionCollector: ValidationExceptionCollector): RawPassword? {
+        if (password == null) {
+            log.warn { "패스워드가 누락됐습니다." }
+            exceptionCollector.addCustomExceptionOrThrow(NullArgumentException("password"))
+            return null
+        }
+        return passwordManager.createRawPassword(password)
+            .getOrElse {
+                log.warn(it)
+                exceptionCollector.addCustomExceptionOrThrow(it)
+                return null
+            }
+    }
+
+    private fun getUsername(username: String?, exceptionCollector: ValidationExceptionCollector): Username? {
+        if (username == null) {
+            log.warn { "사용자 아이디(username)가 누락됐습니다." }
+            exceptionCollector.addCustomExceptionOrThrow(NullArgumentException("username"))
+            return null
+        }
+        return usernameCreator.create(username)
+            .getOrElse {
+                log.warn(it)
+                exceptionCollector.addCustomExceptionOrThrow(it)
+                return null
+            }
+    }
+
+    private fun getNickname(nickname: String?, exceptionCollector: ValidationExceptionCollector): Nickname? {
+        if (nickname == null) {
+            log.warn { "닉네임이 누락됐습니다." }
+            exceptionCollector.addCustomExceptionOrThrow(NullArgumentException("nickname"))
+            return null
+        }
+        return nicknameCreator.create(nickname)
+            .getOrElse {
+                log.warn(it)
+                exceptionCollector.addCustomExceptionOrThrow(it)
+                return null
+            }
+    }
+}

--- a/board-system-application/application-member/src/main/kotlin/com/ttasjwi/board/system/member/application/processor/RegisterMemberProcessor.kt
+++ b/board-system-application/application-member/src/main/kotlin/com/ttasjwi/board/system/member/application/processor/RegisterMemberProcessor.kt
@@ -1,0 +1,91 @@
+package com.ttasjwi.board.system.member.application.processor
+
+import com.ttasjwi.board.system.core.annotation.component.ApplicationProcessor
+import com.ttasjwi.board.system.core.exception.CustomException
+import com.ttasjwi.board.system.logging.getLogger
+import com.ttasjwi.board.system.member.application.dto.RegisterMemberCommand
+import com.ttasjwi.board.system.member.application.exception.DuplicateMemberEmailException
+import com.ttasjwi.board.system.member.application.exception.DuplicateMemberNicknameException
+import com.ttasjwi.board.system.member.application.exception.DuplicateMemberUsernameException
+import com.ttasjwi.board.system.member.application.exception.EmailVerificationNotFoundException
+import com.ttasjwi.board.system.member.domain.event.MemberRegisteredEvent
+import com.ttasjwi.board.system.member.domain.model.Member
+import com.ttasjwi.board.system.member.domain.service.*
+
+@ApplicationProcessor
+internal class RegisterMemberProcessor(
+    private val memberFinder: MemberFinder,
+    private val emailVerificationFinder: EmailVerificationFinder,
+    private val emailVerificationHandler: EmailVerificationHandler,
+    private val emailVerificationAppender: EmailVerificationAppender,
+    private val memberCreator: MemberCreator,
+    private val memberAppender: MemberAppender,
+    private val memberEventCreator: MemberEventCreator,
+) {
+
+    companion object {
+        private val log = getLogger(RegisterMemberProcessor::class.java)
+    }
+
+    fun register(command: RegisterMemberCommand): MemberRegisteredEvent {
+        checkDuplicate(command)
+        checkEmailVerificationAndRemove(command)
+
+        val member = createMember(command)
+
+        val savedMember = memberAppender.save(member)
+        log.info { "회원 생성 및 저장됨 (memberId=${savedMember.id})" }
+
+        val event = memberEventCreator.onMemberRegistered(savedMember)
+        return event
+    }
+
+    private fun checkDuplicate(command: RegisterMemberCommand) {
+        log.info { "중복되는 회원이 있는 지 확인합니다. " }
+        val ex: CustomException
+        if (memberFinder.existsByEmail(command.email)) {
+            ex = DuplicateMemberEmailException(command.email.value)
+            log.warn(ex)
+            throw ex
+        }
+        if (memberFinder.existsByUsername(command.username)) {
+            ex = DuplicateMemberUsernameException(command.username.value)
+            log.warn(ex)
+            throw ex
+        }
+        if (memberFinder.existsByNickname(command.nickname)) {
+            ex = DuplicateMemberNicknameException(command.nickname.value)
+            log.warn(ex)
+            throw ex
+        }
+        log.info { "중복되는 회원이 없습니다." }
+    }
+
+    private fun checkEmailVerificationAndRemove(command: RegisterMemberCommand) {
+        log.info { "이메일 인증을 조회합니다. (email=${command.email})" }
+        val emailVerification = emailVerificationFinder.findByEmailOrNull(command.email)
+
+        if (emailVerification == null) {
+            val ex = EmailVerificationNotFoundException(command.email.value)
+            log.warn(ex)
+            throw ex
+        }
+        log.info { "이메일 인증이 존재합니다." }
+
+        // 이메일이 인증됐는지, 그리고 인증이 현재 유효한 지 확인
+        emailVerificationHandler.checkVerifiedAndCurrentlyValid(emailVerification, command.currentTime)
+
+        // 더 이상 이메일 인증이 필요 없으므로 말소
+        emailVerificationAppender.removeByEmail(emailVerification.email)
+    }
+
+    private fun createMember(command: RegisterMemberCommand): Member {
+        return memberCreator.create(
+            email = command.email,
+            password = command.rawPassword,
+            username = command.username,
+            nickname = command.nickname,
+            currentTime = command.currentTime,
+        )
+    }
+}

--- a/board-system-application/application-member/src/main/kotlin/com/ttasjwi/board/system/member/application/service/RegisterMemberApplicationService.kt
+++ b/board-system-application/application-member/src/main/kotlin/com/ttasjwi/board/system/member/application/service/RegisterMemberApplicationService.kt
@@ -1,14 +1,53 @@
 package com.ttasjwi.board.system.member.application.service
 
 import com.ttasjwi.board.system.core.annotation.component.ApplicationService
+import com.ttasjwi.board.system.core.application.TransactionRunner
+import com.ttasjwi.board.system.logging.getLogger
+import com.ttasjwi.board.system.member.application.mapper.RegisterMemberCommandMapper
+import com.ttasjwi.board.system.member.application.processor.RegisterMemberProcessor
 import com.ttasjwi.board.system.member.application.usecase.RegisterMemberRequest
 import com.ttasjwi.board.system.member.application.usecase.RegisterMemberResult
 import com.ttasjwi.board.system.member.application.usecase.RegisterMemberUseCase
+import com.ttasjwi.board.system.member.domain.event.MemberRegisteredEvent
 
 @ApplicationService
-internal class RegisterMemberApplicationService : RegisterMemberUseCase {
+internal class RegisterMemberApplicationService(
+    private val commandMapper: RegisterMemberCommandMapper,
+    private val processor: RegisterMemberProcessor,
+    private val transactionRunner: TransactionRunner
+) : RegisterMemberUseCase {
+
+    companion object {
+        private val log = getLogger(RegisterMemberApplicationService::class.java)
+    }
+
 
     override fun register(request: RegisterMemberRequest): RegisterMemberResult {
-        TODO("Not yet implemented")
+        log.info { "회원 가입을 시작합니다." }
+
+        // 유효성 검사를 거쳐서 명령으로 변환
+        val command = commandMapper.mapToCommand(request)
+
+        // 프로세서에 위임
+        val event = transactionRunner.run {
+            processor.register(command)
+        }
+
+        log.info { "회원가입 됨(id=${event.data.memberId},email = ${event.data.email})" }
+
+        // 처리 결과로 가공, 반환
+        return makeResult(event)
     }
+
+    private fun makeResult(event: MemberRegisteredEvent): RegisterMemberResult {
+        return RegisterMemberResult(
+            memberId = event.data.memberId,
+            email = event.data.email,
+            username = event.data.username,
+            nickname = event.data.nickname,
+            role = event.data.roleName,
+            registeredAt = event.data.registeredAt,
+        )
+    }
+
 }

--- a/board-system-application/application-member/src/test/kotlin/com/ttasjwi/board/system/member/application/exception/DuplicateMemberEmailExceptionTest.kt
+++ b/board-system-application/application-member/src/test/kotlin/com/ttasjwi/board/system/member/application/exception/DuplicateMemberEmailExceptionTest.kt
@@ -1,0 +1,25 @@
+package com.ttasjwi.board.system.member.application.exception
+
+import com.ttasjwi.board.system.core.exception.ErrorStatus
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("DuplicateMemberEmailException: 이메일이 중복될 때 발생하는 예외")
+class DuplicateMemberEmailExceptionTest {
+
+    @Test
+    @DisplayName("예외 기본값 테스트")
+    fun test() {
+        val email = "hello@gmail.com"
+        val exception = DuplicateMemberEmailException(email)
+
+        assertThat(exception.status).isEqualTo(ErrorStatus.CONFLICT)
+        assertThat(exception.code).isEqualTo("Error.DuplicateMemberEmail")
+        assertThat(exception.source).isEqualTo("email")
+        assertThat(exception.args).containsExactly(email)
+        assertThat(exception.message).isEqualTo(exception.debugMessage)
+        assertThat(exception.cause).isNull()
+        assertThat(exception.debugMessage).isEqualTo("중복되는 이메일의 회원이 존재합니다.(email=${email})")
+    }
+}

--- a/board-system-application/application-member/src/test/kotlin/com/ttasjwi/board/system/member/application/exception/DuplicateMemberNicknameExceptionTest.kt
+++ b/board-system-application/application-member/src/test/kotlin/com/ttasjwi/board/system/member/application/exception/DuplicateMemberNicknameExceptionTest.kt
@@ -1,0 +1,25 @@
+package com.ttasjwi.board.system.member.application.exception
+
+import com.ttasjwi.board.system.core.exception.ErrorStatus
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("DuplicateMemberNicknameException: 닉네임이 중복될 때 발생하는 예외")
+class DuplicateMemberNicknameExceptionTest {
+
+    @Test
+    @DisplayName("예외 기본값 테스트")
+    fun test() {
+        val nickname = "hello"
+        val exception = DuplicateMemberNicknameException(nickname)
+
+        assertThat(exception.status).isEqualTo(ErrorStatus.CONFLICT)
+        assertThat(exception.code).isEqualTo("Error.DuplicateMemberNickname")
+        assertThat(exception.source).isEqualTo("nickname")
+        assertThat(exception.args).containsExactly(nickname)
+        assertThat(exception.message).isEqualTo(exception.debugMessage)
+        assertThat(exception.cause).isNull()
+        assertThat(exception.debugMessage).isEqualTo("중복되는 닉네임의 회원이 존재합니다.(nickname=${nickname})")
+    }
+}

--- a/board-system-application/application-member/src/test/kotlin/com/ttasjwi/board/system/member/application/exception/DuplicateMemberUsernameExceptionTest.kt
+++ b/board-system-application/application-member/src/test/kotlin/com/ttasjwi/board/system/member/application/exception/DuplicateMemberUsernameExceptionTest.kt
@@ -1,0 +1,25 @@
+package com.ttasjwi.board.system.member.application.exception
+
+import com.ttasjwi.board.system.core.exception.ErrorStatus
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("DuplicateMemberUsernameException: 사용자아이디(username)가 중복될 때 발생하는 예외")
+class DuplicateMemberUsernameExceptionTest {
+
+    @Test
+    @DisplayName("예외 기본값 테스트")
+    fun test() {
+        val username = "hello"
+        val exception = DuplicateMemberUsernameException(username)
+
+        assertThat(exception.status).isEqualTo(ErrorStatus.CONFLICT)
+        assertThat(exception.code).isEqualTo("Error.DuplicateMemberUsername")
+        assertThat(exception.source).isEqualTo("username")
+        assertThat(exception.args).containsExactly(username)
+        assertThat(exception.message).isEqualTo(exception.debugMessage)
+        assertThat(exception.cause).isNull()
+        assertThat(exception.debugMessage).isEqualTo("중복되는 사용자 아이디(username)의 회원이 존재합니다.(username=${username})")
+    }
+}

--- a/board-system-application/application-member/src/test/kotlin/com/ttasjwi/board/system/member/application/mapper/RegisterMemberCommandMapperTest.kt
+++ b/board-system-application/application-member/src/test/kotlin/com/ttasjwi/board/system/member/application/mapper/RegisterMemberCommandMapperTest.kt
@@ -1,0 +1,233 @@
+package com.ttasjwi.board.system.member.application.mapper
+
+import com.ttasjwi.board.system.core.exception.CustomException
+import com.ttasjwi.board.system.core.exception.NullArgumentException
+import com.ttasjwi.board.system.core.exception.ValidationExceptionCollector
+import com.ttasjwi.board.system.core.time.fixture.TimeManagerFixture
+import com.ttasjwi.board.system.core.time.fixture.timeFixture
+import com.ttasjwi.board.system.member.application.usecase.RegisterMemberRequest
+import com.ttasjwi.board.system.member.domain.model.fixture.emailFixture
+import com.ttasjwi.board.system.member.domain.model.fixture.nicknameFixture
+import com.ttasjwi.board.system.member.domain.model.fixture.usernameFixture
+import com.ttasjwi.board.system.member.domain.service.fixture.EmailCreatorFixture
+import com.ttasjwi.board.system.member.domain.service.fixture.NicknameCreatorFixture
+import com.ttasjwi.board.system.member.domain.service.fixture.PasswordManagerFixture
+import com.ttasjwi.board.system.member.domain.service.fixture.UsernameCreatorFixture
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.ZonedDateTime
+
+@DisplayName("RegisterMemberCommandMapper 테스트")
+class RegisterMemberCommandMapperTest {
+
+    private lateinit var commandMapper: RegisterMemberCommandMapper
+    private lateinit var currentTime: ZonedDateTime
+
+    @BeforeEach
+    fun setup() {
+        val timeManager = TimeManagerFixture()
+        currentTime = timeFixture(minute = 6)
+        timeManager.changeCurrentTime(currentTime)
+
+        commandMapper = RegisterMemberCommandMapper(
+            emailCreator = EmailCreatorFixture(),
+            passwordManager = PasswordManagerFixture(),
+            usernameCreator = UsernameCreatorFixture(),
+            nicknameCreator = NicknameCreatorFixture(),
+            timeManager = timeManager,
+        )
+    }
+
+    @Test
+    @DisplayName("성공 테스트")
+    fun testSuccess() {
+        // given
+        val request = RegisterMemberRequest(
+            email = "hello@gmail.com",
+            password = "1234",
+            username = "ttasjwi",
+            nickname = "땃쥐",
+        )
+
+        // when
+        val command = commandMapper.mapToCommand(request)
+
+        // then
+        assertThat(command.email).isEqualTo(emailFixture(request.email!!))
+        assertThat(command.rawPassword.value).isEqualTo(request.password)
+        assertThat(command.username).isEqualTo(usernameFixture(request.username!!))
+        assertThat(command.nickname).isEqualTo(nicknameFixture(request.nickname!!))
+        assertThat(command.currentTime).isEqualTo(currentTime)
+    }
+
+    @Test
+    @DisplayName("이메일이 누락되면 예외 발생")
+    fun testEmailNull() {
+        val request = RegisterMemberRequest(
+            email = null,
+            password = "1234",
+            username = "ttasjwi",
+            nickname = "땃쥐",
+        )
+
+        val exceptionCollector = assertThrows<ValidationExceptionCollector> {
+            commandMapper.mapToCommand(request)
+        }
+        val exceptions = exceptionCollector.getExceptions()
+        val exception = exceptions.first()
+
+        assertThat(exceptions.size).isEqualTo(1)
+        assertThat(exception).isInstanceOf(NullArgumentException::class.java)
+        assertThat(exception.source).isEqualTo("email")
+    }
+
+    @Test
+    @DisplayName("패스워드 누락되면 예외 발생")
+    fun testPasswordNull() {
+        val request = RegisterMemberRequest(
+            email = "hello@gmail.com",
+            password = null,
+            username = "ttasjwi",
+            nickname = "땃쥐",
+        )
+
+        val exceptionCollector = assertThrows<ValidationExceptionCollector> {
+            commandMapper.mapToCommand(request)
+        }
+        val exceptions = exceptionCollector.getExceptions()
+        val exception = exceptions.first()
+
+        assertThat(exceptions.size).isEqualTo(1)
+        assertThat(exception).isInstanceOf(NullArgumentException::class.java)
+        assertThat(exception.source).isEqualTo("password")
+    }
+
+    @Test
+    @DisplayName("사용자아이디(username) 누락되면 예외 발생")
+    fun testUsernameNull() {
+        val request = RegisterMemberRequest(
+            email = "hello@gmail.com",
+            password = "1234",
+            username = null,
+            nickname = "땃쥐",
+        )
+
+        val exceptionCollector = assertThrows<ValidationExceptionCollector> {
+            commandMapper.mapToCommand(request)
+        }
+        val exceptions = exceptionCollector.getExceptions()
+        val exception = exceptions.first()
+
+        assertThat(exceptions.size).isEqualTo(1)
+        assertThat(exception).isInstanceOf(NullArgumentException::class.java)
+        assertThat(exception.source).isEqualTo("username")
+    }
+
+    @Test
+    @DisplayName("닉네임 누락되면 예외 발생")
+    fun testNicknameNull() {
+        val request = RegisterMemberRequest(
+            email = "hello@gmail.com",
+            password = "1234",
+            username = "ttasjwi",
+            nickname = null,
+        )
+
+        val exceptionCollector = assertThrows<ValidationExceptionCollector> {
+            commandMapper.mapToCommand(request)
+        }
+        val exceptions = exceptionCollector.getExceptions()
+        val exception = exceptions.first()
+
+        assertThat(exceptions.size).isEqualTo(1)
+        assertThat(exception).isInstanceOf(NullArgumentException::class.java)
+        assertThat(exception.source).isEqualTo("nickname")
+    }
+
+    @Test
+    @DisplayName("이메일 포맷이 유효하지 않을 때 예외 발생")
+    fun testInvalidEmailFormat() {
+        val request = RegisterMemberRequest(
+            email = EmailCreatorFixture.ERROR_EMAIL,
+            password = "1234",
+            username = "ttasjwi",
+            nickname = "땃쥐",
+        )
+
+        val exceptionCollector = assertThrows<ValidationExceptionCollector> {
+            commandMapper.mapToCommand(request)
+        }
+        val exceptions = exceptionCollector.getExceptions()
+        val exception = exceptions.first()
+
+        assertThat(exceptions.size).isEqualTo(1)
+        assertThat(exception).isInstanceOf(CustomException::class.java)
+        assertThat(exception.source).isEqualTo("email")
+    }
+
+    @Test
+    @DisplayName("패스워드 포맷이 유효하지 않을 때 예외 발생")
+    fun testInvalidPasswordFormat() {
+        val request = RegisterMemberRequest(
+            email = "hello@gmail.com",
+            password = PasswordManagerFixture.ERROR_PASSWORD,
+            username = "ttasjwi",
+            nickname = "땃쥐",
+        )
+
+        val exceptionCollector = assertThrows<ValidationExceptionCollector> {
+            commandMapper.mapToCommand(request)
+        }
+        val exceptions = exceptionCollector.getExceptions()
+        val exception = exceptions.first()
+
+        assertThat(exceptions.size).isEqualTo(1)
+        assertThat(exception).isInstanceOf(CustomException::class.java)
+        assertThat(exception.source).isEqualTo("password")
+    }
+
+    @Test
+    @DisplayName("사용자아이디(username) 포맷이 유효하지 않을 때 예외 발생")
+    fun testInvalidUsernameFormat() {
+        val request = RegisterMemberRequest(
+            email = "hello@gmail.com",
+            password = "1234",
+            username = UsernameCreatorFixture.ERROR_USERNAME,
+            nickname = "땃쥐",
+        )
+
+        val exceptionCollector = assertThrows<ValidationExceptionCollector> {
+            commandMapper.mapToCommand(request)
+        }
+        val exceptions = exceptionCollector.getExceptions()
+        val exception = exceptions.first()
+
+        assertThat(exceptions.size).isEqualTo(1)
+        assertThat(exception).isInstanceOf(CustomException::class.java)
+        assertThat(exception.source).isEqualTo("username")
+    }
+
+    @Test
+    @DisplayName("닉네임 포맷이 유효하지 않을 때 예외 발생")
+    fun testInvalidNicknameFormat() {
+        val request = RegisterMemberRequest(
+            email = "hello@gmail.com",
+            password = "1234",
+            username = "ttasjwi",
+            nickname = NicknameCreatorFixture.ERROR_NICKNAME,
+        )
+
+        val exceptionCollector = assertThrows<ValidationExceptionCollector> {
+            commandMapper.mapToCommand(request)
+        }
+        val exceptions = exceptionCollector.getExceptions()
+        val exception = exceptions.first()
+
+        assertThat(exceptions.size).isEqualTo(1)
+        assertThat(exception).isInstanceOf(CustomException::class.java)
+        assertThat(exception.source).isEqualTo("nickname")
+    }
+}

--- a/board-system-application/application-member/src/test/kotlin/com/ttasjwi/board/system/member/application/processor/EmailVerificationProcessorTest.kt
+++ b/board-system-application/application-member/src/test/kotlin/com/ttasjwi/board/system/member/application/processor/EmailVerificationProcessorTest.kt
@@ -5,12 +5,10 @@ import com.ttasjwi.board.system.member.application.dto.EmailVerificationCommand
 import com.ttasjwi.board.system.member.application.exception.EmailVerificationNotFoundException
 import com.ttasjwi.board.system.member.domain.model.fixture.emailFixture
 import com.ttasjwi.board.system.member.domain.model.fixture.emailVerificationFixtureNotVerified
-import com.ttasjwi.board.system.member.domain.service.EmailVerificationFinder
 import com.ttasjwi.board.system.member.domain.service.fixture.EmailVerificationEventCreatorFixture
 import com.ttasjwi.board.system.member.domain.service.fixture.EmailVerificationHandlerFixture
 import com.ttasjwi.board.system.member.domain.service.fixture.EmailVerificationStorageFixture
-import org.assertj.core.api.Assertions
-import org.assertj.core.api.Assertions.*
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -43,7 +41,7 @@ class EmailVerificationProcessorTest {
         val command = EmailVerificationCommand(
             email = emailFixture("hello@gmail.com"),
             code = "1234",
-            currentTime = timeFixture(minute=3)
+            currentTime = timeFixture(minute = 3)
         )
         assertThrows<EmailVerificationNotFoundException> {
             emailVerificationProcessor.verify(command)
@@ -57,15 +55,15 @@ class EmailVerificationProcessorTest {
         val savedEmailVerification = emailVerificationFixtureNotVerified(
             email = "hello@gmail.com",
             code = "1234",
-            codeCreatedAt = timeFixture(minute=0),
-            codeExpiresAt = timeFixture(minute=5),
+            codeCreatedAt = timeFixture(minute = 0),
+            codeExpiresAt = timeFixture(minute = 5),
         )
         emailVerificationStorageFixture.append(savedEmailVerification, savedEmailVerification.codeExpiresAt)
 
         val command = EmailVerificationCommand(
             email = savedEmailVerification.email,
             code = savedEmailVerification.code,
-            currentTime = timeFixture(minute=3)
+            currentTime = timeFixture(minute = 3)
         )
 
         // when

--- a/board-system-application/application-member/src/test/kotlin/com/ttasjwi/board/system/member/application/processor/RegisterMemberProcessorTest.kt
+++ b/board-system-application/application-member/src/test/kotlin/com/ttasjwi/board/system/member/application/processor/RegisterMemberProcessorTest.kt
@@ -1,0 +1,152 @@
+package com.ttasjwi.board.system.member.application.processor
+
+import com.ttasjwi.board.system.core.time.fixture.timeFixture
+import com.ttasjwi.board.system.member.application.dto.RegisterMemberCommand
+import com.ttasjwi.board.system.member.application.exception.DuplicateMemberEmailException
+import com.ttasjwi.board.system.member.application.exception.DuplicateMemberNicknameException
+import com.ttasjwi.board.system.member.application.exception.DuplicateMemberUsernameException
+import com.ttasjwi.board.system.member.application.exception.EmailVerificationNotFoundException
+import com.ttasjwi.board.system.member.domain.model.Member
+import com.ttasjwi.board.system.member.domain.model.fixture.*
+import com.ttasjwi.board.system.member.domain.service.fixture.*
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+@DisplayName("RegisterMemberProcessor: 회원가입 명령을 처리하는 애플리케이션 처리자")
+class RegisterMemberProcessorTest {
+
+    private lateinit var processor: RegisterMemberProcessor
+    private lateinit var memberStorageFixture: MemberStorageFixture
+    private lateinit var emailVerificationStorageFixture: EmailVerificationStorageFixture
+    private lateinit var registeredMember: Member
+
+    @BeforeEach
+    fun setup() {
+        memberStorageFixture = MemberStorageFixture()
+        emailVerificationStorageFixture = EmailVerificationStorageFixture()
+        processor = RegisterMemberProcessor(
+            memberFinder = memberStorageFixture,
+            emailVerificationFinder = emailVerificationStorageFixture,
+            emailVerificationHandler = EmailVerificationHandlerFixture(),
+            emailVerificationAppender = emailVerificationStorageFixture,
+            memberCreator = MemberCreatorFixture(),
+            memberAppender = memberStorageFixture,
+            memberEventCreator = MemberEventCreatorFixture()
+        )
+        registeredMember = memberStorageFixture.save(
+            memberFixtureNotRegistered(
+                email = "registered@gmail.com",
+                username = "registered",
+                nickname = "가입된회원쟝",
+            )
+        )
+    }
+
+    @Test
+    @DisplayName("성공 테스트")
+    fun testSuccess() {
+        val email = emailFixture("hello@gmail.com")
+        val currentTime = timeFixture(minute = 6)
+        emailVerificationStorageFixture.append(
+            emailVerificationFixtureVerified(
+                email = email.value,
+                code = "code",
+                codeCreatedAt = timeFixture(minute = 0),
+                codeExpiresAt = timeFixture(minute = 5),
+                verifiedAt = timeFixture(minute = 3),
+                verificationExpiresAt = timeFixture(minute = 33),
+            ), timeFixture(minute = 33)
+        )
+
+        val command = RegisterMemberCommand(
+            email = email,
+            rawPassword = rawPasswordFixture("1234"),
+            username = usernameFixture("testuser"),
+            nickname = nicknameFixture("testnick"),
+            currentTime = currentTime
+        )
+
+        // when
+        val event = processor.register(command)
+
+        // then
+        val data = event.data
+        val findMember = memberStorageFixture.findByIdOrNull(memberIdFixture(data.memberId))!!
+        val findEmailVerification = emailVerificationStorageFixture.findByEmailOrNull(email)
+
+        assertThat(event.occurredAt).isEqualTo(currentTime)
+        assertThat(data.memberId).isNotNull()
+        assertThat(data.email).isEqualTo(email.value)
+        assertThat(data.username).isEqualTo(command.username.value)
+        assertThat(data.nickname).isEqualTo(command.nickname.value)
+        assertThat(data.roleName).isEqualTo(findMember.role.name)
+        assertThat(data.registeredAt).isEqualTo(currentTime)
+
+        assertThat(findEmailVerification).isNull()
+        assertThat(findMember.id!!.value).isEqualTo(data.memberId)
+        assertThat(findMember.email).isEqualTo(command.email)
+        assertThat(findMember.password.value).isEqualTo(command.rawPassword.value)
+        assertThat(findMember.username).isEqualTo(command.username)
+        assertThat(findMember.nickname).isEqualTo(command.nickname)
+        assertThat(findMember.role).isNotNull()
+        assertThat(findMember.registeredAt).isEqualTo(currentTime)
+    }
+
+    @Test
+    @DisplayName("중복되는 이메일의 회원이 존재하면 예외가 발생한다")
+    fun testDuplicateEmail() {
+        val command = RegisterMemberCommand(
+            email = registeredMember.email,
+            rawPassword = rawPasswordFixture("1234"),
+            username = usernameFixture("testuser"),
+            nickname = nicknameFixture("testnick"),
+            currentTime = timeFixture(minute = 6)
+        )
+
+        assertThrows<DuplicateMemberEmailException> { processor.register(command) }
+    }
+
+    @Test
+    @DisplayName("중복되는 사용자 아이디(username)의 회원이 존재하면 예외가 발생한다")
+    fun testDuplicateUsername() {
+        val command = RegisterMemberCommand(
+            email = emailFixture("hello@gmail.com"),
+            rawPassword = rawPasswordFixture("1234"),
+            username = registeredMember.username,
+            nickname = nicknameFixture("testnick"),
+            currentTime = timeFixture(minute = 6)
+        )
+
+        assertThrows<DuplicateMemberUsernameException> { processor.register(command) }
+    }
+
+    @Test
+    @DisplayName("중복되는 닉네임의 회원이 존재하면 예외가 발생한다")
+    fun testDuplicateNickname() {
+        val command = RegisterMemberCommand(
+            email = emailFixture("hello@gmail.com"),
+            rawPassword = rawPasswordFixture("1234"),
+            username = usernameFixture("testuser"),
+            nickname = registeredMember.nickname,
+            currentTime = timeFixture(minute = 6)
+        )
+
+        assertThrows<DuplicateMemberNicknameException> { processor.register(command) }
+    }
+
+    @Test
+    @DisplayName("이메일 인증을 조회하지 못 했을 경우(만료됐거나, 없음) 예외가 발생한다.")
+    fun testEmailVerificationNotFound() {
+        val command = RegisterMemberCommand(
+            email = emailFixture("hello@gmail.com"),
+            rawPassword = rawPasswordFixture("1234"),
+            username = usernameFixture("testuser"),
+            nickname = nicknameFixture("testnick"),
+            currentTime = timeFixture(minute = 6)
+        )
+        assertThrows<EmailVerificationNotFoundException> { processor.register(command) }
+    }
+}

--- a/board-system-application/application-member/src/test/kotlin/com/ttasjwi/board/system/member/application/service/RegisterMemberApplicationServiceTest.kt
+++ b/board-system-application/application-member/src/test/kotlin/com/ttasjwi/board/system/member/application/service/RegisterMemberApplicationServiceTest.kt
@@ -1,0 +1,85 @@
+package com.ttasjwi.board.system.member.application.service
+
+import com.ttasjwi.board.system.core.application.fixture.TransactionRunnerFixture
+import com.ttasjwi.board.system.core.time.fixture.TimeManagerFixture
+import com.ttasjwi.board.system.core.time.fixture.timeFixture
+import com.ttasjwi.board.system.member.application.mapper.RegisterMemberCommandMapper
+import com.ttasjwi.board.system.member.application.processor.RegisterMemberProcessor
+import com.ttasjwi.board.system.member.application.usecase.RegisterMemberRequest
+import com.ttasjwi.board.system.member.domain.model.fixture.emailVerificationFixtureVerified
+import com.ttasjwi.board.system.member.domain.service.fixture.*
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.time.ZonedDateTime
+
+@DisplayName("RegisterMemberApplicationService: 회원가입 애플리케이션 서비스")
+class RegisterMemberApplicationServiceTest {
+
+    private lateinit var applicationService: RegisterMemberApplicationService
+    private lateinit var emailVerificationStorageFixture: EmailVerificationStorageFixture
+    private lateinit var currentTime: ZonedDateTime
+
+    @BeforeEach
+    fun setup() {
+        val timeManager = TimeManagerFixture()
+        currentTime = timeFixture(minute = 6)
+        timeManager.changeCurrentTime(currentTime)
+
+        val memberStorageFixture = MemberStorageFixture()
+        emailVerificationStorageFixture = EmailVerificationStorageFixture()
+
+        applicationService = RegisterMemberApplicationService(
+            commandMapper = RegisterMemberCommandMapper(
+                emailCreator = EmailCreatorFixture(),
+                passwordManager = PasswordManagerFixture(),
+                usernameCreator = UsernameCreatorFixture(),
+                nicknameCreator = NicknameCreatorFixture(),
+                timeManager = timeManager,
+            ),
+            processor = RegisterMemberProcessor(
+                memberFinder = memberStorageFixture,
+                emailVerificationFinder = emailVerificationStorageFixture,
+                emailVerificationHandler = EmailVerificationHandlerFixture(),
+                emailVerificationAppender = emailVerificationStorageFixture,
+                memberCreator = MemberCreatorFixture(),
+                memberAppender = memberStorageFixture,
+                memberEventCreator = MemberEventCreatorFixture()
+            ),
+            transactionRunner = TransactionRunnerFixture()
+        )
+    }
+
+    @Test
+    @DisplayName("회원가입을 처리하고 그 결과를 반환한다.")
+    fun test() {
+        val email = "hello@gmail.com"
+        emailVerificationStorageFixture.append(
+            emailVerificationFixtureVerified(
+                email = email,
+                code = "code",
+                codeCreatedAt = timeFixture(minute = 0),
+                codeExpiresAt = timeFixture(minute = 5),
+                verifiedAt = timeFixture(minute = 3),
+                verificationExpiresAt = timeFixture(minute = 33),
+            ), timeFixture(minute = 33)
+        )
+
+        val request = RegisterMemberRequest(
+            email = email,
+            password = "1111",
+            username = "testuser",
+            nickname = "testnick",
+        )
+
+        val result = applicationService.register(request)
+
+        assertThat(result.memberId).isNotNull()
+        assertThat(result.email).isEqualTo(request.email)
+        assertThat(result.username).isEqualTo(request.username)
+        assertThat(result.nickname).isEqualTo(request.nickname)
+        assertThat(result.role).isNotNull()
+        assertThat(result.registeredAt).isEqualTo(currentTime)
+    }
+}

--- a/board-system-application/application-member/src/test/kotlin/com/ttasjwi/board/system/member/application/usecase/fixture/RegisterMemberUseCaseFixtureTest.kt
+++ b/board-system-application/application-member/src/test/kotlin/com/ttasjwi/board/system/member/application/usecase/fixture/RegisterMemberUseCaseFixtureTest.kt
@@ -1,0 +1,37 @@
+package com.ttasjwi.board.system.member.application.usecase.fixture
+
+import com.ttasjwi.board.system.member.application.usecase.RegisterMemberRequest
+import com.ttasjwi.board.system.member.application.usecase.RegisterMemberUseCase
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("RegisterMemberUseCaseFixture 테스트")
+class RegisterMemberUseCaseFixtureTest {
+
+    private lateinit var useCase: RegisterMemberUseCase
+
+    @BeforeEach
+    fun setUp() {
+        useCase = RegisterMemberUseCaseFixture()
+    }
+
+    @Test
+    fun test() {
+        val request = RegisterMemberRequest(
+            email = "hello@gmail.com",
+            password = "1111",
+            username = "hello",
+            nickname = "안뇽",
+        )
+        val result = useCase.register(request)
+
+        assertThat(result.memberId).isNotNull()
+        assertThat(result.email).isEqualTo(request.email)
+        assertThat(result.username).isEqualTo(request.username)
+        assertThat(result.nickname).isEqualTo(request.nickname)
+        assertThat(result.role).isNotNull()
+        assertThat(result.registeredAt).isNotNull()
+    }
+}

--- a/board-system-application/application-member/src/testFixtures/kotlin/com/ttasjwi/board/system/member/application/usecase/fixture/RegisterMemberUseCaseFixture.kt
+++ b/board-system-application/application-member/src/testFixtures/kotlin/com/ttasjwi/board/system/member/application/usecase/fixture/RegisterMemberUseCaseFixture.kt
@@ -1,0 +1,20 @@
+package com.ttasjwi.board.system.member.application.usecase.fixture
+
+import com.ttasjwi.board.system.core.time.fixture.timeFixture
+import com.ttasjwi.board.system.member.application.usecase.RegisterMemberRequest
+import com.ttasjwi.board.system.member.application.usecase.RegisterMemberResult
+import com.ttasjwi.board.system.member.application.usecase.RegisterMemberUseCase
+
+class RegisterMemberUseCaseFixture : RegisterMemberUseCase {
+
+    override fun register(request: RegisterMemberRequest): RegisterMemberResult {
+        return RegisterMemberResult(
+            memberId = 1L,
+            email = request.email!!,
+            username = request.username!!,
+            nickname = request.nickname!!,
+            role = "USER",
+            registeredAt = timeFixture(minute = 6)
+        )
+    }
+}

--- a/board-system-container/build.gradle.kts
+++ b/board-system-container/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     implementation(project(":board-system-external:external-message"))
     implementation(project(":board-system-external:external-db"))
     implementation(project(":board-system-external:external-redis"))
+    implementation(project(":board-system-external:external-security"))
     implementation(project(":board-system-external:external-exception-handle"))
     implementation(project(":board-system-external:external-email-format-checker"))
     implementation(project(":board-system-external:external-email-sender"))

--- a/board-system-domain/domain-core/src/main/kotlin/com/ttasjwi/board/system/member/domain/exception/InvalidNicknameFormatException.kt
+++ b/board-system-domain/domain-core/src/main/kotlin/com/ttasjwi/board/system/member/domain/exception/InvalidNicknameFormatException.kt
@@ -5,7 +5,7 @@ import com.ttasjwi.board.system.core.exception.ErrorStatus
 import com.ttasjwi.board.system.member.domain.model.Nickname
 
 class InvalidNicknameFormatException(
-    nicknameValue: String?,
+    nicknameValue: String,
 ) : CustomException(
     status = ErrorStatus.BAD_REQUEST,
     code = "Error.InvalidNicknameFormat",

--- a/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/event/MemberRegisteredEvent.kt
+++ b/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/event/MemberRegisteredEvent.kt
@@ -2,6 +2,7 @@ package com.ttasjwi.board.system.member.domain.event
 
 import com.ttasjwi.board.system.core.domain.event.DomainEvent
 import com.ttasjwi.board.system.member.domain.event.MemberRegisteredEvent.RegisteredMemberData
+import com.ttasjwi.board.system.member.domain.model.Member
 import java.time.ZonedDateTime
 
 class MemberRegisteredEvent
@@ -24,6 +25,19 @@ internal constructor(
     )
 ) {
 
+    companion object {
+        internal fun create(member: Member): MemberRegisteredEvent {
+            return MemberRegisteredEvent(
+                memberId = member.id!!.value,
+                email = member.email.value,
+                username = member.username.value,
+                nickname = member.nickname.value,
+                roleName = member.role.name,
+                registeredAt = member.registeredAt,
+            )
+        }
+    }
+
     class RegisteredMemberData(
         val memberId: Long,
         val email: String,
@@ -32,4 +46,5 @@ internal constructor(
         val roleName: String,
         val registeredAt: ZonedDateTime,
     )
+
 }

--- a/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/event/MemberRegisteredEvent.kt
+++ b/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/event/MemberRegisteredEvent.kt
@@ -10,6 +10,7 @@ internal constructor(
     email: String,
     username: String,
     nickname: String,
+    roleName: String,
     registeredAt: ZonedDateTime,
 ) : DomainEvent<RegisteredMemberData>(
     occurredAt = registeredAt,
@@ -18,7 +19,8 @@ internal constructor(
         email = email,
         username = username,
         nickname = nickname,
-        registeredAt = registeredAt
+        roleName = roleName,
+        registeredAt = registeredAt,
     )
 ) {
 
@@ -27,6 +29,7 @@ internal constructor(
         val email: String,
         val username: String,
         val nickname: String,
+        val roleName: String,
         val registeredAt: ZonedDateTime,
     )
 }

--- a/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/exception/EmailNotVerifiedException.kt
+++ b/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/exception/EmailNotVerifiedException.kt
@@ -1,0 +1,14 @@
+package com.ttasjwi.board.system.member.domain.exception
+
+import com.ttasjwi.board.system.core.exception.CustomException
+import com.ttasjwi.board.system.core.exception.ErrorStatus
+
+class EmailNotVerifiedException(
+    val email: String,
+) : CustomException(
+    status = ErrorStatus.BAD_REQUEST,
+    code = "Error.EmailNotVerified",
+    args = listOf(email),
+    source = "emailVerification",
+    debugMessage = "이 이메일은 인증되지 않았습니다. 인증을 먼저 수행해주세요. (email=${email})"
+)

--- a/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/exception/InvalidPasswordFormatException.kt
+++ b/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/exception/InvalidPasswordFormatException.kt
@@ -1,0 +1,15 @@
+package com.ttasjwi.board.system.member.domain.exception
+
+import com.ttasjwi.board.system.core.exception.CustomException
+import com.ttasjwi.board.system.core.exception.ErrorStatus
+import com.ttasjwi.board.system.member.domain.model.RawPassword
+
+class InvalidPasswordFormatException : CustomException(
+    status = ErrorStatus.BAD_REQUEST,
+    code = "Error.InvalidPasswordFormat",
+    args = listOf(RawPassword.MIN_LENGTH, RawPassword.MAX_LENGTH),
+    source = "password",
+    debugMessage =
+    "패스워드는 ${RawPassword.MIN_LENGTH} 자 이상 " +
+            "${RawPassword.MAX_LENGTH} 이하여야 합니다."
+)

--- a/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/external/ExternalPasswordHandler.kt
+++ b/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/external/ExternalPasswordHandler.kt
@@ -1,0 +1,10 @@
+package com.ttasjwi.board.system.member.domain.external
+
+import com.ttasjwi.board.system.member.domain.model.EncodedPassword
+import com.ttasjwi.board.system.member.domain.model.RawPassword
+
+interface ExternalPasswordHandler {
+
+    fun encode(rawPassword: RawPassword): EncodedPassword
+    fun matches(rawPassword: RawPassword, encodedPassword: EncodedPassword): Boolean
+}

--- a/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/model/EmailVerification.kt
+++ b/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/model/EmailVerification.kt
@@ -1,6 +1,7 @@
 package com.ttasjwi.board.system.member.domain.model
 
 import com.ttasjwi.board.system.logging.getLogger
+import com.ttasjwi.board.system.member.domain.exception.EmailNotVerifiedException
 import com.ttasjwi.board.system.member.domain.exception.EmailVerificationExpiredException
 import com.ttasjwi.board.system.member.domain.exception.InvalidEmailVerificationCodeException
 import java.time.ZonedDateTime
@@ -61,17 +62,31 @@ internal constructor(
 
     internal fun codeVerify(code: String, currentTime: ZonedDateTime): EmailVerification {
         if (currentTime >= this.codeExpiresAt) {
-            log.warn{ "이메일 인증이 만료됐습니다. (email=${email.value},expiredAt=${codeExpiresAt},currentTime=${currentTime}" }
+            log.warn { "이메일 인증이 만료됐습니다. (email=${email.value},expiredAt=${codeExpiresAt},currentTime=${currentTime}" }
             throw EmailVerificationExpiredException(email.value, codeExpiresAt, currentTime)
         }
         if (this.code != code) {
-            log.warn{ "잘못된 code 입니다." }
+            log.warn { "잘못된 code 입니다." }
             throw InvalidEmailVerificationCodeException()
         }
         this.verifiedAt = currentTime
         this.verificationExpiresAt = currentTime.plusMinutes(VERIFICATION_VALIDITY_MINUTE)
 
-        log.info{ "이메일 인증 성공 (email=${email.value}" }
+        log.info { "이메일 인증 성공 (email=${email.value}" }
         return this
+    }
+
+    internal fun checkVerifiedAndCurrentlyValid(currentTime: ZonedDateTime) {
+        // 인증이 안 됨 -> 다시 인증 해라
+        if (this.verifiedAt == null) {
+            log.warn{ "해당 이메일은 인증이 되지 않았음. (email=${this.email.value})" }
+            throw EmailNotVerifiedException(email.value)
+        }
+        // 인증은 했는데, 인증이 만료된 경우 -> 처음부터 다시 인증해라
+        if (currentTime >= this.verificationExpiresAt!!) {
+            log.warn{ "이메일 인증이 만료됐음. 다시 인증해야합니다. (email=${email.value},expiredAt=${this.verificationExpiresAt!!},currentTime=${currentTime})"}
+            throw EmailVerificationExpiredException(email.value, verificationExpiresAt!!, currentTime)
+        }
+        // 그 외: 인증이 됐고, 인증이 만료되지 않은 경우(유효함)
     }
 }

--- a/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/model/EmailVerification.kt
+++ b/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/model/EmailVerification.kt
@@ -77,6 +77,8 @@ internal constructor(
     }
 
     internal fun checkVerifiedAndCurrentlyValid(currentTime: ZonedDateTime) {
+        log.info{ "이메일 인증이 현재 유효한 지 확인합니다." }
+
         // 인증이 안 됨 -> 다시 인증 해라
         if (this.verifiedAt == null) {
             log.warn{ "해당 이메일은 인증이 되지 않았음. (email=${this.email.value})" }
@@ -88,5 +90,6 @@ internal constructor(
             throw EmailVerificationExpiredException(email.value, verificationExpiresAt!!, currentTime)
         }
         // 그 외: 인증이 됐고, 인증이 만료되지 않은 경우(유효함)
+        log.info{ "이메일 인증이 현재 유효합니다." }
     }
 }

--- a/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/model/Member.kt
+++ b/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/model/Member.kt
@@ -31,6 +31,26 @@ internal constructor(
 
     companion object {
 
+        /**
+         * 가입 회원 생성
+         */
+        internal fun create(
+            email: Email,
+            password: EncodedPassword,
+            username: Username,
+            nickname: Nickname,
+            registeredAt: ZonedDateTime,
+        ): Member {
+            return Member(
+                email = email,
+                password = password,
+                username = username,
+                nickname = nickname,
+                role = Role.USER,
+                registeredAt = registeredAt,
+            )
+        }
+
         fun restore(
             id: Long,
             email: String,

--- a/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/model/RawPassword.kt
+++ b/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/model/RawPassword.kt
@@ -1,5 +1,6 @@
 package com.ttasjwi.board.system.member.domain.model
 
+import com.ttasjwi.board.system.member.domain.exception.InvalidPasswordFormatException
 
 class RawPassword
 internal constructor(
@@ -7,9 +8,19 @@ internal constructor(
 ) {
     companion object {
         private const val RAW_PASSWORD_TO_STRING = "RawPassword(value=[SECRET])"
+        internal const val MIN_LENGTH = 4
+        internal const val MAX_LENGTH = 32
+
+        internal fun create(value: String): RawPassword {
+            if (value.length < MIN_LENGTH || value.length > MAX_LENGTH) {
+                throw InvalidPasswordFormatException()
+            }
+            return RawPassword(value)
+        }
     }
 
     override fun toString(): String {
         return RAW_PASSWORD_TO_STRING
     }
+
 }

--- a/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/service/MemberCreator.kt
+++ b/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/service/MemberCreator.kt
@@ -11,7 +11,6 @@ interface MemberCreator {
 
     fun create(
         email: Email,
-        emailVerified: Boolean,
         password: RawPassword,
         username: Username,
         nickname: Nickname,

--- a/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/service/impl/EmailVerificationHandlerImpl.kt
+++ b/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/service/impl/EmailVerificationHandlerImpl.kt
@@ -13,6 +13,6 @@ internal class EmailVerificationHandlerImpl : EmailVerificationHandler {
     }
 
     override fun checkVerifiedAndCurrentlyValid(emailVerification: EmailVerification, currentTime: ZonedDateTime) {
-        TODO("Not yet implemented")
+        emailVerification.checkVerifiedAndCurrentlyValid(currentTime)
     }
 }

--- a/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/service/impl/MemberCreatorImpl.kt
+++ b/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/service/impl/MemberCreatorImpl.kt
@@ -1,25 +1,29 @@
 package com.ttasjwi.board.system.member.domain.service.impl
 
 import com.ttasjwi.board.system.core.annotation.component.DomainService
-import com.ttasjwi.board.system.member.domain.model.Email
-import com.ttasjwi.board.system.member.domain.model.Member
-import com.ttasjwi.board.system.member.domain.model.Nickname
-import com.ttasjwi.board.system.member.domain.model.RawPassword
-import com.ttasjwi.board.system.member.domain.model.Username
+import com.ttasjwi.board.system.member.domain.model.*
 import com.ttasjwi.board.system.member.domain.service.MemberCreator
+import com.ttasjwi.board.system.member.domain.service.PasswordManager
 import java.time.ZonedDateTime
 
 @DomainService
-class MemberCreatorImpl : MemberCreator {
+class MemberCreatorImpl(
+    private val passwordManager: PasswordManager,
+) : MemberCreator {
 
     override fun create(
         email: Email,
-        emailVerified: Boolean,
         password: RawPassword,
         username: Username,
         nickname: Nickname,
         currentTime: ZonedDateTime
     ): Member {
-        TODO("Not yet implemented")
+        return Member.create(
+            email = email,
+            password = passwordManager.encode(password),
+            username = username,
+            nickname = nickname,
+            registeredAt = currentTime,
+        )
     }
 }

--- a/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/service/impl/MemberEventCreatorImpl.kt
+++ b/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/service/impl/MemberEventCreatorImpl.kt
@@ -7,7 +7,8 @@ import com.ttasjwi.board.system.member.domain.service.MemberEventCreator
 
 @DomainService
 internal class MemberEventCreatorImpl : MemberEventCreator {
+
     override fun onMemberRegistered(member: Member): MemberRegisteredEvent {
-        TODO("Not yet implemented")
+        return MemberRegisteredEvent.create(member)
     }
 }

--- a/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/service/impl/PasswordManagerImpl.kt
+++ b/board-system-domain/domain-member/src/main/kotlin/com/ttasjwi/board/system/member/domain/service/impl/PasswordManagerImpl.kt
@@ -1,23 +1,25 @@
 package com.ttasjwi.board.system.member.domain.service.impl
 
 import com.ttasjwi.board.system.core.annotation.component.DomainService
+import com.ttasjwi.board.system.member.domain.external.ExternalPasswordHandler
 import com.ttasjwi.board.system.member.domain.model.EncodedPassword
 import com.ttasjwi.board.system.member.domain.model.RawPassword
 import com.ttasjwi.board.system.member.domain.service.PasswordManager
 
 @DomainService
-internal class PasswordManagerImpl : PasswordManager {
+internal class PasswordManagerImpl(
+    private val externalPasswordHandler: ExternalPasswordHandler
+) : PasswordManager {
 
     override fun createRawPassword(value: String): Result<RawPassword> {
-        TODO("Not yet implemented")
+        return kotlin.runCatching { RawPassword.create(value) }
     }
 
     override fun encode(rawPassword: RawPassword): EncodedPassword {
-        TODO("Not yet implemented")
+        return externalPasswordHandler.encode(rawPassword)
     }
 
     override fun matches(rawPassword: RawPassword, encodedPassword: EncodedPassword): Boolean {
-        TODO("Not yet implemented")
+        return externalPasswordHandler.matches(rawPassword, encodedPassword)
     }
-
 }

--- a/board-system-domain/domain-member/src/test/kotlin/com/ttasjwi/board/system/member/domain/event/MemberRegisteredEventTest.kt
+++ b/board-system-domain/domain-member/src/test/kotlin/com/ttasjwi/board/system/member/domain/event/MemberRegisteredEventTest.kt
@@ -2,6 +2,7 @@ package com.ttasjwi.board.system.member.domain.event
 
 import com.ttasjwi.board.system.core.time.fixture.timeFixture
 import com.ttasjwi.board.system.member.domain.event.fixture.memberRegisteredEventFixture
+import com.ttasjwi.board.system.member.domain.model.Role
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -16,6 +17,7 @@ class MemberRegisteredEventTest {
         val memberId = 4L
         val email = "bye@gmail.com"
         val username = "ttasjwi"
+        val role = Role.USER
         val nickname = "땃쥐"
 
         val event = memberRegisteredEventFixture(
@@ -23,6 +25,7 @@ class MemberRegisteredEventTest {
             memberId = memberId,
             email = email,
             username = username,
+            role = role,
             nickname = nickname,
         )
         val data = event.data
@@ -32,6 +35,7 @@ class MemberRegisteredEventTest {
         assertThat(data.email).isEqualTo(email)
         assertThat(data.username).isEqualTo(username)
         assertThat(data.nickname).isEqualTo(nickname)
+        assertThat(data.roleName).isEqualTo(role.name)
         assertThat(data.registeredAt).isEqualTo(registeredAt)
     }
 }

--- a/board-system-domain/domain-member/src/test/kotlin/com/ttasjwi/board/system/member/domain/exception/EmailNotVerifiedExceptionTest.kt
+++ b/board-system-domain/domain-member/src/test/kotlin/com/ttasjwi/board/system/member/domain/exception/EmailNotVerifiedExceptionTest.kt
@@ -1,0 +1,26 @@
+package com.ttasjwi.board.system.member.domain.exception
+
+import com.ttasjwi.board.system.core.exception.ErrorStatus
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("EmailNotVerifiedException: 이메일이 인증되지 않았을 때 발생하는 예외")
+class EmailNotVerifiedExceptionTest {
+
+    @Test
+    @DisplayName("예외 기본값 테스트")
+    fun test() {
+        val email = "hello@gmail.com"
+
+        val exception = EmailNotVerifiedException(email)
+
+        assertThat(exception.status).isEqualTo(ErrorStatus.BAD_REQUEST)
+        assertThat(exception.code).isEqualTo("Error.EmailNotVerified")
+        assertThat(exception.source).isEqualTo("emailVerification")
+        assertThat(exception.args).containsExactly(email)
+        assertThat(exception.message).isEqualTo(exception.debugMessage)
+        assertThat(exception.cause).isNull()
+        assertThat(exception.debugMessage).isEqualTo("이 이메일은 인증되지 않았습니다. 인증을 먼저 수행해주세요. (email=${email})")
+    }
+}

--- a/board-system-domain/domain-member/src/test/kotlin/com/ttasjwi/board/system/member/domain/external/fixture/ExternalPasswordHandlerFixtureTest.kt
+++ b/board-system-domain/domain-member/src/test/kotlin/com/ttasjwi/board/system/member/domain/external/fixture/ExternalPasswordHandlerFixtureTest.kt
@@ -1,0 +1,65 @@
+package com.ttasjwi.board.system.member.domain.external.fixture
+
+import com.ttasjwi.board.system.member.domain.model.fixture.rawPasswordFixture
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("ExternalPasswordHandlerFixture 테스트")
+class ExternalPasswordHandlerFixtureTest {
+
+    private lateinit var externalPasswordHandler: ExternalPasswordHandlerFixture
+
+    @BeforeEach
+    fun setup() {
+        externalPasswordHandler = ExternalPasswordHandlerFixture()
+    }
+
+    @Nested
+    @DisplayName("encode: 패스워드를 인코딩한다")
+    inner class Encode {
+
+        @Test
+        @DisplayName("encode: 패스워드를 인코딩한다. 이 때 인코딩된 값은 원본 값과 같다.")
+        fun test() {
+            val rawPassword = rawPasswordFixture("1234")
+            val encodedPassword = externalPasswordHandler.encode(rawPassword)
+            assertThat(encodedPassword.value).isEqualTo(rawPassword.value)
+        }
+    }
+
+    @Nested
+    @DisplayName("matches: 원본 패스워드와 인코딩 된 패스워드를 비교하여 일치하는 지 여부를 반환한다.")
+    inner class Matches {
+
+        @Test
+        @DisplayName("원본 패스워드가 같으면, true를 반환한다.")
+        fun testSamePassword() {
+            // given
+            val rawPassword = rawPasswordFixture("1234")
+            val encodedPassword = externalPasswordHandler.encode(rawPassword)
+
+            // when
+            val matches = externalPasswordHandler.matches(rawPassword, encodedPassword)
+
+            // then
+            assertThat(matches).isTrue()
+        }
+
+        @Test
+        @DisplayName("원본 패스워드가 다르면, false를 반환한다.")
+        fun testDifferentPassword() {
+            // given
+            val rawPassword = rawPasswordFixture("1234")
+            val encodedPassword = externalPasswordHandler.encode(rawPassword)
+
+            // when
+            val matches = externalPasswordHandler.matches(rawPasswordFixture("1235"), encodedPassword)
+
+            // then
+            assertThat(matches).isFalse()
+        }
+    }
+}

--- a/board-system-domain/domain-member/src/test/kotlin/com/ttasjwi/board/system/member/domain/service/fixture/EmailVerificationHandlerFixtureTest.kt
+++ b/board-system-domain/domain-member/src/test/kotlin/com/ttasjwi/board/system/member/domain/service/fixture/EmailVerificationHandlerFixtureTest.kt
@@ -2,12 +2,14 @@ package com.ttasjwi.board.system.member.domain.service.fixture
 
 import com.ttasjwi.board.system.core.time.fixture.timeFixture
 import com.ttasjwi.board.system.member.domain.model.fixture.emailVerificationFixtureNotVerified
+import com.ttasjwi.board.system.member.domain.model.fixture.emailVerificationFixtureVerified
 import org.assertj.core.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
+@DisplayName("EmailVerificationHandlerFixture 테스트")
 class EmailVerificationHandlerFixtureTest {
 
     private lateinit var emailVerificationHandlerFixture: EmailVerificationHandlerFixture
@@ -18,6 +20,7 @@ class EmailVerificationHandlerFixtureTest {
     }
 
     @Nested
+    @DisplayName("codeVerify: 코드를 받아 이메일 인증을 처리한다.")
     inner class CodeVerify {
 
         @Test
@@ -32,6 +35,19 @@ class EmailVerificationHandlerFixtureTest {
             assertThat(verifiedEmailVerification.verifiedAt).isEqualTo(currentTime)
             assertThat(verifiedEmailVerification.verificationExpiresAt).isEqualTo(currentTime.plusMinutes(EmailVerificationHandlerFixture.VERIFICATION_VALIDITY_MINUTE))
         }
+    }
 
+    @Nested
+    @DisplayName("checkVerifiedAndCurrentlyValid: 이메일 인증이 인증 됐는지, 현재 인증이 유효한 지 체크한다")
+    inner class CheckVerifiedAndCurrentlyValid {
+
+        @Test
+        @DisplayName("픽스쳐 - 아무 것도 안 한다. 실행만 되는 지 테스트")
+        fun test() {
+            val emailVerification = emailVerificationFixtureVerified()
+            val currentTime = timeFixture(minute=6)
+
+            emailVerificationHandlerFixture.checkVerifiedAndCurrentlyValid(emailVerification, currentTime)
+        }
     }
 }

--- a/board-system-domain/domain-member/src/test/kotlin/com/ttasjwi/board/system/member/domain/service/fixture/MemberCreatorFixtureTest.kt
+++ b/board-system-domain/domain-member/src/test/kotlin/com/ttasjwi/board/system/member/domain/service/fixture/MemberCreatorFixtureTest.kt
@@ -1,0 +1,56 @@
+package com.ttasjwi.board.system.member.domain.service.fixture
+
+import com.ttasjwi.board.system.core.time.fixture.timeFixture
+import com.ttasjwi.board.system.member.domain.model.Role
+import com.ttasjwi.board.system.member.domain.model.fixture.emailFixture
+import com.ttasjwi.board.system.member.domain.model.fixture.nicknameFixture
+import com.ttasjwi.board.system.member.domain.model.fixture.rawPasswordFixture
+import com.ttasjwi.board.system.member.domain.model.fixture.usernameFixture
+import com.ttasjwi.board.system.member.domain.service.MemberCreator
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("MemberCreatorFixture 테스트")
+class MemberCreatorFixtureTest {
+
+    private lateinit var memberCreator: MemberCreator
+
+    @BeforeEach
+    fun setup() {
+        memberCreator = MemberCreatorFixture()
+    }
+
+    @Nested
+    @DisplayName("create: 가입되지 않은 일반 사용자를 생성한다")
+    inner class Create {
+
+        @Test
+        @DisplayName("가입되지 않은 일반 사용자(USER)가 생성되고, id는 null 이다.")
+        fun test() {
+            val email = emailFixture()
+            val username = usernameFixture()
+            val nickname = nicknameFixture()
+            val rawPassword = rawPasswordFixture("1111")
+            val currentTime = timeFixture()
+            val member = memberCreator.create(
+                email = email,
+                username = username,
+                nickname = nickname,
+                password = rawPassword,
+                currentTime = currentTime,
+            )
+
+            assertThat(member).isNotNull()
+            assertThat(member.id).isNull()
+            assertThat(member.email).isEqualTo(email)
+            assertThat(member.username).isEqualTo(username)
+            assertThat(member.nickname).isEqualTo(nickname)
+            assertThat(member.password.value).isEqualTo(rawPassword.value)
+            assertThat(member.role).isEqualTo(Role.USER)
+            assertThat(member.registeredAt).isEqualTo(currentTime)
+        }
+    }
+}

--- a/board-system-domain/domain-member/src/test/kotlin/com/ttasjwi/board/system/member/domain/service/fixture/MemberEventCreatorFixtureTest.kt
+++ b/board-system-domain/domain-member/src/test/kotlin/com/ttasjwi/board/system/member/domain/service/fixture/MemberEventCreatorFixtureTest.kt
@@ -1,0 +1,45 @@
+package com.ttasjwi.board.system.member.domain.service.fixture
+
+import com.ttasjwi.board.system.member.domain.model.fixture.memberFixtureRegistered
+import com.ttasjwi.board.system.member.domain.service.MemberEventCreator
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("MemberEventCreatorFixture 테스트")
+class MemberEventCreatorFixtureTest {
+
+    private lateinit var memberEventCreator: MemberEventCreator
+
+    @BeforeEach
+    fun setup() {
+        memberEventCreator = MemberEventCreatorFixture()
+    }
+
+    @Nested
+    @DisplayName("onMemberRegistered: 회원 가입했을 때, 회원가입됨 이벤트 생성")
+    inner class OnMemberRegistered {
+
+        @Test
+        @DisplayName("onMemberRegistered: 회원 가입됨 이벤트를 생성한다")
+        fun test() {
+            // given
+            val member = memberFixtureRegistered()
+
+            // when
+            val event = memberEventCreator.onMemberRegistered(member)
+            val data = event.data
+
+            // then
+            assertThat(event.occurredAt).isEqualTo(member.registeredAt)
+            assertThat(data.memberId).isEqualTo(member.id!!.value)
+            assertThat(data.email).isEqualTo(member.email.value)
+            assertThat(data.username).isEqualTo(member.username.value)
+            assertThat(data.nickname).isEqualTo(member.nickname.value)
+            assertThat(data.roleName).isEqualTo(member.role.name)
+            assertThat(data.registeredAt).isEqualTo(member.registeredAt)
+        }
+    }
+}

--- a/board-system-domain/domain-member/src/test/kotlin/com/ttasjwi/board/system/member/domain/service/fixture/PasswordManagerFixtureTest.kt
+++ b/board-system-domain/domain-member/src/test/kotlin/com/ttasjwi/board/system/member/domain/service/fixture/PasswordManagerFixtureTest.kt
@@ -1,0 +1,93 @@
+package com.ttasjwi.board.system.member.domain.service.fixture
+
+import com.ttasjwi.board.system.core.exception.CustomException
+import com.ttasjwi.board.system.member.domain.model.fixture.rawPasswordFixture
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("PasswordManagerFixture 테스트")
+class PasswordManagerFixtureTest {
+
+    private lateinit var passwordManager: PasswordManagerFixture
+
+    @BeforeEach
+    fun setup() {
+        passwordManager = PasswordManagerFixture()
+    }
+
+    @Nested
+    @DisplayName("createRawPassword: RawPassword 를 생성하고 그 결과를 Result 로 감싸 반환한다")
+    inner class CreateRawPassword {
+
+        @Test
+        @DisplayName("성공테스트 - 원본값과 같은 RawPassword를 생성한다")
+        fun success() {
+            val value = "1234"
+            val rawPassword = passwordManager.createRawPassword(value).getOrThrow()
+
+            assertThat(rawPassword.value).isEqualTo(value)
+        }
+
+        @Test
+        @DisplayName("실패테스트 - ${PasswordManagerFixture.ERROR_PASSWORD} 가 입력일 경우 예외가 발생한다")
+        fun failure() {
+            val value = PasswordManagerFixture.ERROR_PASSWORD
+            val result = passwordManager.createRawPassword(value)
+
+            val exception = result.exceptionOrNull() as CustomException
+
+            assertThat(result.isFailure).isTrue()
+            assertThat(exception.source).isEqualTo("password")
+            assertThat(exception.debugMessage).isEqualTo("패스워드 포맷 예외 - 픽스쳐")
+        }
+    }
+
+    @Nested
+    @DisplayName("encode: 패스워드를 인코딩한다")
+    inner class Encode {
+
+        @Test
+        @DisplayName("encode: 패스워드를 인코딩한다. 이 때 인코딩된 값은 원본 값과 같다.")
+        fun test() {
+            val rawPassword = rawPasswordFixture("1234")
+            val encodedPassword = passwordManager.encode(rawPassword)
+            assertThat(encodedPassword.value).isEqualTo(rawPassword.value)
+        }
+    }
+
+    @Nested
+    @DisplayName("matches: 원본 패스워드와 인코딩 된 패스워드를 비교하여 일치하는 지 여부를 반환한다.")
+    inner class Matches {
+
+        @Test
+        @DisplayName("원본 패스워드가 같으면, true를 반환한다.")
+        fun testSamePassword() {
+            // given
+            val rawPassword = rawPasswordFixture("1234")
+            val encodedPassword = passwordManager.encode(rawPassword)
+
+            // when
+            val matches = passwordManager.matches(rawPassword, encodedPassword)
+
+            // then
+            assertThat(matches).isTrue()
+        }
+
+        @Test
+        @DisplayName("원본 패스워드가 다르면, false를 반환한다.")
+        fun testDifferentPassword() {
+            // given
+            val rawPassword = rawPasswordFixture("1234")
+            val encodedPassword = passwordManager.encode(rawPassword)
+
+            // when
+            val matches = passwordManager.matches(rawPasswordFixture("1235"), encodedPassword)
+
+            // then
+            assertThat(matches).isFalse()
+        }
+    }
+}

--- a/board-system-domain/domain-member/src/test/kotlin/com/ttasjwi/board/system/member/domain/service/impl/MemberCreatorImplTest.kt
+++ b/board-system-domain/domain-member/src/test/kotlin/com/ttasjwi/board/system/member/domain/service/impl/MemberCreatorImplTest.kt
@@ -1,0 +1,60 @@
+package com.ttasjwi.board.system.member.domain.service.impl
+
+import com.ttasjwi.board.system.core.time.fixture.timeFixture
+import com.ttasjwi.board.system.member.domain.model.Role
+import com.ttasjwi.board.system.member.domain.model.fixture.emailFixture
+import com.ttasjwi.board.system.member.domain.model.fixture.nicknameFixture
+import com.ttasjwi.board.system.member.domain.model.fixture.rawPasswordFixture
+import com.ttasjwi.board.system.member.domain.model.fixture.usernameFixture
+import com.ttasjwi.board.system.member.domain.service.MemberCreator
+import com.ttasjwi.board.system.member.domain.service.PasswordManager
+import com.ttasjwi.board.system.member.domain.service.fixture.PasswordManagerFixture
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("MemberCreatorImpl: 회원을 생성한다")
+class MemberCreatorImplTest {
+
+    private lateinit var memberCreator: MemberCreator
+    private lateinit var passwordManager: PasswordManager
+
+    @BeforeEach
+    fun setup() {
+        passwordManager = PasswordManagerFixture()
+        memberCreator = MemberCreatorImpl(passwordManager)
+    }
+
+    @Nested
+    @DisplayName("create: 회원을 생성한다")
+    inner class Create {
+
+        @Test
+        @DisplayName("생성하면 일반 사용자 권한을 가진 사용자가 id 없는 상태로 생성된다.")
+        fun test() {
+            val email = emailFixture()
+            val username = usernameFixture()
+            val nickname = nicknameFixture()
+            val rawPassword = rawPasswordFixture("1111")
+            val currentTime = timeFixture()
+            val member = memberCreator.create(
+                email = email,
+                username = username,
+                nickname = nickname,
+                password = rawPassword,
+                currentTime = currentTime,
+            )
+
+            assertThat(member).isNotNull()
+            assertThat(member.id).isNull()
+            assertThat(member.email).isEqualTo(email)
+            assertThat(member.username).isEqualTo(username)
+            assertThat(member.nickname).isEqualTo(nickname)
+            assertThat(member.password.value).isEqualTo(rawPassword.value)
+            assertThat(member.role).isEqualTo(Role.USER)
+            assertThat(member.registeredAt).isEqualTo(currentTime)
+        }
+    }
+}

--- a/board-system-domain/domain-member/src/test/kotlin/com/ttasjwi/board/system/member/domain/service/impl/MemberEventCreatorImplTest.kt
+++ b/board-system-domain/domain-member/src/test/kotlin/com/ttasjwi/board/system/member/domain/service/impl/MemberEventCreatorImplTest.kt
@@ -1,0 +1,46 @@
+package com.ttasjwi.board.system.member.domain.service.impl
+
+import com.ttasjwi.board.system.member.domain.model.fixture.memberFixtureRegistered
+import com.ttasjwi.board.system.member.domain.service.MemberEventCreator
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+
+@DisplayName("MemberEventCreatorImpl: 회원관련 이벤트 생성기")
+class MemberEventCreatorImplTest {
+
+    private lateinit var memberEventCreator: MemberEventCreator
+
+    @BeforeEach
+    fun setup() {
+        memberEventCreator = MemberEventCreatorImpl()
+    }
+
+    @Nested
+    @DisplayName("onMemberRegistered: 회원 가입했을 때, 회원가입됨 이벤트 생성")
+    inner class OnMemberRegistered {
+
+        @Test
+        @DisplayName("onMemberRegistered: 회원 가입됨 이벤트를 생성한다")
+        fun test() {
+            // given
+            val member = memberFixtureRegistered()
+
+            // when
+            val event = memberEventCreator.onMemberRegistered(member)
+            val data = event.data
+
+            // then
+            assertThat(event.occurredAt).isEqualTo(member.registeredAt)
+            assertThat(data.memberId).isEqualTo(member.id!!.value)
+            assertThat(data.email).isEqualTo(member.email.value)
+            assertThat(data.username).isEqualTo(member.username.value)
+            assertThat(data.nickname).isEqualTo(member.nickname.value)
+            assertThat(data.roleName).isEqualTo(member.role.name)
+            assertThat(data.registeredAt).isEqualTo(member.registeredAt)
+        }
+    }
+}

--- a/board-system-domain/domain-member/src/test/kotlin/com/ttasjwi/board/system/member/domain/service/impl/PasswordManagerImplTest.kt
+++ b/board-system-domain/domain-member/src/test/kotlin/com/ttasjwi/board/system/member/domain/service/impl/PasswordManagerImplTest.kt
@@ -1,0 +1,100 @@
+package com.ttasjwi.board.system.member.domain.service.impl
+
+import com.ttasjwi.board.system.member.domain.exception.InvalidPasswordFormatException
+import com.ttasjwi.board.system.member.domain.external.ExternalPasswordHandler
+import com.ttasjwi.board.system.member.domain.external.fixture.ExternalPasswordHandlerFixture
+import com.ttasjwi.board.system.member.domain.model.RawPassword
+import com.ttasjwi.board.system.member.domain.model.fixture.encodedPasswordFixture
+import com.ttasjwi.board.system.member.domain.model.fixture.rawPasswordFixture
+import com.ttasjwi.board.system.member.domain.service.PasswordManager
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.*
+
+@DisplayName("PasswordManagerImpl: 패스워드 인스턴스 생성, 인코딩, 매칭을 담당한다")
+class PasswordManagerImplTest {
+
+    private lateinit var passwordManager: PasswordManager
+    private lateinit var externalPasswordHandler: ExternalPasswordHandler
+
+    @BeforeEach
+    fun setup() {
+        externalPasswordHandler = ExternalPasswordHandlerFixture()
+        passwordManager = PasswordManagerImpl(externalPasswordHandler)
+    }
+
+    @Nested
+    @DisplayName("createRawPassword : 문자열로부터 RawPassword 인스턴스를 생성하고 그 결과를 Result 로 담아 반환한다.")
+    inner class CreateRawPassword {
+
+        @Test
+        @DisplayName("길이 유효성: ${RawPassword.MIN_LENGTH}자 이상, ${RawPassword.MAX_LENGTH}자 이하")
+        fun testSuccess() {
+            val minLengthString = "a".repeat(RawPassword.MIN_LENGTH)
+            val maxLengthString = "a".repeat(RawPassword.MAX_LENGTH)
+
+
+            val minLengthPasswordResult = passwordManager.createRawPassword(minLengthString)
+            val maxLengthPasswordResult = passwordManager.createRawPassword(maxLengthString)
+
+            assertThat(minLengthPasswordResult.isSuccess).isTrue()
+            assertThat(maxLengthPasswordResult.isSuccess).isTrue()
+
+            val minLengthRawPassword = minLengthPasswordResult.getOrThrow()
+            val maxLengthRawPassword = maxLengthPasswordResult.getOrThrow()
+
+            assertThat(minLengthRawPassword.value).isEqualTo(minLengthString)
+            assertThat(maxLengthRawPassword.value).isEqualTo(maxLengthString)
+        }
+
+        @Test
+        @DisplayName("최소 글자수보다 글자수가 적으면 예외가 발생한다.")
+        fun testFailure1() {
+            val tooShortLengthString = "a".repeat(RawPassword.MIN_LENGTH - 1)
+
+            val tooShortLengthPasswordResult = passwordManager.createRawPassword(tooShortLengthString)
+
+            assertThat(tooShortLengthPasswordResult.isFailure).isTrue()
+            assertThrows<InvalidPasswordFormatException> { tooShortLengthPasswordResult.getOrThrow() }
+        }
+
+        @Test
+        @DisplayName("최대 글자수보다 글자수가 많으면 예외가 발생한다.")
+        fun testFailure() {
+            val tooLongLengthString = "a".repeat(RawPassword.MAX_LENGTH + 1)
+
+            val tooLongLengthPasswordResult = passwordManager.createRawPassword(tooLongLengthString)
+
+            assertThat(tooLongLengthPasswordResult.isFailure).isTrue()
+            assertThrows<InvalidPasswordFormatException> { tooLongLengthPasswordResult.getOrThrow() }
+        }
+    }
+
+    @Nested
+    @DisplayName("encode: RawPassword 의 값을 인코딩하여, EncodedPassword 화 한다.")
+    inner class Encode {
+
+        @Test
+        @DisplayName("외부 패스워드 처리기를 통해 인코딩된 값을 기반으로 EncodedPassword 를 구성한다.")
+        fun test() {
+            val rawPassword = rawPasswordFixture("1234")
+            val encodedPassword = passwordManager.encode(rawPassword)
+            assertThat(encodedPassword).isNotNull
+            assertThat(encodedPassword.value).isEqualTo(rawPassword.value)
+        }
+    }
+
+    @Nested
+    @DisplayName("matches: RawPassword 와 EncodedPassword 를 매칭시켜서 서로 맞는 지 여부를 반환한다.")
+    inner class Matches {
+
+        @Test
+        @DisplayName("외부 패스워드 인코더를 통해 매칭을 위임하고 그 결과를 반환한다.")
+        fun test() {
+            val rawPassword = rawPasswordFixture("1234")
+            val encodedPassword = encodedPasswordFixture("1234")
+
+            assertThat(passwordManager.matches(rawPassword, encodedPassword)).isTrue()
+            assertThat(passwordManager.matches(rawPasswordFixture("1235"), encodedPassword)).isFalse()
+        }
+    }
+}

--- a/board-system-domain/domain-member/src/testFixtures/kotlin/com/ttasjwi/board/system/member/domain/event/fixture/MemberRegisteredEventFixture.kt
+++ b/board-system-domain/domain-member/src/testFixtures/kotlin/com/ttasjwi/board/system/member/domain/event/fixture/MemberRegisteredEventFixture.kt
@@ -2,20 +2,23 @@ package com.ttasjwi.board.system.member.domain.event.fixture
 
 import com.ttasjwi.board.system.core.time.fixture.timeFixture
 import com.ttasjwi.board.system.member.domain.event.MemberRegisteredEvent
+import com.ttasjwi.board.system.member.domain.model.Role
 import java.time.ZonedDateTime
 
 fun memberRegisteredEventFixture(
-    registeredAt: ZonedDateTime = timeFixture(),
     memberId: Long = 1L,
     email: String = "hello@gmail.com",
     username: String = "username",
     nickname: String = "테스트닉네임",
+    role: Role = Role.USER,
+    registeredAt: ZonedDateTime = timeFixture(),
 ): MemberRegisteredEvent {
     return MemberRegisteredEvent(
-        registeredAt = registeredAt,
         memberId = memberId,
         email = email,
         username = username,
         nickname = nickname,
+        roleName = role.name,
+        registeredAt = registeredAt,
     )
 }

--- a/board-system-domain/domain-member/src/testFixtures/kotlin/com/ttasjwi/board/system/member/domain/external/fixture/ExternalPasswordHandlerFixture.kt
+++ b/board-system-domain/domain-member/src/testFixtures/kotlin/com/ttasjwi/board/system/member/domain/external/fixture/ExternalPasswordHandlerFixture.kt
@@ -1,0 +1,17 @@
+package com.ttasjwi.board.system.member.domain.external.fixture
+
+import com.ttasjwi.board.system.member.domain.external.ExternalPasswordHandler
+import com.ttasjwi.board.system.member.domain.model.EncodedPassword
+import com.ttasjwi.board.system.member.domain.model.RawPassword
+import com.ttasjwi.board.system.member.domain.model.fixture.encodedPasswordFixture
+
+class ExternalPasswordHandlerFixture : ExternalPasswordHandler{
+
+    override fun encode(rawPassword: RawPassword): EncodedPassword {
+        return encodedPasswordFixture(rawPassword.value)
+    }
+
+    override fun matches(rawPassword: RawPassword, encodedPassword: EncodedPassword): Boolean {
+        return rawPassword.value == encodedPassword.value
+    }
+}

--- a/board-system-domain/domain-member/src/testFixtures/kotlin/com/ttasjwi/board/system/member/domain/service/fixture/EmailVerificationHandlerFixture.kt
+++ b/board-system-domain/domain-member/src/testFixtures/kotlin/com/ttasjwi/board/system/member/domain/service/fixture/EmailVerificationHandlerFixture.kt
@@ -23,7 +23,5 @@ class EmailVerificationHandlerFixture : EmailVerificationHandler {
         )
     }
 
-    override fun checkVerifiedAndCurrentlyValid(emailVerification: EmailVerification, currentTime: ZonedDateTime) {
-        TODO("Not yet implemented")
-    }
+    override fun checkVerifiedAndCurrentlyValid(emailVerification: EmailVerification, currentTime: ZonedDateTime) {}
 }

--- a/board-system-domain/domain-member/src/testFixtures/kotlin/com/ttasjwi/board/system/member/domain/service/fixture/MemberCreatorFixture.kt
+++ b/board-system-domain/domain-member/src/testFixtures/kotlin/com/ttasjwi/board/system/member/domain/service/fixture/MemberCreatorFixture.kt
@@ -1,0 +1,26 @@
+package com.ttasjwi.board.system.member.domain.service.fixture
+
+import com.ttasjwi.board.system.member.domain.model.*
+import com.ttasjwi.board.system.member.domain.model.fixture.memberFixtureNotRegistered
+import com.ttasjwi.board.system.member.domain.service.MemberCreator
+import java.time.ZonedDateTime
+
+class MemberCreatorFixture : MemberCreator {
+
+    override fun create(
+        email: Email,
+        password: RawPassword,
+        username: Username,
+        nickname: Nickname,
+        currentTime: ZonedDateTime
+    ): Member {
+        return memberFixtureNotRegistered(
+            email = email.value,
+            password = password.value,
+            username = username.value,
+            nickname = nickname.value,
+            role = Role.USER,
+            registeredAt = currentTime,
+        )
+    }
+}

--- a/board-system-domain/domain-member/src/testFixtures/kotlin/com/ttasjwi/board/system/member/domain/service/fixture/MemberEventCreatorFixture.kt
+++ b/board-system-domain/domain-member/src/testFixtures/kotlin/com/ttasjwi/board/system/member/domain/service/fixture/MemberEventCreatorFixture.kt
@@ -1,0 +1,20 @@
+package com.ttasjwi.board.system.member.domain.service.fixture
+
+import com.ttasjwi.board.system.member.domain.event.MemberRegisteredEvent
+import com.ttasjwi.board.system.member.domain.event.fixture.memberRegisteredEventFixture
+import com.ttasjwi.board.system.member.domain.model.Member
+import com.ttasjwi.board.system.member.domain.service.MemberEventCreator
+
+class MemberEventCreatorFixture : MemberEventCreator {
+
+    override fun onMemberRegistered(member: Member): MemberRegisteredEvent {
+        return memberRegisteredEventFixture(
+            memberId = member.id!!.value,
+            email = member.email.value,
+            username = member.username.value,
+            nickname = member.nickname.value,
+            role = member.role,
+            registeredAt = member.registeredAt,
+        )
+    }
+}

--- a/board-system-domain/domain-member/src/testFixtures/kotlin/com/ttasjwi/board/system/member/domain/service/fixture/PasswordManagerFixture.kt
+++ b/board-system-domain/domain-member/src/testFixtures/kotlin/com/ttasjwi/board/system/member/domain/service/fixture/PasswordManagerFixture.kt
@@ -1,0 +1,37 @@
+package com.ttasjwi.board.system.member.domain.service.fixture
+
+import com.ttasjwi.board.system.core.exception.ErrorStatus
+import com.ttasjwi.board.system.core.exception.fixture.customExceptionFixture
+import com.ttasjwi.board.system.member.domain.model.EncodedPassword
+import com.ttasjwi.board.system.member.domain.model.RawPassword
+import com.ttasjwi.board.system.member.domain.model.fixture.encodedPasswordFixture
+import com.ttasjwi.board.system.member.domain.model.fixture.rawPasswordFixture
+import com.ttasjwi.board.system.member.domain.service.PasswordManager
+
+class PasswordManagerFixture : PasswordManager {
+
+    companion object {
+        const val ERROR_PASSWORD = "2#!"
+    }
+
+    override fun createRawPassword(value: String): Result<RawPassword> = kotlin.runCatching {
+        if (value == ERROR_PASSWORD) {
+            throw customExceptionFixture(
+                status = ErrorStatus.BAD_REQUEST,
+                code = "Error.InvalidPasswordFormat",
+                args = emptyList(),
+                source = "password",
+                debugMessage = "패스워드 포맷 예외 - 픽스쳐"
+            )
+        }
+        rawPasswordFixture(value)
+    }
+
+    override fun encode(rawPassword: RawPassword): EncodedPassword {
+        return encodedPasswordFixture(rawPassword.value)
+    }
+
+    override fun matches(rawPassword: RawPassword, encodedPassword: EncodedPassword): Boolean {
+        return rawPassword.value == encodedPassword.value
+    }
+}

--- a/board-system-external/external-message/src/main/resources/message/error-message_en.yml
+++ b/board-system-external/external-message/src/main/resources/message/error-message_en.yml
@@ -8,18 +8,23 @@ Error:
   NotImplemented:
     message: "Feature Not Implemented"
     description: "The requested feature is currently not implemented. It is under development and is expected to be added in the near future."
+
   NullArgument:
     message: "Missing required value"
     description: "The field ''{0}'' is required."
   InvalidEmailFormat:
     message: "Invalid email format"
     description: "The email format is not valid. (email = {0})"
+  InvalidPasswordFormat:
+    message: "Invalid Password Format"
+    description: "The password format is invalid. Passwords must be at least {0} characters long and at most {1} characters."
   InvalidUsernameFormat:
     message: "Invalid username format"
     description: "The username format is incorrect. The username must be at least {0} characters and at most {1} characters, and can only contain lowercase English letters, numbers, and underscores. (username = {2})"
   InvalidNicknameFormat:
     message: "Invalid nickname format"
     description: "The nickname format is incorrect. The nickname must be between {0} and {1} characters, consisting only of Korean letters, English letters, or numbers. (nickname= {2})"
+
   EmailVerificationNotFound:
     message: "Email verification not found or expired"
     description: "Could not find email verification for the provided email. It may not exist or may have expired. Please complete the verification process.(email={0})"
@@ -29,3 +34,16 @@ Error:
   InvalidEmailVerificationCode:
     message: "Invalid email verification code"
     description: "The email verification code is invalid. Please enter a valid verification code."
+  EmailNotVerified:
+    message: "Email Not Verified"
+    description: "This email has not been verified. Please complete the verification first. (email={0})"
+
+  DuplicateMemberEmail:
+    message: "Duplicate Email"
+    description: "A member with a duplicate email exists. (email={0})"
+  DuplicateMemberUsername:
+    message: "Duplicate Username"
+    description: "A member with a duplicate username exists. (username={0})"
+  DuplicateMemberNickname:
+    message: "Duplicate Nickname"
+    description: "A member with a duplicate nickname exists. (nickname={0})"

--- a/board-system-external/external-message/src/main/resources/message/error-message_ko.yml
+++ b/board-system-external/external-message/src/main/resources/message/error-message_ko.yml
@@ -1,13 +1,10 @@
 Error:
-
   Occurred:
     message: "에러 발생"
     description: "요청 처리에 실패했습니다. 에러가 발생했습니다."
-
   Server:
     message: "서버 에러"
     description: "알 수 없는 에러가 발생했습니다. 문제가 지속되면 고객 지원팀에 문의해 주세요."
-
   NotImplemented:
     message: "미구현 기능"
     description: "요청하신 기능은 현재 미구현 상태입니다. 해당 기능은 개발 중이며, 가까운 시일 내에 추가될 예정입니다."
@@ -15,15 +12,15 @@ Error:
   NullArgument:
     message: "필수값 누락"
     description: "''{0}''은(는) 필수입니다."
-
   InvalidEmailFormat:
     message: "유효하지 않은 이메일 포맷"
     description: "이메일 포맷이 올바르지 않습니다. (email = {0})"
-
+  InvalidPasswordFormat:
+    message: "유효하지 않은 패스워드 포맷"
+    description: "패스워드의 포맷이 유효하지 않습니다. 패스워드는 {0} 자 이상 {1} 이하여야 합니다."
   InvalidUsernameFormat:
     message: "유효하지 않은 사용자아이디 포맷"
     description: "사용자 아이디 포맷이 올바르지 않습니다. 사용자아이디(username)는 {0} 자 이상 {1} 자 이하여야 하며, 영어소문자/숫자/언더바 만 허용됩니다. (username = {2})"
-
   InvalidNicknameFormat:
     message: "유효하지 않은 닉네임 포맷"
     description: "닉네임 포맷이 올바르지 않습니다. 닉네임은 {0} 자 이상, {1} 자 이하의 한글/영어/숫자로만 구성되어야 합니다. (nickname= {2})"
@@ -31,11 +28,22 @@ Error:
   EmailVerificationNotFound:
     message: "이메일인증이 없거나 만료됨"
     description: "이메일에 대응하는 이메일 인증을 찾지 못 했습니다. 없거나 만료됐습니다. 인증처리를 해주세요.(email={0})"
-
   EmailVerificationExpired:
     message: "이메일인증 만료됨"
     description: "이메일인증이 만료됐습니다. 인증처리를 해주세요.(email={0},만료시각={1},현재시각={2})"
-
   InvalidEmailVerificationCode:
     message: "이메일인증 코드가 유효하지 않음"
     description: "이메일인증 코드가 유효하지 않습니다. 올바른 인증 코드를 입력해주세요."
+  EmailNotVerified:
+    message: "인증되지 않은 이메일"
+    description: "이 이메일은 인증되지 않았습니다. 인증을 먼저 수행해주세요.(email={0})"
+
+  DuplicateMemberEmail:
+    message: "이메일 중복"
+    description: "중복되는 이메일의 회원이 존재합니다.(email={0})"
+  DuplicateMemberUsername:
+    message: "사용자 아이디(username) 중복"
+    description: "중복되는 사용자 아이디(username)의 회원이 존재합니다.(username={0})"
+  DuplicateMemberNickname:
+    message: "닉네임 중복"
+    description: "중복되는 닉네임의 회원이 존재합니다.(nickname={0})"

--- a/board-system-external/external-message/src/main/resources/message/general-message_en.yml
+++ b/board-system-external/external-message/src/main/resources/message/general-message_en.yml
@@ -60,3 +60,7 @@ EmailVerification:
   EmailSubject: "Your Email Verification Code"
   EmailContent: "Email Verification Code: {0}"
 
+RegisterMember:
+  Complete:
+    message: "Registration Complete"
+    description: "The registration has been completed."

--- a/board-system-external/external-message/src/main/resources/message/general-message_ko.yml
+++ b/board-system-external/external-message/src/main/resources/message/general-message_ko.yml
@@ -59,3 +59,8 @@ EmailVerification:
     description: "이메일 인증을 완료했습니다."
   EmailSubject: "이메일인증 코드입니다"
   EmailContent: "이메일인증 코드: {0}"
+
+RegisterMember:
+  Complete:
+    message: "회원가입 완료됨"
+    description: "회원가입이 완료됐습니다."

--- a/board-system-external/external-security/build.gradle.kts
+++ b/board-system-external/external-security/build.gradle.kts
@@ -1,0 +1,8 @@
+dependencies {
+    implementation(Dependencies.SPRING_BOOT_STARTER.fullName)
+    implementation(Dependencies.SPRING_SECURITY_CRYPTO.fullName)
+    implementation(project(":board-system-domain:domain-core"))
+    implementation(project(":board-system-domain:domain-member"))
+    testImplementation(testFixtures(project(":board-system-domain:domain-core")))
+    testImplementation(testFixtures(project(":board-system-domain:domain-member")))
+}

--- a/board-system-external/external-security/src/main/kotlin/com/ttasjwi/board/system/core/config/PasswordConfig.kt
+++ b/board-system-external/external-security/src/main/kotlin/com/ttasjwi/board/system/core/config/PasswordConfig.kt
@@ -1,0 +1,15 @@
+package com.ttasjwi.board.system.core.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.crypto.factory.PasswordEncoderFactories
+import org.springframework.security.crypto.password.PasswordEncoder
+
+@Configuration
+class PasswordConfig {
+
+    @Bean
+    fun passwordEncoder(): PasswordEncoder {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder()
+    }
+}

--- a/board-system-external/external-security/src/main/kotlin/com/ttasjwi/board/system/member/domain/external/ExternalPasswordHandlerImpl.kt
+++ b/board-system-external/external-security/src/main/kotlin/com/ttasjwi/board/system/member/domain/external/ExternalPasswordHandlerImpl.kt
@@ -1,0 +1,21 @@
+package com.ttasjwi.board.system.member.domain.external
+
+import com.ttasjwi.board.system.member.domain.model.EncodedPassword
+import com.ttasjwi.board.system.member.domain.model.RawPassword
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Component
+
+@Component
+class ExternalPasswordHandlerImpl(
+    private val passwordEncoder: PasswordEncoder,
+) : ExternalPasswordHandler {
+
+    override fun encode(rawPassword: RawPassword): EncodedPassword {
+        val encodedPasswordValue = passwordEncoder.encode(rawPassword.value)
+        return EncodedPassword.restore(encodedPasswordValue)
+    }
+
+    override fun matches(rawPassword: RawPassword, encodedPassword: EncodedPassword): Boolean {
+        return passwordEncoder.matches(rawPassword.value, encodedPassword.value)
+    }
+}

--- a/board-system-external/external-security/src/test/kotlin/com/ttasjwi/board/system/SecurityTestApplication.kt
+++ b/board-system-external/external-security/src/test/kotlin/com/ttasjwi/board/system/SecurityTestApplication.kt
@@ -1,0 +1,11 @@
+package com.ttasjwi.board.system
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+@SpringBootApplication
+class SecurityTestApplication
+
+fun main(args: Array<String>) {
+    runApplication<SecurityTestApplication>(*args)
+}

--- a/board-system-external/external-security/src/test/kotlin/com/ttasjwi/board/system/member/domain/external/ExternalPasswordHandlerImplTest.kt
+++ b/board-system-external/external-security/src/test/kotlin/com/ttasjwi/board/system/member/domain/external/ExternalPasswordHandlerImplTest.kt
@@ -1,0 +1,63 @@
+package com.ttasjwi.board.system.member.domain.external
+
+import com.ttasjwi.board.system.member.domain.model.fixture.rawPasswordFixture
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Profile
+
+@SpringBootTest
+@Profile("test")
+@DisplayName("ExternalPasswordHandlerImpl 테스트")
+class ExternalPasswordHandlerImplTest @Autowired constructor(
+    private val externalPasswordHandler: ExternalPasswordHandler
+) {
+
+    @Nested
+    @DisplayName("encode: 패스워드를 인코딩한다")
+    inner class Encode {
+
+        @Test
+        fun test() {
+            val rawPassword = rawPasswordFixture("1234")
+            val encodedPassword = externalPasswordHandler.encode(rawPassword)
+            assertThat(encodedPassword).isNotNull()
+        }
+    }
+
+    @Nested
+    @DisplayName("matches: 원본 패스워드와 인코딩 된 패스워드를 비교하여 일치하는 지 여부를 반환한다.")
+    inner class Matches {
+
+        @Test
+        @DisplayName("원본 패스워드가 같으면, true를 반환한다.")
+        fun testSamePassword() {
+            // given
+            val rawPassword = rawPasswordFixture("1234")
+            val encodedPassword = externalPasswordHandler.encode(rawPassword)
+
+            // when
+            val matches = externalPasswordHandler.matches(rawPassword, encodedPassword)
+
+            // then
+            assertThat(matches).isTrue()
+        }
+
+        @Test
+        @DisplayName("원본 패스워드가 다르면, false를 반환한다.")
+        fun testDifferentPassword() {
+            // given
+            val rawPassword = rawPasswordFixture("1234")
+            val encodedPassword = externalPasswordHandler.encode(rawPassword)
+
+            // when
+            val matches = externalPasswordHandler.matches(rawPasswordFixture("1235"), encodedPassword)
+
+            // then
+            assertThat(matches).isFalse()
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -17,6 +17,8 @@ enum class Dependencies(
     SPRING_BOOT_MAIL(groupId = "org.springframework.boot", artifactId = "spring-boot-starter-mail"),
     SPRING_BOOT_TEST(groupId = "org.springframework.boot", artifactId = "spring-boot-starter-test"),
 
+    SPRING_SECURITY_CRYPTO(groupId = "org.springframework.security", artifactId = "spring-security-crypto"),
+
     // p6spy
     P6SPY_DATASOURCE_DECORATOR(groupId = "com.github.gavlyukovskiy", artifactId = "p6spy-spring-boot-starter", version = "1.9.2"),
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -30,6 +30,7 @@ include(
     "board-system-external:external-message",
     "board-system-external:external-db",
     "board-system-external:external-redis",
+    "board-system-external:external-security",
     "board-system-external:external-exception-handle",
     "board-system-external:external-email-sender",
     "board-system-external:external-email-format-checker",


### PR DESCRIPTION
# JIRA 티켓
- [BRD-45]

---

# 내부 흐름

## 1. api-member 모듈 > RegisterMemberController
![image](https://github.com/user-attachments/assets/56079d11-a891-4b3b-a67c-cecaecf401ff)

- 요청을 받고 유즈케이스(RegisterMemberUseCase)에 요청 처리를 위임한다
  - 유즈케이스의 구현체는 RegisterMemberApplicationService 로서, application-member 모듈에 위치해있다.
- 요청결과를 받고, 응답으로 가공한다.
  - 이 과정에서 사용자의 로케일을 얻기 위한 LocaleManager, 메시지 처리를 위한 MessageResolver가 개입한다
  - LocaleManager 구현체, MessageResolver 구현체는 external-message 모듈에 위치해있다.

## 2. application-member 모듈 > RegisterMemberApplicationService
![image](https://github.com/user-attachments/assets/43d8c104-0f43-4a91-a897-f752992c84a3)

- 요청(RegisterMemberRequest) 를 받고 RegisterMemberCommandMapper를 통해 애플리케이션 명령으로 변환한다.
  - 이 과정에서 유효성 검사가 함께 일어난다
- 프로세서(RegisterMemberProcessor) 를 통해 애플리케이션 로직을 처리한다.
- 프로세서를 호출하는 콜백함수를 TransactionRunner 에게 전달함으로서, 트랜잭션에서 프로세서 처리가 일어난다.
- 프로세서가 처리한 결과를 재가공하여 반환한다.

## 3. application-member 모듈 > RegisterMemberCommandMapper

## 4. application-member 모듈 > RegisterMemberProcessor

## 5. 도메인 모듈


---


[BRD-45]: https://ttasjwi.atlassian.net/browse/BRD-45?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ