### PR TITLE
Refactor: (BRD-79) 시간대 규칙 통일(TimeRule.ZONE_ID)

### DIFF
--- a/board-system-core/src/main/kotlin/com/ttasjwi/board/system/core/time/TimeRule.kt
+++ b/board-system-core/src/main/kotlin/com/ttasjwi/board/system/core/time/TimeRule.kt
@@ -1,0 +1,7 @@
+package com.ttasjwi.board.system.core.time
+
+import java.time.ZoneId
+
+object TimeRule {
+    val ZONE_ID: ZoneId = ZoneId.of("Asia/Seoul")
+}

--- a/board-system-core/src/main/kotlin/com/ttasjwi/board/system/core/time/impl/TimeManagerImpl.kt
+++ b/board-system-core/src/main/kotlin/com/ttasjwi/board/system/core/time/impl/TimeManagerImpl.kt
@@ -2,12 +2,13 @@ package com.ttasjwi.board.system.core.time.impl
 
 import com.ttasjwi.board.system.core.annotation.component.AppComponent
 import com.ttasjwi.board.system.core.time.TimeManager
+import com.ttasjwi.board.system.core.time.TimeRule
 import java.time.ZonedDateTime
 
 @AppComponent
 class TimeManagerImpl : TimeManager {
 
     override fun now(): ZonedDateTime {
-        return ZonedDateTime.now()
+        return ZonedDateTime.now(TimeRule.ZONE_ID)
     }
 }

--- a/board-system-core/src/test/kotlin/com/ttasjwi/board/system/core/time/TimeRuleTest.kt
+++ b/board-system-core/src/test/kotlin/com/ttasjwi/board/system/core/time/TimeRuleTest.kt
@@ -1,0 +1,16 @@
+package com.ttasjwi.board.system.core.time
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.time.ZoneId
+
+@DisplayName("TimeRule: 우리 서비스의 시간대 규칙")
+class TimeRuleTest {
+
+    @Test
+    @DisplayName("우리 서비스의 기준 시간대는 서울 시간을 기준으로 삼는다.")
+    fun testZoneId() {
+        assertThat(TimeRule.ZONE_ID).isEqualTo(ZoneId.of("Asia/Seoul"))
+    }
+}

--- a/board-system-core/src/testFixtures/kotlin/com/ttasjwi/board/system/core/time/fixture/TimeFixture.kt
+++ b/board-system-core/src/testFixtures/kotlin/com/ttasjwi/board/system/core/time/fixture/TimeFixture.kt
@@ -1,5 +1,6 @@
 package com.ttasjwi.board.system.core.time.fixture
 
+import com.ttasjwi.board.system.core.time.TimeRule
 import java.time.ZoneId
 import java.time.ZonedDateTime
 
@@ -11,7 +12,7 @@ fun timeFixture(
     minute: Int = 0,
     second: Int = 0,
     nanoOfSecond: Int = 0,
-    zone: ZoneId = ZoneId.of("Asia/Seoul")
+    zone: ZoneId = TimeRule.ZONE_ID
 ): ZonedDateTime {
     return ZonedDateTime.of(
         year,

--- a/board-system-domain/domain-auth/src/main/kotlin/com/ttasjwi/board/system/auth/domain/model/RefreshTokenHolder.kt
+++ b/board-system-domain/domain-auth/src/main/kotlin/com/ttasjwi/board/system/auth/domain/model/RefreshTokenHolder.kt
@@ -1,7 +1,7 @@
 package com.ttasjwi.board.system.auth.domain.model
 
+import com.ttasjwi.board.system.core.time.TimeRule
 import java.time.LocalDateTime
-import java.time.ZoneId
 import java.time.ZonedDateTime
 
 /**
@@ -76,7 +76,7 @@ internal constructor(
         }
         // 만료일이 가장 늦은 것을 기준으로 만료시킴
         // 가장 만료시간이 마지막인 토큰을 기준으로 만료시간을 잡음
-        var maxExpireTime = ZonedDateTime.of(LocalDateTime.MIN, ZoneId.of("Asia/Seoul"))
+        var maxExpireTime = ZonedDateTime.of(LocalDateTime.MIN, TimeRule.ZONE_ID)
         for (token in _tokens.values) {
             if (token.expiresAt > maxExpireTime) {
                 maxExpireTime = token.expiresAt

--- a/board-system-domain/domain-core/src/test/kotlin/com/ttasjwi/board/system/core/domain/event/DomainEventTest.kt
+++ b/board-system-domain/domain-core/src/test/kotlin/com/ttasjwi/board/system/core/domain/event/DomainEventTest.kt
@@ -1,9 +1,9 @@
 package com.ttasjwi.board.system.core.domain.event
 
+import com.ttasjwi.board.system.core.time.TimeRule
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import java.time.ZoneId
 import java.time.ZonedDateTime
 
 @DisplayName("DomainEvent 테스트")
@@ -24,7 +24,7 @@ class DomainEventTest {
     @Test
     @DisplayName("개발자는 커스텀한 데이터를 이벤트 객체에 담을 수 있고 이를 꺼내서 쓸 수 있다.")
     fun testData() {
-        val occurredAt =ZonedDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneId.of("Asia/Seoul"))
+        val occurredAt = ZonedDateTime.of(2024, 1, 1, 0, 0, 0, 0, TimeRule.ZONE_ID)
         val event = TestDomainEvent(
             occurredAt,
             "ttasjwi",
@@ -41,7 +41,7 @@ class DomainEventTest {
     @Test
     @DisplayName("이벤트는 발생한 시간 정보를 가진다.")
     fun testTime() {
-        val occurredAt = ZonedDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneId.of("Asia/Seoul"))
+        val occurredAt = ZonedDateTime.of(2024, 1, 1, 0, 0, 0, 0, TimeRule.ZONE_ID)
         val event = TestDomainEvent(
             occurredAt,
             "ttasjwi",

--- a/board-system-external/external-redis/src/main/kotlin/com/ttasjwi/board/system/auth/domain/external/redis/RedisRefreshTokenHolder.kt
+++ b/board-system-external/external-redis/src/main/kotlin/com/ttasjwi/board/system/auth/domain/external/redis/RedisRefreshTokenHolder.kt
@@ -3,7 +3,7 @@ package com.ttasjwi.board.system.auth.domain.external.redis
 import com.ttasjwi.board.system.auth.domain.model.RefreshToken
 import com.ttasjwi.board.system.auth.domain.model.RefreshTokenHolder
 import com.ttasjwi.board.system.auth.domain.model.RefreshTokenId
-import java.time.ZoneId
+import com.ttasjwi.board.system.core.time.TimeRule
 import java.time.ZonedDateTime
 
 class RedisRefreshTokenHolder(
@@ -28,8 +28,6 @@ class RedisRefreshTokenHolder(
     )
 
     companion object {
-
-        private val TIME_ZONE = ZoneId.of("Asia/Seoul")
 
         fun from(refreshTokenHolder: RefreshTokenHolder): RedisRefreshTokenHolder {
             return RedisRefreshTokenHolder(
@@ -68,8 +66,8 @@ class RedisRefreshTokenHolder(
                     memberId = token.memberId,
                     refreshTokenId = token.refreshTokenId,
                     tokenValue = token.tokenValue,
-                    issuedAt = token.issuedAt.withZoneSameInstant(TIME_ZONE),
-                    expiresAt = token.expiresAt.withZoneSameInstant(TIME_ZONE)
+                    issuedAt = token.issuedAt.withZoneSameInstant(TimeRule.ZONE_ID),
+                    expiresAt = token.expiresAt.withZoneSameInstant(TimeRule.ZONE_ID)
                 )
                 key to value
             }.toMap().toMutableMap()

--- a/board-system-external/external-redis/src/main/kotlin/com/ttasjwi/board/system/member/domain/service/impl/redis/RedisEmailVerification.kt
+++ b/board-system-external/external-redis/src/main/kotlin/com/ttasjwi/board/system/member/domain/service/impl/redis/RedisEmailVerification.kt
@@ -1,7 +1,7 @@
 package com.ttasjwi.board.system.member.domain.service.impl.redis
 
+import com.ttasjwi.board.system.core.time.TimeRule
 import com.ttasjwi.board.system.member.domain.model.EmailVerification
-import java.time.ZoneId
 import java.time.ZonedDateTime
 
 class RedisEmailVerification(
@@ -14,8 +14,6 @@ class RedisEmailVerification(
 ) {
 
     companion object {
-
-        private val TIME_ZONE = ZoneId.of("Asia/Seoul")
 
         fun from(emailVerification: EmailVerification): RedisEmailVerification {
             return RedisEmailVerification(
@@ -33,10 +31,10 @@ class RedisEmailVerification(
         return EmailVerification.restore(
             email = this.email,
             code = this.code,
-            codeCreatedAt = this.codeCreatedAt.withZoneSameInstant(TIME_ZONE),
-            codeExpiresAt = this.codeExpiresAt.withZoneSameInstant(TIME_ZONE),
-            verifiedAt = this.verifiedAt?.withZoneSameInstant(TIME_ZONE),
-            verificationExpiresAt = this.verificationExpiresAt?.withZoneSameInstant(TIME_ZONE)
+            codeCreatedAt = this.codeCreatedAt.withZoneSameInstant(TimeRule.ZONE_ID),
+            codeExpiresAt = this.codeExpiresAt.withZoneSameInstant(TimeRule.ZONE_ID),
+            verifiedAt = this.verifiedAt?.withZoneSameInstant(TimeRule.ZONE_ID),
+            verificationExpiresAt = this.verificationExpiresAt?.withZoneSameInstant(TimeRule.ZONE_ID)
         )
     }
 }

--- a/board-system-external/external-security/src/main/kotlin/com/ttasjwi/board/system/auth/domain/external/ExternalAccessTokenManagerImpl.kt
+++ b/board-system-external/external-security/src/main/kotlin/com/ttasjwi/board/system/auth/domain/external/ExternalAccessTokenManagerImpl.kt
@@ -3,10 +3,10 @@ package com.ttasjwi.board.system.auth.domain.external
 import com.ttasjwi.board.system.auth.domain.exception.InvalidAccessTokenFormatException
 import com.ttasjwi.board.system.auth.domain.model.AccessToken
 import com.ttasjwi.board.system.auth.domain.model.AuthMember
+import com.ttasjwi.board.system.core.time.TimeRule
 import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm
 import org.springframework.security.oauth2.jwt.*
 import org.springframework.stereotype.Component
-import java.time.ZoneId
 import java.time.ZonedDateTime
 
 @Component
@@ -23,7 +23,6 @@ class ExternalAccessTokenManagerImpl(
         private const val EMAIL_CLAIM = "email"
         private const val ROLE_CLAIM = "role"
         private const val ISSUER_VALUE = "board-system"
-        private val TIME_ZONE = ZoneId.of("Asia/Seoul")
     }
 
     override fun generate(authMember: AuthMember, issuedAt: ZonedDateTime, expiresAt: ZonedDateTime): AccessToken {
@@ -81,8 +80,8 @@ class ExternalAccessTokenManagerImpl(
             nickname = jwt.getClaim(NICKNAME_CLAIM),
             roleName = jwt.getClaim(ROLE_CLAIM),
             tokenValue = jwt.tokenValue,
-            issuedAt = jwt.issuedAt!!.atZone(TIME_ZONE),
-            expiresAt = jwt.expiresAt!!.atZone(TIME_ZONE)
+            issuedAt = jwt.issuedAt!!.atZone(TimeRule.ZONE_ID),
+            expiresAt = jwt.expiresAt!!.atZone(TimeRule.ZONE_ID)
         )
     }
 }

--- a/board-system-external/external-security/src/main/kotlin/com/ttasjwi/board/system/auth/domain/external/ExternalRefreshTokenManagerImpl.kt
+++ b/board-system-external/external-security/src/main/kotlin/com/ttasjwi/board/system/auth/domain/external/ExternalRefreshTokenManagerImpl.kt
@@ -3,6 +3,7 @@ package com.ttasjwi.board.system.auth.domain.external
 import com.ttasjwi.board.system.auth.domain.exception.InvalidRefreshTokenFormatException
 import com.ttasjwi.board.system.auth.domain.model.RefreshToken
 import com.ttasjwi.board.system.auth.domain.model.RefreshTokenId
+import com.ttasjwi.board.system.core.time.TimeRule
 import com.ttasjwi.board.system.member.domain.model.MemberId
 import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm
 import org.springframework.security.oauth2.jwt.*
@@ -21,7 +22,6 @@ class ExternalRefreshTokenManagerImpl(
         private const val TOKEN_TYPE_CLAIM = "tokenType"
         private const val TOKEN_TYPE_VALUE = "refreshToken"
         private const val ISSUER_VALUE = "board-system"
-        private val TIME_ZONE = ZoneId.of("Asia/Seoul")
     }
 
     override fun generate(
@@ -90,8 +90,8 @@ class ExternalRefreshTokenManagerImpl(
             memberId = jwt.subject.toLong(),
             refreshTokenId = jwt.getClaim(REFRESH_TOKEN_ID_CLAIM),
             tokenValue = jwt.tokenValue,
-            issuedAt = jwt.issuedAt!!.atZone(TIME_ZONE),
-            expiresAt = jwt.expiresAt!!.atZone(TIME_ZONE)
+            issuedAt = jwt.issuedAt!!.atZone(TimeRule.ZONE_ID),
+            expiresAt = jwt.expiresAt!!.atZone(TimeRule.ZONE_ID)
         )
     }
 }


### PR DESCRIPTION

# JIRA 티켓
- [BRD-79]

---

# 작업내역
- 기존에는 시간대 설정 코드가 애플리케이션 이곳 저곳에 분산되어 있었음
- 우리 서비스의 시간대를 TimeZone.ZONE_ID 로 명시해두고 해당 설정값을 의존하도록 수정

[BRD-79]: https://ttasjwi.atlassian.net/browse/BRD-79?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ