### PR TITLE
Feature: (BRD-90) 소셜 로그인 - OAuth2AuthorizedClient를 저장하지 않도록 변경

### DIFF
--- a/board-system-external/external-message/src/main/resources/message/general-message_en.yml
+++ b/board-system-external/external-message/src/main/resources/message/general-message_en.yml
@@ -74,3 +74,8 @@ TokenRefresh:
   Complete:
     message: "Token refresh successful"
     description: "The token was successfully refreshed."
+
+SocialLogin:
+  Complete:
+    message: "Social login successful"
+    description: "You have successfully logged in using social login."

--- a/board-system-external/external-message/src/main/resources/message/general-message_ko.yml
+++ b/board-system-external/external-message/src/main/resources/message/general-message_ko.yml
@@ -74,3 +74,8 @@ TokenRefresh:
   Complete:
     message: "토큰 재갱신 성공"
     description: "토큰 재갱신에 성공했습니다."
+
+SocialLogin:
+  Complete:
+    message: "소셜로그인 성공"
+    description: "소셜로그인에 성공했습니다."

--- a/board-system-external/external-security/src/main/kotlin/com/ttasjwi/board/system/core/config/FilterChainConfig.kt
+++ b/board-system-external/external-security/src/main/kotlin/com/ttasjwi/board/system/core/config/FilterChainConfig.kt
@@ -13,6 +13,7 @@ import com.ttasjwi.board.system.external.spring.security.exception.CustomAuthent
 import com.ttasjwi.board.system.external.spring.security.oauth2.CustomOAuth2AuthorizationRequestResolver
 import com.ttasjwi.board.system.external.spring.security.oauth2.CustomOAuth2UserService
 import com.ttasjwi.board.system.external.spring.security.oauth2.CustomOidcUserService
+import com.ttasjwi.board.system.external.spring.security.oauth2.NullOAuth2AuthorizedClientRepository
 import com.ttasjwi.board.system.external.spring.security.support.BearerTokenResolver
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest
@@ -30,6 +31,7 @@ import org.springframework.security.oauth2.client.userinfo.OAuth2UserService
 import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest
 import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.security.web.SecurityFilterChain
@@ -84,7 +86,8 @@ class FilterChainConfig(
                     userService = customOAuth2UserService()
                     oidcUserService = customOidcUserService()
                 }
-                authenticationSuccessHandler = customAuthenticationSuccessHandler()
+                authorizedClientRepository = customOAuth2AuthorizedClientRepository()
+                authenticationSuccessHandler = customOAuth2LoginAuthenticationSuccessHandler()
                 authenticationFailureHandler = customAuthenticationFailureHandler()
             }
 
@@ -141,7 +144,7 @@ class FilterChainConfig(
         return CustomAuthenticationFailureHandler(handlerExceptionResolver)
     }
 
-    private fun customAuthenticationSuccessHandler(): AuthenticationSuccessHandler {
+    private fun customOAuth2LoginAuthenticationSuccessHandler(): AuthenticationSuccessHandler {
         return CustomOAuth2LoginAuthenticationSuccessHandler(
             useCase = socialLoginUseCase,
             messageResolver = messageResolver,
@@ -155,5 +158,9 @@ class FilterChainConfig(
 
     private fun customOidcUserService(): OidcUserService {
         return CustomOidcUserService(OidcUserService())
+    }
+
+    private fun customOAuth2AuthorizedClientRepository(): OAuth2AuthorizedClientRepository {
+        return NullOAuth2AuthorizedClientRepository()
     }
 }

--- a/board-system-external/external-security/src/main/kotlin/com/ttasjwi/board/system/external/spring/security/oauth2/NullOAuth2AuthorizedClientRepository.kt
+++ b/board-system-external/external-security/src/main/kotlin/com/ttasjwi/board/system/external/spring/security/oauth2/NullOAuth2AuthorizedClientRepository.kt
@@ -1,0 +1,32 @@
+package com.ttasjwi.board.system.external.spring.security.oauth2
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.core.Authentication
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository
+
+class NullOAuth2AuthorizedClientRepository : OAuth2AuthorizedClientRepository {
+
+    override fun <T : OAuth2AuthorizedClient?> loadAuthorizedClient(
+        clientRegistrationId: String?,
+        principal: Authentication?,
+        request: HttpServletRequest?
+    ): T? {
+        return null
+    }
+
+    override fun saveAuthorizedClient(
+        authorizedClient: OAuth2AuthorizedClient?,
+        principal: Authentication?,
+        request: HttpServletRequest?,
+        response: HttpServletResponse?
+    ) {}
+
+    override fun removeAuthorizedClient(
+        clientRegistrationId: String?,
+        principal: Authentication?,
+        request: HttpServletRequest?,
+        response: HttpServletResponse?
+    ) {}
+}


### PR DESCRIPTION
# JIRA 티켓
- [BRD-90]


---

# 작업내역

- OAuth2AuthorizedClientRepositor수정
  - 기존 OAuth2AuthorizedClientRepository 는 HttpSession 에 인증된 OAuth2 최종 사용자 정보를 저장하고 있었다.
  - 그런데 이걸 계속해서 저장할 필요가 없어서 저장하지 않도록 구현을 변경함
- 소셜로그인 메시지 파일추가

[BRD-90]: https://ttasjwi.atlassian.net/browse/BRD-90?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ