### PR TITLE
Fix: (BRD-73) 회원가입 성공 상태코드 변경(200 OK -> 201 CREATED)

### DIFF
--- a/board-system-api/api-member/src/main/kotlin/com/ttasjwi/board/system/member/api/RegisterMemberController.kt
+++ b/board-system-api/api-member/src/main/kotlin/com/ttasjwi/board/system/member/api/RegisterMemberController.kt
@@ -6,6 +6,7 @@ import com.ttasjwi.board.system.core.message.MessageResolver
 import com.ttasjwi.board.system.member.application.usecase.RegisterMemberRequest
 import com.ttasjwi.board.system.member.application.usecase.RegisterMemberResult
 import com.ttasjwi.board.system.member.application.usecase.RegisterMemberUseCase
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -27,8 +28,8 @@ class RegisterMemberController(
         // 처리 결과로부터 응답 메시지 가공
         val response = makeResponse(result)
 
-        // 200 상태코드와 함께 HTTP 응답
-        return ResponseEntity.ok(response)
+        // 201 상태코드와 함께 HTTP 응답
+        return ResponseEntity.status(HttpStatus.CREATED).body(response)
     }
 
     private fun makeResponse(result: RegisterMemberResult): SuccessResponse<RegisterMemberResponse> {

--- a/board-system-api/api-member/src/test/kotlin/com/ttasjwi/board/system/member/api/RegisterMemberControllerTest.kt
+++ b/board-system-api/api-member/src/test/kotlin/com/ttasjwi/board/system/member/api/RegisterMemberControllerTest.kt
@@ -48,7 +48,7 @@ class RegisterMemberControllerTest {
         val response = responseEntity.body as SuccessResponse<RegisterMemberResponse>
 
         // then
-        assertThat(responseEntity.statusCode.value()).isEqualTo(HttpStatus.OK.value())
+        assertThat(responseEntity.statusCode.value()).isEqualTo(HttpStatus.CREATED.value())
         assertThat(response.isSuccess).isTrue()
         assertThat(response.code).isEqualTo("RegisterMember.Complete")
         assertThat(response.message).isEqualTo("RegisterMember.Complete.message(locale=${Locale.KOREAN},args=[])")


### PR DESCRIPTION

# JIRA 티켓
- [BRD-73]

---

# 작업내역
- 기존엔 회원가입 성공 응답의 상태코드가 200 OK였다.
- 회원이라는 자원이 새로 생성됐다는 의미에서 상태코드를 201 CREATED 로 변경했다.