### PR TITLE
Fix: (BRD-72) 이메일 인증 API - 요청 매핑 안 되는 문제 수정

### DIFF
--- a/board-system-api/api-member/src/main/kotlin/com/ttasjwi/board/system/member/api/EmailVerificationController.kt
+++ b/board-system-api/api-member/src/main/kotlin/com/ttasjwi/board/system/member/api/EmailVerificationController.kt
@@ -8,6 +8,7 @@ import com.ttasjwi.board.system.member.application.usecase.EmailVerificationResu
 import com.ttasjwi.board.system.member.application.usecase.EmailVerificationUseCase
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
 import java.time.ZonedDateTime
 
@@ -19,7 +20,7 @@ class EmailVerificationController(
 ) {
 
     @PostMapping("/api/v1/members/email-verification")
-    fun emailVerification(request: EmailVerificationRequest): ResponseEntity<SuccessResponse<EmailVerificationResponse>> {
+    fun emailVerification(@RequestBody request: EmailVerificationRequest): ResponseEntity<SuccessResponse<EmailVerificationResponse>> {
         // 애플리케이션 서비스에 요청 처리를 위임
         val result = useCase.emailVerification(request)
 


### PR DESCRIPTION

# JIRA 티켓
- [BRD-72]

---

# 작업 내역
- 요청 Body 가 요청 객체에 매핑되지 않는 문제가 있음
- 컨트롤러 요청 객체 앞에 `@RequestBody` 를 안 붙여서 생긴 문제여서, 어노테이션을 새로 붙임

---

# 동일한 문제 방지
- 추후 이런 문제를 방지하려면 MVC 통합 테스트를 추가적으로 만들어야할 듯 함.



[BRD-72]: https://ttasjwi.atlassian.net/browse/BRD-72?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ