### PR TITLE
Feature: (BRD-94) 게시글 카테고리 생성 API 구현

### DIFF
--- a/board-system-app/src/main/resources/local-schema.sql
+++ b/board-system-app/src/main/resources/local-schema.sql
@@ -24,3 +24,17 @@ CREATE TABLE IF NOT EXISTS boards(
     slug        VARCHAR(30) UNIQUE NOT NULL,
     created_at  DATETIME           NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS board_article_categories(
+    board_article_category_id BIGINT NOT NULL PRIMARY KEY,
+    name VARCHAR(20) NOT NULL,
+    slug VARCHAR(8) NOT NULL,
+    board_id BIGINT NOT NULL,
+    allow_self_delete BOOLEAN NOT NULL,
+    allow_like BOOLEAN NOT NULL,
+    allow_dislike BOOLEAN NOT NULL,
+    created_at DATETIME NOT NULL,
+
+    CONSTRAINT uq_board_id_and_name UNIQUE (board_id, name),
+    CONSTRAINT uq_board_id_and_slug UNIQUE (board_id, slug)
+);

--- a/board-system-app/src/test/resources/test-schema.sql
+++ b/board-system-app/src/test/resources/test-schema.sql
@@ -24,3 +24,17 @@ CREATE TABLE IF NOT EXISTS boards(
     slug        VARCHAR(30) UNIQUE NOT NULL,
     created_at  DATETIME           NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS board_article_categories(
+    board_article_category_id BIGINT      NOT NULL PRIMARY KEY,
+    name                      VARCHAR(20) NOT NULL,
+    slug                      VARCHAR(8)  NOT NULL,
+    board_id                  BIGINT      NOT NULL,
+    allow_self_delete         BOOLEAN     NOT NULL,
+    allow_like                BOOLEAN     NOT NULL,
+    allow_dislike             BOOLEAN     NOT NULL,
+    created_at                DATETIME    NOT NULL,
+
+    CONSTRAINT uq_board_id_and_name UNIQUE (board_id, name),
+    CONSTRAINT uq_board_id_and_slug UNIQUE (board_id, slug)
+);

--- a/board-system-board/board-application-input-port/src/main/kotlin/com/ttasjwi/board/system/board/domain/BoardArticleCategoryCreateUseCase.kt
+++ b/board-system-board/board-application-input-port/src/main/kotlin/com/ttasjwi/board/system/board/domain/BoardArticleCategoryCreateUseCase.kt
@@ -1,5 +1,7 @@
 package com.ttasjwi.board.system.board.domain
 
+import java.time.ZonedDateTime
+
 interface BoardArticleCategoryCreateUseCase {
     fun create(boardId: Long, request: BoardArticleCategoryCreateRequest): BoardArticleCategoryCreateResponse
 }
@@ -20,4 +22,5 @@ data class BoardArticleCategoryCreateResponse(
     val allowSelfDelete: Boolean,
     val allowLike: Boolean,
     val allowDislike: Boolean,
+    val createdAt: ZonedDateTime
 )

--- a/board-system-board/board-application-input-port/src/main/kotlin/com/ttasjwi/board/system/board/domain/BoardArticleCategoryCreateUseCase.kt
+++ b/board-system-board/board-application-input-port/src/main/kotlin/com/ttasjwi/board/system/board/domain/BoardArticleCategoryCreateUseCase.kt
@@ -1,0 +1,23 @@
+package com.ttasjwi.board.system.board.domain
+
+interface BoardArticleCategoryCreateUseCase {
+    fun create(boardId: Long, request: BoardArticleCategoryCreateRequest): BoardArticleCategoryCreateResponse
+}
+
+data class BoardArticleCategoryCreateRequest(
+    val name: String?,
+    val slug: String?,
+    val allowSelfDelete: Boolean?,
+    val allowLike: Boolean?,
+    val allowDislike: Boolean?
+)
+
+data class BoardArticleCategoryCreateResponse(
+    val boardArticleCategoryId: String,
+    val boardId: String,
+    val name: String,
+    val slug: String,
+    val allowSelfDelete: Boolean,
+    val allowLike: Boolean,
+    val allowDislike: Boolean,
+)

--- a/board-system-board/board-application-input-port/src/test/kotlin/com/ttasjwi/board/system/board/domain/fixture/BoardArticleCategoryCreateUseCaseFixtureTest.kt
+++ b/board-system-board/board-application-input-port/src/test/kotlin/com/ttasjwi/board/system/board/domain/fixture/BoardArticleCategoryCreateUseCaseFixtureTest.kt
@@ -1,0 +1,44 @@
+package com.ttasjwi.board.system.board.domain.fixture
+
+import com.ttasjwi.board.system.board.domain.BoardArticleCategoryCreateRequest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("BoardArticleCreateUseCase 픽스쳐 테스트")
+class BoardArticleCategoryCreateUseCaseFixtureTest {
+
+    private lateinit var useCaseFixture: BoardArticleCategoryCreateUseCaseFixture
+
+    @BeforeEach
+    fun setup() {
+        useCaseFixture = BoardArticleCategoryCreateUseCaseFixture()
+    }
+
+    @Test
+    @DisplayName("요청을 받고, 결과를 반환한다.")
+    fun test() {
+        // given
+        val boardId = 12345L
+        val request = BoardArticleCategoryCreateRequest(
+            name = "일반",
+            slug = "general",
+            allowSelfDelete = true,
+            allowLike = true,
+            allowDislike = true,
+        )
+
+        // when
+        val response = useCaseFixture.create(boardId, request)
+
+        // then
+        assertThat(response.boardArticleCategoryId).isNotNull()
+        assertThat(response.boardId).isEqualTo(response.boardId)
+        assertThat(response.name).isEqualTo(request.name)
+        assertThat(response.slug).isEqualTo(request.slug)
+        assertThat(response.allowSelfDelete).isEqualTo(request.allowSelfDelete)
+        assertThat(response.allowLike).isEqualTo(request.allowLike)
+        assertThat(response.allowDislike).isEqualTo(request.allowDislike)
+    }
+}

--- a/board-system-board/board-application-input-port/src/test/kotlin/com/ttasjwi/board/system/board/domain/fixture/BoardArticleCategoryCreateUseCaseFixtureTest.kt
+++ b/board-system-board/board-application-input-port/src/test/kotlin/com/ttasjwi/board/system/board/domain/fixture/BoardArticleCategoryCreateUseCaseFixtureTest.kt
@@ -40,5 +40,6 @@ class BoardArticleCategoryCreateUseCaseFixtureTest {
         assertThat(response.allowSelfDelete).isEqualTo(request.allowSelfDelete)
         assertThat(response.allowLike).isEqualTo(request.allowLike)
         assertThat(response.allowDislike).isEqualTo(request.allowDislike)
+        assertThat(response.createdAt).isNotNull()
     }
 }

--- a/board-system-board/board-application-input-port/src/testFixtures/kotlin/com/ttasjwi/board/system/board/domain/fixture/BoardArticleCategoryCreateUseCaseFixture.kt
+++ b/board-system-board/board-application-input-port/src/testFixtures/kotlin/com/ttasjwi/board/system/board/domain/fixture/BoardArticleCategoryCreateUseCaseFixture.kt
@@ -1,0 +1,21 @@
+package com.ttasjwi.board.system.board.domain.fixture
+
+import com.ttasjwi.board.system.board.domain.BoardArticleCategoryCreateRequest
+import com.ttasjwi.board.system.board.domain.BoardArticleCategoryCreateResponse
+import com.ttasjwi.board.system.board.domain.BoardArticleCategoryCreateUseCase
+
+class BoardArticleCategoryCreateUseCaseFixture : BoardArticleCategoryCreateUseCase {
+
+
+    override fun create(boardId: Long, request: BoardArticleCategoryCreateRequest): BoardArticleCategoryCreateResponse {
+        return BoardArticleCategoryCreateResponse(
+            boardArticleCategoryId = "12435346",
+            boardId = boardId.toString(),
+            name = request.name!!,
+            slug = request.slug!!,
+            allowSelfDelete = request.allowSelfDelete!!,
+            allowLike = request.allowLike!!,
+            allowDislike = request.allowDislike!!,
+        )
+    }
+}

--- a/board-system-board/board-application-input-port/src/testFixtures/kotlin/com/ttasjwi/board/system/board/domain/fixture/BoardArticleCategoryCreateUseCaseFixture.kt
+++ b/board-system-board/board-application-input-port/src/testFixtures/kotlin/com/ttasjwi/board/system/board/domain/fixture/BoardArticleCategoryCreateUseCaseFixture.kt
@@ -3,6 +3,7 @@ package com.ttasjwi.board.system.board.domain.fixture
 import com.ttasjwi.board.system.board.domain.BoardArticleCategoryCreateRequest
 import com.ttasjwi.board.system.board.domain.BoardArticleCategoryCreateResponse
 import com.ttasjwi.board.system.board.domain.BoardArticleCategoryCreateUseCase
+import com.ttasjwi.board.system.common.time.fixture.appDateTimeFixture
 
 class BoardArticleCategoryCreateUseCaseFixture : BoardArticleCategoryCreateUseCase {
 
@@ -16,6 +17,7 @@ class BoardArticleCategoryCreateUseCaseFixture : BoardArticleCategoryCreateUseCa
             allowSelfDelete = request.allowSelfDelete!!,
             allowLike = request.allowLike!!,
             allowDislike = request.allowDislike!!,
+            createdAt = appDateTimeFixture(dayOfMonth = 1).toZonedDateTime(),
         )
     }
 }

--- a/board-system-board/board-application-output-port/src/main/kotlin/com/ttasjwi/board/system/board/domain/port/BoardArticleCategoryPersistencePort.kt
+++ b/board-system-board/board-application-output-port/src/main/kotlin/com/ttasjwi/board/system/board/domain/port/BoardArticleCategoryPersistencePort.kt
@@ -1,0 +1,12 @@
+package com.ttasjwi.board.system.board.domain.port
+
+import com.ttasjwi.board.system.board.domain.model.BoardArticleCategory
+
+interface BoardArticleCategoryPersistencePort {
+
+    fun save(boardArticleCategory: BoardArticleCategory): BoardArticleCategory
+    fun findByIdOrNull(boardArticleCategoryId: Long): BoardArticleCategory?
+
+    fun existsByName(boardId: Long, boardArticleCategoryName: String): Boolean
+    fun existsBySlug(boardId: Long, boardArticleCategorySlug: String): Boolean
+}

--- a/board-system-board/board-application-output-port/src/test/kotlin/com/ttasjwi/board/system/board/domain/port/BoardPersistencePortFixtureTest.kt
+++ b/board-system-board/board-application-output-port/src/test/kotlin/com/ttasjwi/board/system/board/domain/port/BoardPersistencePortFixtureTest.kt
@@ -33,7 +33,7 @@ class BoardPersistencePortFixtureTest {
 
             val changedBoard = boardPersistencePortFixture.save(
                 boardFixture(
-                    id = savedBoard.boardId,
+                    boardId = savedBoard.boardId,
                     name = "요리"
                 )
             )

--- a/board-system-board/board-application-output-port/src/test/kotlin/com/ttasjwi/board/system/board/domain/port/fixture/BoardArticleCategoryPersistencePortFixtureTest.kt
+++ b/board-system-board/board-application-output-port/src/test/kotlin/com/ttasjwi/board/system/board/domain/port/fixture/BoardArticleCategoryPersistencePortFixtureTest.kt
@@ -1,0 +1,197 @@
+package com.ttasjwi.board.system.board.domain.port.fixture
+
+import com.ttasjwi.board.system.board.domain.model.fixture.boardArticleCategoryFixture
+import com.ttasjwi.board.system.common.time.fixture.appDateTimeFixture
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("BoardArticleCategoryPersistencePortFixture 테스트")
+class BoardArticleCategoryPersistencePortFixtureTest {
+
+    private lateinit var boardArticleCategoryPersistencePortFixture: BoardArticleCategoryPersistencePortFixture
+
+    @BeforeEach
+    fun setup() {
+        boardArticleCategoryPersistencePortFixture = BoardArticleCategoryPersistencePortFixture()
+    }
+
+    @Nested
+    @DisplayName("save & find : 저장 후 조회 테스트")
+    inner class SaveAndFindTest {
+
+        @Test
+        @DisplayName("최초 생성 시 잘 저장되는 지 테스트")
+        fun testCreate() {
+            // given
+            val boardArticleCategory = boardArticleCategoryFixture(
+                boardArticleCategoryId = 123123677L,
+                name = "일반",
+                slug = "general",
+                boardId = 1234567899L,
+                allowSelfDelete = false,
+                allowLike = true,
+                allowDislike = true,
+                createdAt = appDateTimeFixture(hour = 12)
+            )
+
+            // when
+            boardArticleCategoryPersistencePortFixture.save(boardArticleCategory)
+            val findBoardArticleCategory =
+                boardArticleCategoryPersistencePortFixture.findByIdOrNull(boardArticleCategory.boardArticleCategoryId)!!
+
+            // then
+            assertThat(findBoardArticleCategory.boardArticleCategoryId).isEqualTo(boardArticleCategory.boardArticleCategoryId)
+            assertThat(findBoardArticleCategory.boardId).isEqualTo(boardArticleCategory.boardId)
+            assertThat(findBoardArticleCategory.name).isEqualTo(boardArticleCategory.name)
+            assertThat(findBoardArticleCategory.slug).isEqualTo(boardArticleCategory.slug)
+            assertThat(findBoardArticleCategory.allowSelfDelete).isEqualTo(boardArticleCategory.allowSelfDelete)
+            assertThat(findBoardArticleCategory.allowLike).isEqualTo(boardArticleCategory.allowLike)
+            assertThat(findBoardArticleCategory.allowDislike).isEqualTo(boardArticleCategory.allowDislike)
+            assertThat(findBoardArticleCategory.createdAt).isEqualTo(boardArticleCategory.createdAt)
+        }
+
+
+        @Test
+        @DisplayName("수정한 결과물을 저장 시, 수정한 결과물 상태로 변경되는 지 테스트")
+        fun testModified() {
+            // given
+            val boardArticleCategory = boardArticleCategoryFixture(
+                boardArticleCategoryId = 123123677L,
+                name = "일반",
+                slug = "general",
+                boardId = 1234567899L,
+                allowSelfDelete = false,
+                allowLike = true,
+                allowDislike = true,
+                createdAt = appDateTimeFixture(hour = 12)
+            )
+            boardArticleCategoryPersistencePortFixture.save(boardArticleCategory)
+
+
+            val modifiedBoardArticleCategory = boardArticleCategoryFixture(
+                boardArticleCategoryId = boardArticleCategory.boardArticleCategoryId,
+                name = boardArticleCategory.name,
+                slug = boardArticleCategory.slug,
+                boardId = 1234567899L,
+                allowSelfDelete = true,
+                allowLike = false,
+                allowDislike = false,
+                createdAt = boardArticleCategory.createdAt,
+            )
+            boardArticleCategoryPersistencePortFixture.save(modifiedBoardArticleCategory)
+
+            val findBoardArticleCategory = boardArticleCategoryPersistencePortFixture.findByIdOrNull(boardArticleCategory.boardArticleCategoryId)!!
+
+            // then
+            assertThat(findBoardArticleCategory.boardArticleCategoryId).isEqualTo(boardArticleCategory.boardArticleCategoryId)
+            assertThat(findBoardArticleCategory.boardId).isEqualTo(boardArticleCategory.boardId)
+            assertThat(findBoardArticleCategory.name).isEqualTo(boardArticleCategory.name)
+            assertThat(findBoardArticleCategory.slug).isEqualTo(boardArticleCategory.slug)
+            assertThat(findBoardArticleCategory.allowSelfDelete).isEqualTo(modifiedBoardArticleCategory.allowSelfDelete)
+            assertThat(findBoardArticleCategory.allowLike).isEqualTo(modifiedBoardArticleCategory.allowLike)
+            assertThat(findBoardArticleCategory.allowDislike).isEqualTo(modifiedBoardArticleCategory.allowDislike)
+            assertThat(findBoardArticleCategory.createdAt).isEqualTo(boardArticleCategory.createdAt)
+        }
+
+        @Test
+        @DisplayName("조회 결과물이 없으면 null 을 반환하는 지 테스트")
+        fun testNotFound() {
+            val findBoardArticleCategory = boardArticleCategoryPersistencePortFixture.findByIdOrNull(81233153L)
+
+            assertThat(findBoardArticleCategory).isNull()
+        }
+    }
+
+    @Nested
+    @DisplayName("existsByName : 게시글 카테고리 이름으로 존재 여부 확인")
+    inner class ExistsByNameTest {
+
+        @Test
+        @DisplayName("boardId, boardArticleCategoryName 이 일치하는 게시글 카테고리가 있으면 true 반환")
+        fun trueTest() {
+            // given
+            val boardArticleCategory = boardArticleCategoryPersistencePortFixture.save(
+                boardArticleCategoryFixture(
+                    boardArticleCategoryId = 123123677L,
+                    name = "일반",
+                    slug = "general",
+                    boardId = 1234567899L,
+                    allowSelfDelete = false,
+                    allowLike = true,
+                    allowDislike = true,
+                    createdAt = appDateTimeFixture(hour = 12)
+                )
+            )
+
+            // when
+            val exists = boardArticleCategoryPersistencePortFixture.existsByName(
+                boardId = boardArticleCategory.boardId,
+                boardArticleCategoryName = boardArticleCategory.name
+            )
+            assertThat(exists).isTrue()
+        }
+
+
+        @Test
+        @DisplayName("boardId, boardArticleCategoryName 이 일치하는 게시글 카테고리가 없으면 false 반환")
+        fun falseTest() {
+            // given
+            // when
+            val exists = boardArticleCategoryPersistencePortFixture.existsByName(
+                boardId = 5555568L,
+                boardArticleCategoryName = "고양이"
+            )
+
+            // then
+            assertThat(exists).isFalse()
+        }
+    }
+
+    @Nested
+    @DisplayName("existsBySlug : 게시글 카테고리 슬러그로 존재 여부 확인")
+    inner class ExistsBySlugTest {
+
+        @Test
+        @DisplayName("boardId, boardArticleCategorySlug 가 일치하는 게시글 카테고리가 있으면 true 반환")
+        fun trueTest() {
+            // given
+            val boardArticleCategory = boardArticleCategoryPersistencePortFixture.save(
+                boardArticleCategoryFixture(
+                    boardArticleCategoryId = 123123677L,
+                    name = "일반",
+                    slug = "general",
+                    boardId = 1234567899L,
+                    allowSelfDelete = false,
+                    allowLike = true,
+                    allowDislike = true,
+                    createdAt = appDateTimeFixture(hour = 12)
+                )
+            )
+
+            // when
+            val exists = boardArticleCategoryPersistencePortFixture.existsBySlug(
+                boardId = boardArticleCategory.boardId,
+                boardArticleCategorySlug = boardArticleCategory.slug
+            )
+            assertThat(exists).isTrue()
+        }
+
+
+        @Test
+        @DisplayName("boardId, boardArticleCategorySlug 가 일치하는 게시글 카테고리가 없으면 false 반환")
+        fun falseTest() {
+            // given
+            // when
+            val exists = boardArticleCategoryPersistencePortFixture.existsBySlug(
+                boardId = 5555568L,
+                boardArticleCategorySlug = "cat"
+            )
+
+            // then
+            assertThat(exists).isFalse()
+        }
+    }
+}

--- a/board-system-board/board-application-output-port/src/test/kotlin/com/ttasjwi/board/system/board/domain/port/fixture/BoardPersistencePortFixtureTest.kt
+++ b/board-system-board/board-application-output-port/src/test/kotlin/com/ttasjwi/board/system/board/domain/port/fixture/BoardPersistencePortFixtureTest.kt
@@ -1,4 +1,4 @@
-package com.ttasjwi.board.system.board.domain.port
+package com.ttasjwi.board.system.board.domain.port.fixture
 
 import com.ttasjwi.board.system.board.domain.model.fixture.boardFixture
 import org.assertj.core.api.Assertions.assertThat

--- a/board-system-board/board-application-output-port/src/testFixtures/kotlin/com/ttasjwi/board/system/board/domain/port/fixture/BoardArticleCategoryPersistencePortFixture.kt
+++ b/board-system-board/board-application-output-port/src/testFixtures/kotlin/com/ttasjwi/board/system/board/domain/port/fixture/BoardArticleCategoryPersistencePortFixture.kt
@@ -1,0 +1,26 @@
+package com.ttasjwi.board.system.board.domain.port.fixture
+
+import com.ttasjwi.board.system.board.domain.model.BoardArticleCategory
+import com.ttasjwi.board.system.board.domain.port.BoardArticleCategoryPersistencePort
+
+class BoardArticleCategoryPersistencePortFixture : BoardArticleCategoryPersistencePort {
+
+    private val storage = mutableMapOf<Long, BoardArticleCategory>()
+
+    override fun save(boardArticleCategory: BoardArticleCategory): BoardArticleCategory {
+        storage[boardArticleCategory.boardArticleCategoryId] = boardArticleCategory
+        return boardArticleCategory
+    }
+
+    override fun findByIdOrNull(boardArticleCategoryId: Long): BoardArticleCategory? {
+        return storage[boardArticleCategoryId]
+    }
+
+    override fun existsByName(boardId: Long, boardArticleCategoryName: String): Boolean {
+        return storage.values.any { it.boardId == boardId && it.name == boardArticleCategoryName}
+    }
+
+    override fun existsBySlug(boardId: Long, boardArticleCategorySlug: String): Boolean {
+        return storage.values.any { it.boardId == boardId && it.slug == boardArticleCategorySlug }
+    }
+}

--- a/board-system-board/board-application-output-port/src/testFixtures/kotlin/com/ttasjwi/board/system/board/domain/port/fixture/BoardPersistencePortFixture.kt
+++ b/board-system-board/board-application-output-port/src/testFixtures/kotlin/com/ttasjwi/board/system/board/domain/port/fixture/BoardPersistencePortFixture.kt
@@ -1,6 +1,7 @@
-package com.ttasjwi.board.system.board.domain.port
+package com.ttasjwi.board.system.board.domain.port.fixture
 
 import com.ttasjwi.board.system.board.domain.model.Board
+import com.ttasjwi.board.system.board.domain.port.BoardPersistencePort
 
 class BoardPersistencePortFixture : BoardPersistencePort {
 

--- a/board-system-board/board-application-service/src/main/kotlin/com/ttasjwi/board/system/board/domain/BoardArticleCategoryCreateUseCaseImpl.kt
+++ b/board-system-board/board-application-service/src/main/kotlin/com/ttasjwi/board/system/board/domain/BoardArticleCategoryCreateUseCaseImpl.kt
@@ -1,0 +1,32 @@
+package com.ttasjwi.board.system.board.domain
+
+import com.ttasjwi.board.system.board.domain.mapper.BoardArticleCategoryCreateCommandMapper
+import com.ttasjwi.board.system.board.domain.model.BoardArticleCategory
+import com.ttasjwi.board.system.board.domain.processor.BoardArticleCategoryCreateProcessor
+import com.ttasjwi.board.system.common.annotation.component.UseCase
+
+@UseCase
+internal class BoardArticleCategoryCreateUseCaseImpl(
+    private val commandMapper: BoardArticleCategoryCreateCommandMapper,
+    private val processor: BoardArticleCategoryCreateProcessor,
+) : BoardArticleCategoryCreateUseCase {
+
+    override fun create(boardId: Long, request: BoardArticleCategoryCreateRequest): BoardArticleCategoryCreateResponse {
+        val command = commandMapper.mapToCommand(boardId, request)
+        val boardArticleCategory = processor.create(command)
+        return makeResponse(boardArticleCategory)
+    }
+
+    private fun makeResponse(boardArticleCategory: BoardArticleCategory): BoardArticleCategoryCreateResponse {
+        return BoardArticleCategoryCreateResponse(
+            boardArticleCategoryId = boardArticleCategory.boardArticleCategoryId.toString(),
+            boardId = boardArticleCategory.boardId.toString(),
+            name = boardArticleCategory.name,
+            slug = boardArticleCategory.slug,
+            allowSelfDelete = boardArticleCategory.allowSelfDelete,
+            allowLike = boardArticleCategory.allowLike,
+            allowDislike = boardArticleCategory.allowDislike,
+            createdAt = boardArticleCategory.createdAt.toZonedDateTime(),
+        )
+    }
+}

--- a/board-system-board/board-application-service/src/main/kotlin/com/ttasjwi/board/system/board/domain/dto/BoardArticleCategoryCreateCommand.kt
+++ b/board-system-board/board-application-service/src/main/kotlin/com/ttasjwi/board/system/board/domain/dto/BoardArticleCategoryCreateCommand.kt
@@ -1,0 +1,15 @@
+package com.ttasjwi.board.system.board.domain.dto
+
+import com.ttasjwi.board.system.common.auth.AuthMember
+import com.ttasjwi.board.system.common.time.AppDateTime
+
+data class BoardArticleCategoryCreateCommand(
+    val boardId: Long,
+    val creator: AuthMember,
+    val boardArticleCategoryName: String,
+    val boardArticleCategorySlug: String,
+    val allowSelfDelete: Boolean,
+    val allowLike: Boolean,
+    val allowDislike: Boolean,
+    val currentTime: AppDateTime
+)

--- a/board-system-board/board-application-service/src/main/kotlin/com/ttasjwi/board/system/board/domain/mapper/BoardArticleCategoryCreateCommandMapper.kt
+++ b/board-system-board/board-application-service/src/main/kotlin/com/ttasjwi/board/system/board/domain/mapper/BoardArticleCategoryCreateCommandMapper.kt
@@ -1,0 +1,110 @@
+package com.ttasjwi.board.system.board.domain.mapper
+
+import com.ttasjwi.board.system.board.domain.BoardArticleCategoryCreateRequest
+import com.ttasjwi.board.system.board.domain.dto.BoardArticleCategoryCreateCommand
+import com.ttasjwi.board.system.board.domain.policy.BoardArticleCategoryNamePolicy
+import com.ttasjwi.board.system.board.domain.policy.BoardArticleCategorySlugPolicy
+import com.ttasjwi.board.system.common.annotation.component.ApplicationCommandMapper
+import com.ttasjwi.board.system.common.auth.AuthMemberLoader
+import com.ttasjwi.board.system.common.exception.NullArgumentException
+import com.ttasjwi.board.system.common.exception.ValidationExceptionCollector
+import com.ttasjwi.board.system.common.time.TimeManager
+
+@ApplicationCommandMapper
+internal class BoardArticleCategoryCreateCommandMapper(
+    private val boardArticleCategoryNamePolicy: BoardArticleCategoryNamePolicy,
+    private val boardArticleCategorySlugPolicy: BoardArticleCategorySlugPolicy,
+    private val authMemberLoader: AuthMemberLoader,
+    private val timeManager: TimeManager
+) {
+
+    fun mapToCommand(boardId: Long, request: BoardArticleCategoryCreateRequest): BoardArticleCategoryCreateCommand {
+        val exceptionCollector = ValidationExceptionCollector()
+
+        val boardArticleCategoryName = getBoardArticleCategoryName(request.name, exceptionCollector)
+        val boardArticleCategorySlug = getBoardArticleCategorySlug(request.slug, exceptionCollector)
+        val allowSelfDelete = getAllowSelfDelete(request.allowSelfDelete, exceptionCollector)
+        val allowLike = getAllowLike(request.allowLike, exceptionCollector)
+        val allowDislike = getAllowDislike(request.allowDislike, exceptionCollector)
+
+        exceptionCollector.throwIfNotEmpty()
+
+        return BoardArticleCategoryCreateCommand(
+            boardId = boardId,
+            creator = authMemberLoader.loadCurrentAuthMember()!!,
+            boardArticleCategoryName = boardArticleCategoryName!!,
+            boardArticleCategorySlug = boardArticleCategorySlug!!,
+            allowSelfDelete = allowSelfDelete!!,
+            allowLike = allowLike!!,
+            allowDislike = allowDislike!!,
+            currentTime = timeManager.now()
+        )
+    }
+
+    private fun getBoardArticleCategoryName(
+        boardArticleCategoryName: String?,
+        exceptionCollector: ValidationExceptionCollector
+    ): String? {
+        if (boardArticleCategoryName == null) {
+            exceptionCollector.addCustomExceptionOrThrow(
+                NullArgumentException("name")
+            )
+            return null
+        }
+        return boardArticleCategoryNamePolicy.validate(boardArticleCategoryName)
+            .getOrElse {
+                exceptionCollector.addCustomExceptionOrThrow(it)
+                return null
+            }
+    }
+
+    private fun getBoardArticleCategorySlug(
+        boardArticleCategorySlug: String?,
+        exceptionCollector: ValidationExceptionCollector
+    ): String? {
+        if (boardArticleCategorySlug == null) {
+            exceptionCollector.addCustomExceptionOrThrow(
+                NullArgumentException("slug")
+            )
+            return null
+        }
+        return boardArticleCategorySlugPolicy.validate(boardArticleCategorySlug)
+            .getOrElse {
+                exceptionCollector.addCustomExceptionOrThrow(it)
+                return null
+            }
+    }
+
+    private fun getAllowSelfDelete(
+        allowSelfDelete: Boolean?,
+        exceptionCollector: ValidationExceptionCollector
+    ): Boolean? {
+        if (allowSelfDelete == null) {
+            exceptionCollector.addCustomExceptionOrThrow(
+                NullArgumentException("allowSelfDelete")
+            )
+            return null
+        }
+        return allowSelfDelete
+    }
+
+    private fun getAllowLike(allowLike: Boolean?, exceptionCollector: ValidationExceptionCollector): Boolean? {
+        if (allowLike == null) {
+            exceptionCollector.addCustomExceptionOrThrow(
+                NullArgumentException("allowLike")
+            )
+            return null
+        }
+        return allowLike
+    }
+
+    private fun getAllowDislike(allowDislike: Boolean?, exceptionCollector: ValidationExceptionCollector): Boolean? {
+        if (allowDislike == null) {
+            exceptionCollector.addCustomExceptionOrThrow(
+                NullArgumentException("allowDislike")
+            )
+            return null
+        }
+        return allowDislike
+    }
+}

--- a/board-system-board/board-application-service/src/main/kotlin/com/ttasjwi/board/system/board/domain/processor/BoardArticleCategoryCreateProcessor.kt
+++ b/board-system-board/board-application-service/src/main/kotlin/com/ttasjwi/board/system/board/domain/processor/BoardArticleCategoryCreateProcessor.kt
@@ -1,0 +1,84 @@
+package com.ttasjwi.board.system.board.domain.processor
+
+import com.ttasjwi.board.system.board.domain.dto.BoardArticleCategoryCreateCommand
+import com.ttasjwi.board.system.board.domain.exception.BoardNotFoundException
+import com.ttasjwi.board.system.board.domain.exception.DuplicateBoardArticleCategoryNameException
+import com.ttasjwi.board.system.board.domain.exception.DuplicateBoardArticleCategorySlugException
+import com.ttasjwi.board.system.board.domain.exception.NoBoardArticleCategoryCreateAuthorityException
+import com.ttasjwi.board.system.board.domain.model.Board
+import com.ttasjwi.board.system.board.domain.model.BoardArticleCategory
+import com.ttasjwi.board.system.board.domain.port.BoardArticleCategoryPersistencePort
+import com.ttasjwi.board.system.board.domain.port.BoardPersistencePort
+import com.ttasjwi.board.system.common.annotation.component.ApplicationProcessor
+import com.ttasjwi.board.system.common.auth.AuthMember
+import com.ttasjwi.board.system.common.idgenerator.IdGenerator
+import org.springframework.transaction.annotation.Transactional
+
+@ApplicationProcessor
+class BoardArticleCategoryCreateProcessor(
+    private val boardPersistencePort: BoardPersistencePort,
+    private val boardArticleCategoryPersistencePort: BoardArticleCategoryPersistencePort,
+) {
+
+    private val boardArticleCategoryIdGenerator: IdGenerator = IdGenerator.create()
+
+    @Transactional
+    fun create(command: BoardArticleCategoryCreateCommand): BoardArticleCategory {
+        // 게시판 조회
+        val board = getBoardOrThrow(command.boardId)
+
+        // 권한 체크
+        checkBoardCreateAuthority(board, command.creator)
+
+        // 중복 체크
+        checkDuplication(command)
+
+        // 생성, 저장
+        val boardArticleCategory =  createBoardArticleCategoryAndPersist(command)
+
+        return boardArticleCategory
+    }
+
+    private fun getBoardOrThrow(boardId: Long): Board {
+        return boardPersistencePort.findByIdOrNull(boardId)
+            ?: throw BoardNotFoundException(
+                source = "boardId",
+                argument = boardId
+            )
+    }
+
+    private fun checkBoardCreateAuthority(board: Board, creator: AuthMember) {
+        if (board.managerId != creator.memberId) {
+            throw NoBoardArticleCategoryCreateAuthorityException(
+                boardManagerId = board.managerId,
+                creatorId = creator.memberId
+            )
+        }
+    }
+
+    private fun checkDuplication(command: BoardArticleCategoryCreateCommand) {
+        // 카테고리 이름 :  역시 그 게시판 내에서 중복되선 안 된다.
+        if (boardArticleCategoryPersistencePort.existsByName(command.boardId, command.boardArticleCategoryName)) {
+            throw DuplicateBoardArticleCategoryNameException(command.boardArticleCategoryName)
+        }
+        // 카테고리 슬러그 : 그 게시판 내에서 중복되선 안 된다.
+        if (boardArticleCategoryPersistencePort.existsBySlug(command.boardId, command.boardArticleCategorySlug)) {
+            throw DuplicateBoardArticleCategorySlugException(command.boardArticleCategorySlug)
+        }
+    }
+
+    private fun createBoardArticleCategoryAndPersist(command: BoardArticleCategoryCreateCommand): BoardArticleCategory {
+        val boardArticleCategory = BoardArticleCategory.create(
+            boardArticleCategoryId = boardArticleCategoryIdGenerator.nextId(),
+            boardId = command.boardId,
+            name = command.boardArticleCategoryName,
+            slug = command.boardArticleCategorySlug,
+            allowSelfDelete = command.allowSelfDelete,
+            allowLike = command.allowLike,
+            allowDislike = command.allowDislike,
+            createdAt = command.currentTime
+        )
+        boardArticleCategoryPersistencePort.save(boardArticleCategory)
+        return boardArticleCategory
+    }
+}

--- a/board-system-board/board-application-service/src/test/kotlin/com/ttasjwi/board/system/board/domain/BoardArticleCategoryCreateUseCaseImplTest.kt
+++ b/board-system-board/board-application-service/src/test/kotlin/com/ttasjwi/board/system/board/domain/BoardArticleCategoryCreateUseCaseImplTest.kt
@@ -1,0 +1,75 @@
+package com.ttasjwi.board.system.board.domain
+
+import com.ttasjwi.board.system.board.domain.model.Board
+import com.ttasjwi.board.system.board.domain.model.fixture.boardFixture
+import com.ttasjwi.board.system.board.domain.port.fixture.BoardArticleCategoryPersistencePortFixture
+import com.ttasjwi.board.system.board.domain.test.support.TestContainer
+import com.ttasjwi.board.system.common.auth.Role
+import com.ttasjwi.board.system.common.auth.fixture.authMemberFixture
+import com.ttasjwi.board.system.common.time.AppDateTime
+import com.ttasjwi.board.system.common.time.fixture.appDateTimeFixture
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("BoardArticleCategoryUseCaseImpl : 게시글 카테고리 생성 유즈케이스 구현체")
+class BoardArticleCategoryCreateUseCaseImplTest {
+
+    private lateinit var useCase: BoardArticleCategoryCreateUseCase
+    private lateinit var boardArticleCategoryPersistencePortFixture: BoardArticleCategoryPersistencePortFixture
+    private lateinit var savedBoard: Board
+    private lateinit var currentTime: AppDateTime
+
+    @BeforeEach
+    fun setup() {
+        val container = TestContainer.create()
+        useCase = container.boardArticleCategoryCreateUseCase
+        boardArticleCategoryPersistencePortFixture = container.boardArticleCategoryPersistencePortFixture
+        savedBoard = container.boardPersistencePortFixture.save(
+            boardFixture(
+                boardId = 1L,
+                name = "동물",
+                slug = "animal",
+                description = "고양이 게시판입니다.",
+                managerId = 1L,
+                createdAt = appDateTimeFixture(minute = 5)
+            )
+        )
+        currentTime = appDateTimeFixture(minute = 9)
+        container.timeManagerFixture.changeCurrentTime(currentTime)
+
+        container.authMemberLoaderFixture.changeAuthMember(authMemberFixture(savedBoard.managerId, Role.USER))
+    }
+
+
+    @Test
+    @DisplayName("성공")
+    fun test() {
+        // given
+        val boardId = savedBoard.boardId
+        val request = BoardArticleCategoryCreateRequest(
+            name = "일반",
+            slug = "general",
+            allowSelfDelete = true,
+            allowLike = true,
+            allowDislike = true
+        )
+        // when
+        val response = useCase.create(boardId, request)
+
+        // then
+        val findBoardArticleCategory = boardArticleCategoryPersistencePortFixture.findByIdOrNull(response.boardArticleCategoryId.toLong())!!
+
+        assertThat(response.boardArticleCategoryId).isNotNull()
+        assertThat(response.boardId).isEqualTo(boardId.toString())
+        assertThat(response.name).isEqualTo(request.name)
+        assertThat(response.slug).isEqualTo(request.slug)
+        assertThat(response.allowSelfDelete).isEqualTo(request.allowSelfDelete)
+        assertThat(response.allowLike).isEqualTo(request.allowLike)
+        assertThat(response.allowDislike).isEqualTo(request.allowDislike)
+        assertThat(response.createdAt).isEqualTo(currentTime.toZonedDateTime())
+
+        assertThat(findBoardArticleCategory.boardArticleCategoryId).isEqualTo(response.boardArticleCategoryId.toLong())
+    }
+}

--- a/board-system-board/board-application-service/src/test/kotlin/com/ttasjwi/board/system/board/domain/BoardCreateUseCaseImplTest.kt
+++ b/board-system-board/board-application-service/src/test/kotlin/com/ttasjwi/board/system/board/domain/BoardCreateUseCaseImplTest.kt
@@ -1,6 +1,6 @@
 package com.ttasjwi.board.system.board.domain
 
-import com.ttasjwi.board.system.board.domain.port.BoardPersistencePortFixture
+import com.ttasjwi.board.system.board.domain.port.fixture.BoardPersistencePortFixture
 import com.ttasjwi.board.system.board.domain.test.support.TestContainer
 import com.ttasjwi.board.system.common.auth.AuthMember
 import com.ttasjwi.board.system.common.auth.Role

--- a/board-system-board/board-application-service/src/test/kotlin/com/ttasjwi/board/system/board/domain/mapper/BoardArticleCategoryCreateCommandMapperTest.kt
+++ b/board-system-board/board-application-service/src/test/kotlin/com/ttasjwi/board/system/board/domain/mapper/BoardArticleCategoryCreateCommandMapperTest.kt
@@ -1,0 +1,247 @@
+package com.ttasjwi.board.system.board.domain.mapper
+
+import com.ttasjwi.board.system.board.domain.BoardArticleCategoryCreateRequest
+import com.ttasjwi.board.system.board.domain.policy.fixture.BoardArticleCategoryNamePolicyFixture
+import com.ttasjwi.board.system.board.domain.policy.fixture.BoardArticleCategorySlugPolicyFixture
+import com.ttasjwi.board.system.board.domain.test.support.TestContainer
+import com.ttasjwi.board.system.common.auth.AuthMember
+import com.ttasjwi.board.system.common.auth.Role
+import com.ttasjwi.board.system.common.auth.fixture.authMemberFixture
+import com.ttasjwi.board.system.common.exception.CustomException
+import com.ttasjwi.board.system.common.exception.NullArgumentException
+import com.ttasjwi.board.system.common.exception.ValidationExceptionCollector
+import com.ttasjwi.board.system.common.time.AppDateTime
+import com.ttasjwi.board.system.common.time.fixture.appDateTimeFixture
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+@DisplayName("BoardArticleCategoryCreateCommandMapper: 게시글 카테고리 생성명령 매퍼")
+class BoardArticleCategoryCreateCommandMapperTest {
+
+    private lateinit var commandMapper: BoardArticleCategoryCreateCommandMapper
+    private lateinit var currentTime: AppDateTime
+    private lateinit var authMember: AuthMember
+
+    @BeforeEach
+    fun setUp() {
+        val container = TestContainer.create()
+
+        commandMapper = container.boardArticleCategoryCreateCommandMapper
+        currentTime = appDateTimeFixture(minute = 5)
+        container.timeManagerFixture.changeCurrentTime(currentTime)
+
+        authMember = authMemberFixture(
+            memberId = 1557L,
+            role = Role.USER
+        )
+        container.authMemberLoaderFixture.changeAuthMember(authMember)
+    }
+
+
+    @Test
+    @DisplayName("성공 테스트")
+    fun testSuccess() {
+        // given
+        val boardId = 12L
+        val request = BoardArticleCategoryCreateRequest(
+            name = "일반",
+            slug = "general",
+            allowSelfDelete = true,
+            allowLike = false,
+            allowDislike = true,
+        )
+
+        // when
+        val command = commandMapper.mapToCommand(boardId, request)
+
+        // then
+        assertThat(command.boardId).isEqualTo(boardId)
+        assertThat(command.creator).isEqualTo(authMember)
+        assertThat(command.boardArticleCategoryName).isEqualTo(request.name)
+        assertThat(command.boardArticleCategorySlug).isEqualTo(request.slug)
+        assertThat(command.allowSelfDelete).isEqualTo(request.allowSelfDelete)
+        assertThat(command.allowLike).isEqualTo(request.allowLike)
+        assertThat(command.allowDislike).isEqualTo(request.allowDislike)
+        assertThat(command.currentTime).isEqualTo(currentTime)
+    }
+
+    @Test
+    @DisplayName("카테고리명 필드가 null 이면 예외가 발생한다.")
+    fun testBoardArticleCategoryNameNull() {
+        // given
+        val boardId = 12L
+        val request = BoardArticleCategoryCreateRequest(
+            name = null,
+            slug = "general",
+            allowSelfDelete = true,
+            allowLike = false,
+            allowDislike = true,
+        )
+
+        // when
+        val exceptionCollector = assertThrows<ValidationExceptionCollector> { commandMapper.mapToCommand(boardId, request) }
+
+        // then
+        val exceptions = exceptionCollector.getExceptions()
+        val exception = exceptions.first()
+
+        assertThat(exceptions.size).isEqualTo(1)
+        assertThat(exception).isInstanceOf(NullArgumentException::class.java)
+        assertThat(exception.source).isEqualTo("name")
+    }
+
+    @Test
+    @DisplayName("카테고리 이름 필드 포맷이 유효하지 않으면 예외가 발생한다.")
+    fun testInvalidBoardArticleCategoryNameFormat() {
+        // given
+        val boardId = 12L
+        val request = BoardArticleCategoryCreateRequest(
+            name = BoardArticleCategoryNamePolicyFixture.ERROR_NAME,
+            slug = "general",
+            allowSelfDelete = true,
+            allowLike = false,
+            allowDislike = true,
+        )
+
+        // when
+        val exceptionCollector = assertThrows<ValidationExceptionCollector> { commandMapper.mapToCommand(boardId, request) }
+
+        // then
+        val exceptions = exceptionCollector.getExceptions()
+        val exception = exceptions.first()
+
+        assertThat(exceptions.size).isEqualTo(1)
+        assertThat(exception).isInstanceOf(CustomException::class.java)
+        assertThat(exception.code).isEqualTo("Error.InvalidBoardArticleCategoryNameFormat")
+        assertThat(exception.debugMessage).isEqualTo("픽스쳐 예외 : 잘못된 게시글 카테고리 이름 포맷")
+    }
+
+    @Test
+    @DisplayName("카테고리 슬러그 필드가 null 이면 예외가 발생한다.")
+    fun testBoardArticleCategorySlugNull() {
+        // given
+        val boardId = 12L
+        val request = BoardArticleCategoryCreateRequest(
+            name = "일반",
+            slug = null,
+            allowSelfDelete = true,
+            allowLike = false,
+            allowDislike = true,
+        )
+
+        // when
+        val exceptionCollector = assertThrows<ValidationExceptionCollector> { commandMapper.mapToCommand(boardId, request) }
+
+        // then
+        val exceptions = exceptionCollector.getExceptions()
+        val exception = exceptions.first()
+
+        assertThat(exceptions.size).isEqualTo(1)
+        assertThat(exception).isInstanceOf(NullArgumentException::class.java)
+        assertThat(exception.source).isEqualTo("slug")
+    }
+
+    @Test
+    @DisplayName("카테고리 슬러그 필드 포맷이 유효하지 않으면 예외가 발생한다.")
+    fun testInvalidBoardArticleCategorySlugFormat() {
+        // given
+        val boardId = 12L
+        val request = BoardArticleCategoryCreateRequest(
+            name = "일반",
+            slug = BoardArticleCategorySlugPolicyFixture.ERROR_SLUG,
+            allowSelfDelete = true,
+            allowLike = false,
+            allowDislike = true,
+        )
+
+        // when
+        val exceptionCollector = assertThrows<ValidationExceptionCollector> { commandMapper.mapToCommand(boardId, request) }
+
+        // then
+        val exceptions = exceptionCollector.getExceptions()
+        val exception = exceptions.first()
+
+        assertThat(exceptions.size).isEqualTo(1)
+        assertThat(exception).isInstanceOf(CustomException::class.java)
+        assertThat(exception.code).isEqualTo("Error.InvalidBoardArticleCategorySlugFormat")
+        assertThat(exception.debugMessage).isEqualTo("픽스쳐 예외 : 잘못된 게시글 카테고리 슬러그 포맷")
+    }
+
+    @Test
+    @DisplayName("allowSelfDelete 필드가 null 이면 예외가 발생한다.")
+    fun testAllowSelfDeleteNull() {
+        // given
+        val boardId = 12L
+        val request = BoardArticleCategoryCreateRequest(
+            name = "일반",
+            slug = "general",
+            allowSelfDelete = null,
+            allowLike = false,
+            allowDislike = true,
+        )
+
+        // when
+        val exceptionCollector = assertThrows<ValidationExceptionCollector> { commandMapper.mapToCommand(boardId, request) }
+
+        // then
+        val exceptions = exceptionCollector.getExceptions()
+        val exception = exceptions.first()
+
+        assertThat(exceptions.size).isEqualTo(1)
+        assertThat(exception).isInstanceOf(NullArgumentException::class.java)
+        assertThat(exception.source).isEqualTo("allowSelfDelete")
+    }
+
+    @Test
+    @DisplayName("allowLike 필드가 null 이면 예외가 발생한다.")
+    fun testAllowLikeNull() {
+        // given
+        val boardId = 12L
+        val request = BoardArticleCategoryCreateRequest(
+            name = "일반",
+            slug = "general",
+            allowSelfDelete = true,
+            allowLike = null,
+            allowDislike = true,
+        )
+
+        // when
+        val exceptionCollector = assertThrows<ValidationExceptionCollector> { commandMapper.mapToCommand(boardId, request) }
+
+        // then
+        val exceptions = exceptionCollector.getExceptions()
+        val exception = exceptions.first()
+
+        assertThat(exceptions.size).isEqualTo(1)
+        assertThat(exception).isInstanceOf(NullArgumentException::class.java)
+        assertThat(exception.source).isEqualTo("allowLike")
+    }
+
+    @Test
+    @DisplayName("allowDislike 필드가 null 이면 예외가 발생한다.")
+    fun testAllowDislikeNull() {
+        // given
+        val boardId = 12L
+        val request = BoardArticleCategoryCreateRequest(
+            name = "일반",
+            slug = "general",
+            allowSelfDelete = true,
+            allowLike = false,
+            allowDislike = null,
+        )
+
+        // when
+        val exceptionCollector = assertThrows<ValidationExceptionCollector> { commandMapper.mapToCommand(boardId, request) }
+
+        // then
+        val exceptions = exceptionCollector.getExceptions()
+        val exception = exceptions.first()
+
+        assertThat(exceptions.size).isEqualTo(1)
+        assertThat(exception).isInstanceOf(NullArgumentException::class.java)
+        assertThat(exception.source).isEqualTo("allowDislike")
+    }
+}

--- a/board-system-board/board-application-service/src/test/kotlin/com/ttasjwi/board/system/board/domain/processor/BoardArticleCategoryCreateProcessorTest.kt
+++ b/board-system-board/board-application-service/src/test/kotlin/com/ttasjwi/board/system/board/domain/processor/BoardArticleCategoryCreateProcessorTest.kt
@@ -1,0 +1,201 @@
+package com.ttasjwi.board.system.board.domain.processor
+
+import com.ttasjwi.board.system.board.domain.dto.BoardArticleCategoryCreateCommand
+import com.ttasjwi.board.system.board.domain.exception.BoardNotFoundException
+import com.ttasjwi.board.system.board.domain.exception.DuplicateBoardArticleCategoryNameException
+import com.ttasjwi.board.system.board.domain.exception.DuplicateBoardArticleCategorySlugException
+import com.ttasjwi.board.system.board.domain.exception.NoBoardArticleCategoryCreateAuthorityException
+import com.ttasjwi.board.system.board.domain.model.Board
+import com.ttasjwi.board.system.board.domain.model.BoardArticleCategory
+import com.ttasjwi.board.system.board.domain.model.fixture.boardArticleCategoryFixture
+import com.ttasjwi.board.system.board.domain.model.fixture.boardFixture
+import com.ttasjwi.board.system.board.domain.port.fixture.BoardArticleCategoryPersistencePortFixture
+import com.ttasjwi.board.system.board.domain.port.fixture.BoardPersistencePortFixture
+import com.ttasjwi.board.system.board.domain.test.support.TestContainer
+import com.ttasjwi.board.system.common.auth.Role
+import com.ttasjwi.board.system.common.auth.fixture.authMemberFixture
+import com.ttasjwi.board.system.common.time.fixture.appDateTimeFixture
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+@DisplayName("BoardArticleCategoryCreateProcessor 테스트")
+class BoardArticleCategoryCreateProcessorTest {
+
+    private lateinit var processor: BoardArticleCategoryCreateProcessor
+    private lateinit var boardPersistencePortFixture: BoardPersistencePortFixture
+    private lateinit var boardArticleCategoryPersistencePortFixture: BoardArticleCategoryPersistencePortFixture
+    private lateinit var savedBoard: Board
+    private lateinit var savedBoardArticleCategory: BoardArticleCategory
+
+    @BeforeEach
+    fun setup() {
+        val container = TestContainer.create()
+        boardPersistencePortFixture = container.boardPersistencePortFixture
+        boardArticleCategoryPersistencePortFixture = container.boardArticleCategoryPersistencePortFixture
+        processor = container.boardArticleCategoryCreateProcessor
+
+        savedBoard = boardPersistencePortFixture.save(
+            boardFixture(
+                boardId = 1L,
+                name = "동물",
+                slug = "animal",
+                description = "고양이 게시판입니다.",
+                managerId = 1L,
+                createdAt = appDateTimeFixture(minute = 5)
+            )
+        )
+        savedBoardArticleCategory = boardArticleCategoryPersistencePortFixture.save(
+            boardArticleCategoryFixture(
+                boardArticleCategoryId = 1L,
+                name = "일반",
+                slug = "general",
+                boardId = savedBoard.boardId,
+                allowSelfDelete = true,
+                allowLike = true,
+                allowDislike = true
+            )
+        )
+    }
+
+
+    @Test
+    @DisplayName("성공 테스트")
+    fun testSuccess() {
+        // given
+        val command = BoardArticleCategoryCreateCommand(
+            boardId = savedBoard.boardId,
+            creator = authMemberFixture(memberId = savedBoard.managerId, role = Role.USER),
+            boardArticleCategoryName = "질문",
+            boardArticleCategorySlug = "question",
+            allowSelfDelete = false,
+            allowLike = true,
+            allowDislike = true,
+            currentTime = appDateTimeFixture(minute = 8)
+        )
+
+        // when
+        val boardArticleCategory = processor.create(command)
+
+        // then
+        val findBoardArticleCategory = boardArticleCategoryPersistencePortFixture.findByIdOrNull(boardArticleCategory.boardArticleCategoryId)!!
+
+        assertThat(boardArticleCategory.boardArticleCategoryId).isNotNull()
+        assertThat(boardArticleCategory.boardId).isEqualTo(command.boardId)
+        assertThat(boardArticleCategory.name).isEqualTo(command.boardArticleCategoryName)
+        assertThat(boardArticleCategory.slug).isEqualTo(command.boardArticleCategorySlug)
+        assertThat(boardArticleCategory.allowSelfDelete).isEqualTo(command.allowSelfDelete)
+        assertThat(boardArticleCategory.allowLike).isEqualTo(command.allowLike)
+        assertThat(boardArticleCategory.allowDislike).isEqualTo(command.allowDislike)
+        assertThat(boardArticleCategory.createdAt).isEqualTo(command.currentTime)
+
+        assertThat(findBoardArticleCategory.boardArticleCategoryId).isEqualTo(boardArticleCategory.boardArticleCategoryId)
+        assertThat(findBoardArticleCategory.boardId).isEqualTo(boardArticleCategory.boardId)
+        assertThat(findBoardArticleCategory.name).isEqualTo(boardArticleCategory.name)
+        assertThat(findBoardArticleCategory.slug).isEqualTo(boardArticleCategory.slug)
+        assertThat(findBoardArticleCategory.allowSelfDelete).isEqualTo(boardArticleCategory.allowSelfDelete)
+        assertThat(findBoardArticleCategory.allowLike).isEqualTo(boardArticleCategory.allowLike)
+        assertThat(findBoardArticleCategory.allowDislike).isEqualTo(boardArticleCategory.allowDislike)
+        assertThat(findBoardArticleCategory.createdAt).isEqualTo(boardArticleCategory.createdAt)
+    }
+
+
+    @Test
+    @DisplayName("게시판 조회 실패 시, 예외 발생")
+    fun testBoardNotFound() {
+        // given
+        val command = BoardArticleCategoryCreateCommand(
+            boardId = 2L,
+            creator = authMemberFixture(memberId = 1L, role = Role.USER),
+            boardArticleCategoryName = "질문",
+            boardArticleCategorySlug = "question",
+            allowSelfDelete = false,
+            allowLike = true,
+            allowDislike = true,
+            currentTime = appDateTimeFixture(minute = 8)
+        )
+        // when
+        // then
+        val ex = assertThrows<BoardNotFoundException> {
+            processor.create(command)
+        }
+
+        assertThat(ex).isInstanceOf(BoardNotFoundException::class.java)
+        assertThat(ex.source).isEqualTo("boardId")
+        assertThat(ex.args).containsExactly("boardId", command.boardId)
+    }
+
+
+    @Test
+    @DisplayName("게시물 카테고리 생성 권한 없을 때 예외 발생")
+    fun testNoAuthority() {
+        // given
+        val command = BoardArticleCategoryCreateCommand(
+            boardId = savedBoard.boardId,
+            creator = authMemberFixture(memberId = 2L, role = Role.USER),
+            boardArticleCategoryName = "질문",
+            boardArticleCategorySlug = "question",
+            allowSelfDelete = false,
+            allowLike = true,
+            allowDislike = true,
+            currentTime = appDateTimeFixture(minute = 8)
+        )
+
+        // when
+        // then
+        val ex = assertThrows<NoBoardArticleCategoryCreateAuthorityException> {
+            processor.create(command)
+        }
+        assertThat(ex.message).isEqualTo("카테고리를 추가할 권한이 없습니다. 게시판의 관리자가 아닙니다. (boardManagerId = ${savedBoard.managerId}, creatorId = ${command.creator.memberId})")
+    }
+
+
+    @Test
+    @DisplayName("게시물 카테고리명이 중복되면 예외 발생")
+    fun testDuplicateCategoryName() {
+        // given
+        val command = BoardArticleCategoryCreateCommand(
+            boardId = savedBoard.boardId,
+            creator = authMemberFixture(memberId = 1L, role = Role.USER),
+            boardArticleCategoryName = savedBoardArticleCategory.name,
+            boardArticleCategorySlug = "gnr",
+            allowSelfDelete = false,
+            allowLike = true,
+            allowDislike = true,
+            currentTime = appDateTimeFixture(minute = 8)
+        )
+        // when
+        // then
+        val ex = assertThrows<DuplicateBoardArticleCategoryNameException> {
+            processor.create(command)
+        }
+        assertThat(ex.args).containsExactly(command.boardArticleCategoryName)
+        assertThat(ex.debugMessage).isEqualTo("게시판 내에서 게시글 카테고리명이 중복됩니다. (boardArticleCategoryName = ${command.boardArticleCategoryName})")
+    }
+
+    @Test
+    @DisplayName("게시물 카테고리 슬러그가 중복되면 예외 발생")
+    fun testDuplicateCategorySlug() {
+        // given
+        val command = BoardArticleCategoryCreateCommand(
+            boardId = savedBoard.boardId,
+            creator = authMemberFixture(memberId = 1L, role = Role.USER),
+            boardArticleCategoryName = "질문",
+            boardArticleCategorySlug = savedBoardArticleCategory.slug,
+            allowSelfDelete = false,
+            allowLike = true,
+            allowDislike = true,
+            currentTime = appDateTimeFixture(minute = 8)
+        )
+
+        // when
+        // then
+        val ex = assertThrows<DuplicateBoardArticleCategorySlugException> {
+            processor.create(command)
+        }
+        assertThat(ex.args).containsExactly(command.boardArticleCategorySlug)
+        assertThat(ex.debugMessage).isEqualTo("게시판 내에서 게시글 카테고리 슬러그가 중복됩니다. (boardArticleCategorySlug = ${command.boardArticleCategorySlug})")
+    }
+}

--- a/board-system-board/board-application-service/src/test/kotlin/com/ttasjwi/board/system/board/domain/processor/BoardCreateProcessorTest.kt
+++ b/board-system-board/board-application-service/src/test/kotlin/com/ttasjwi/board/system/board/domain/processor/BoardCreateProcessorTest.kt
@@ -30,7 +30,7 @@ class BoardCreateProcessorTest {
         processor = container.boardCreateProcessor
         savedBoard = boardPersistencePortFixture.save(
             boardFixture(
-                id = 1234L,
+                boardId = 1234L,
                 name = "등록된",
                 slug = "registered"
             )

--- a/board-system-board/board-application-service/src/test/kotlin/com/ttasjwi/board/system/board/domain/processor/BoardCreateProcessorTest.kt
+++ b/board-system-board/board-application-service/src/test/kotlin/com/ttasjwi/board/system/board/domain/processor/BoardCreateProcessorTest.kt
@@ -5,7 +5,7 @@ import com.ttasjwi.board.system.board.domain.exception.DuplicateBoardNameExcepti
 import com.ttasjwi.board.system.board.domain.exception.DuplicateBoardSlugException
 import com.ttasjwi.board.system.board.domain.model.Board
 import com.ttasjwi.board.system.board.domain.model.fixture.boardFixture
-import com.ttasjwi.board.system.board.domain.port.BoardPersistencePortFixture
+import com.ttasjwi.board.system.board.domain.port.fixture.BoardPersistencePortFixture
 import com.ttasjwi.board.system.board.domain.test.support.TestContainer
 import com.ttasjwi.board.system.common.auth.Role
 import com.ttasjwi.board.system.common.auth.fixture.authMemberFixture

--- a/board-system-board/board-application-service/src/test/kotlin/com/ttasjwi/board/system/board/domain/test/support/TestContainer.kt
+++ b/board-system-board/board-application-service/src/test/kotlin/com/ttasjwi/board/system/board/domain/test/support/TestContainer.kt
@@ -6,7 +6,7 @@ import com.ttasjwi.board.system.board.domain.mapper.BoardCreateCommandMapper
 import com.ttasjwi.board.system.board.domain.policy.fixture.BoardDescriptionPolicyFixture
 import com.ttasjwi.board.system.board.domain.policy.fixture.BoardNamePolicyFixture
 import com.ttasjwi.board.system.board.domain.policy.fixture.BoardSlugPolicyFixture
-import com.ttasjwi.board.system.board.domain.port.BoardPersistencePortFixture
+import com.ttasjwi.board.system.board.domain.port.fixture.BoardPersistencePortFixture
 import com.ttasjwi.board.system.board.domain.processor.BoardCreateProcessor
 import com.ttasjwi.board.system.common.auth.fixture.AuthMemberLoaderFixture
 import com.ttasjwi.board.system.common.time.fixture.TimeManagerFixture

--- a/board-system-board/board-application-service/src/test/kotlin/com/ttasjwi/board/system/board/domain/test/support/TestContainer.kt
+++ b/board-system-board/board-application-service/src/test/kotlin/com/ttasjwi/board/system/board/domain/test/support/TestContainer.kt
@@ -1,12 +1,15 @@
 package com.ttasjwi.board.system.board.domain.test.support
 
+import com.ttasjwi.board.system.board.domain.BoardArticleCategoryCreateUseCase
+import com.ttasjwi.board.system.board.domain.BoardArticleCategoryCreateUseCaseImpl
 import com.ttasjwi.board.system.board.domain.BoardCreateUseCase
 import com.ttasjwi.board.system.board.domain.BoardCreateUseCaseImpl
+import com.ttasjwi.board.system.board.domain.mapper.BoardArticleCategoryCreateCommandMapper
 import com.ttasjwi.board.system.board.domain.mapper.BoardCreateCommandMapper
-import com.ttasjwi.board.system.board.domain.policy.fixture.BoardDescriptionPolicyFixture
-import com.ttasjwi.board.system.board.domain.policy.fixture.BoardNamePolicyFixture
-import com.ttasjwi.board.system.board.domain.policy.fixture.BoardSlugPolicyFixture
+import com.ttasjwi.board.system.board.domain.policy.fixture.*
+import com.ttasjwi.board.system.board.domain.port.fixture.BoardArticleCategoryPersistencePortFixture
 import com.ttasjwi.board.system.board.domain.port.fixture.BoardPersistencePortFixture
+import com.ttasjwi.board.system.board.domain.processor.BoardArticleCategoryCreateProcessor
 import com.ttasjwi.board.system.board.domain.processor.BoardCreateProcessor
 import com.ttasjwi.board.system.common.auth.fixture.AuthMemberLoaderFixture
 import com.ttasjwi.board.system.common.time.fixture.TimeManagerFixture
@@ -25,11 +28,16 @@ internal class TestContainer private constructor() {
 
     // port
     val boardPersistencePortFixture: BoardPersistencePortFixture by lazy { BoardPersistencePortFixture() }
+    val boardArticleCategoryPersistencePortFixture: BoardArticleCategoryPersistencePortFixture by lazy { BoardArticleCategoryPersistencePortFixture() }
 
     // policy
     val boardNamePolicyFixture: BoardNamePolicyFixture by lazy { BoardNamePolicyFixture() }
     val boardDescriptionPolicyFixture: BoardDescriptionPolicyFixture by lazy { BoardDescriptionPolicyFixture() }
     val boardSlugPolicyFixture: BoardSlugPolicyFixture by lazy { BoardSlugPolicyFixture() }
+
+    val boardArticleCategoryNamePolicyFixture: BoardArticleCategoryNamePolicyFixture by lazy { BoardArticleCategoryNamePolicyFixture() }
+    val boardArticleCategorySlugPolicyFixture: BoardArticleCategorySlugPolicyFixture by lazy { BoardArticleCategorySlugPolicyFixture() }
+
 
     // mapper
     val boardCreateCommandMapper: BoardCreateCommandMapper by lazy {
@@ -42,10 +50,26 @@ internal class TestContainer private constructor() {
         )
     }
 
+    val boardArticleCategoryCreateCommandMapper : BoardArticleCategoryCreateCommandMapper by lazy {
+        BoardArticleCategoryCreateCommandMapper(
+            boardArticleCategoryNamePolicy = boardArticleCategoryNamePolicyFixture,
+            boardArticleCategorySlugPolicy = boardArticleCategorySlugPolicyFixture,
+            authMemberLoader = authMemberLoaderFixture,
+            timeManager = timeManagerFixture
+        )
+    }
+
     // processor
     val boardCreateProcessor: BoardCreateProcessor by lazy {
         BoardCreateProcessor(
             boardPersistencePort = boardPersistencePortFixture,
+        )
+    }
+
+    val boardArticleCategoryCreateProcessor: BoardArticleCategoryCreateProcessor by lazy {
+        BoardArticleCategoryCreateProcessor(
+            boardPersistencePort = boardPersistencePortFixture,
+            boardArticleCategoryPersistencePort = boardArticleCategoryPersistencePortFixture,
         )
     }
 
@@ -54,6 +78,13 @@ internal class TestContainer private constructor() {
         BoardCreateUseCaseImpl(
             commandMapper = boardCreateCommandMapper,
             processor = boardCreateProcessor,
+        )
+    }
+
+    val boardArticleCategoryCreateUseCase: BoardArticleCategoryCreateUseCase by lazy {
+        BoardArticleCategoryCreateUseCaseImpl(
+            commandMapper = boardArticleCategoryCreateCommandMapper,
+            processor = boardArticleCategoryCreateProcessor
         )
     }
 }

--- a/board-system-board/board-database-adapter/src/main/kotlin/com/ttasjwi/board/system/board/infra/persistence/BoardArticleCategoryPersistenceAdapter.kt
+++ b/board-system-board/board-database-adapter/src/main/kotlin/com/ttasjwi/board/system/board/infra/persistence/BoardArticleCategoryPersistenceAdapter.kt
@@ -1,0 +1,34 @@
+package com.ttasjwi.board.system.board.infra.persistence
+
+import com.ttasjwi.board.system.board.domain.model.BoardArticleCategory
+import com.ttasjwi.board.system.board.domain.port.BoardArticleCategoryPersistencePort
+import com.ttasjwi.board.system.board.infra.persistence.jpa.JpaBoardArticleCategory
+import com.ttasjwi.board.system.board.infra.persistence.jpa.JpaBoardArticleCategoryRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+
+@Component
+class BoardArticleCategoryPersistenceAdapter(
+    private val jpaBoardArticleCategoryRepository: JpaBoardArticleCategoryRepository
+) : BoardArticleCategoryPersistencePort {
+
+    override fun save(boardArticleCategory: BoardArticleCategory): BoardArticleCategory {
+        val jpaModel = JpaBoardArticleCategory.from(boardArticleCategory)
+        jpaBoardArticleCategoryRepository.save(jpaModel)
+        return boardArticleCategory
+    }
+
+    override fun findByIdOrNull(boardArticleCategoryId: Long): BoardArticleCategory? {
+        return jpaBoardArticleCategoryRepository
+            .findByIdOrNull(boardArticleCategoryId)
+            ?.restoreDomain()
+    }
+
+    override fun existsByName(boardId: Long, boardArticleCategoryName: String): Boolean {
+        return jpaBoardArticleCategoryRepository.existsByBoardIdAndName(boardId, boardArticleCategoryName)
+    }
+
+    override fun existsBySlug(boardId: Long, boardArticleCategorySlug: String): Boolean {
+        return jpaBoardArticleCategoryRepository.existsByBoardIdAndSlug(boardId, boardArticleCategorySlug)
+    }
+}

--- a/board-system-board/board-database-adapter/src/main/kotlin/com/ttasjwi/board/system/board/infra/persistence/jpa/JpaBoardArticleCategory.kt
+++ b/board-system-board/board-database-adapter/src/main/kotlin/com/ttasjwi/board/system/board/infra/persistence/jpa/JpaBoardArticleCategory.kt
@@ -1,0 +1,68 @@
+package com.ttasjwi.board.system.board.infra.persistence.jpa
+
+import com.ttasjwi.board.system.board.domain.model.BoardArticleCategory
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "board_article_categories")
+class JpaBoardArticleCategory(
+
+    @Id
+    @Column(name = "board_article_category_id")
+    val boardArticleCategoryId: Long,
+
+    @Column(name = "board_id", nullable = false)
+    val boardId: Long,
+
+    @Column(name = "name", length = 20, nullable = false)
+    var name: String,
+
+    @Column(name = "slug", length = 8, nullable = false)
+    var slug: String,
+
+    @Column(name = "allow_self_delete", nullable = false)
+    var allowSelfDelete: Boolean,
+
+    @Column(name = "allow_like", nullable = false)
+    var allowLike: Boolean,
+
+    @Column(name = "allow_dislike", nullable = false)
+    var allowDislike: Boolean,
+
+    @Column(name = "created_at", columnDefinition = "DATETIME", nullable = false)
+    val createdAt: LocalDateTime,
+) {
+
+    companion object {
+
+        fun from(boardArticleCategory: BoardArticleCategory): JpaBoardArticleCategory {
+            return JpaBoardArticleCategory(
+                boardArticleCategoryId = boardArticleCategory.boardArticleCategoryId,
+                boardId = boardArticleCategory.boardId,
+                name = boardArticleCategory.name,
+                slug = boardArticleCategory.slug,
+                allowSelfDelete = boardArticleCategory.allowSelfDelete,
+                allowLike = boardArticleCategory.allowLike,
+                allowDislike = boardArticleCategory.allowDislike,
+                createdAt = boardArticleCategory.createdAt.toLocalDateTime(),
+            )
+        }
+    }
+
+    internal fun restoreDomain(): BoardArticleCategory {
+        return BoardArticleCategory.restore(
+            boardArticleCategoryId = boardArticleCategoryId,
+            boardId = boardId,
+            name = name,
+            slug = slug,
+            allowSelfDelete = allowSelfDelete,
+            allowLike = allowLike,
+            allowDislike = allowDislike,
+            createdAt = createdAt,
+        )
+    }
+}

--- a/board-system-board/board-database-adapter/src/main/kotlin/com/ttasjwi/board/system/board/infra/persistence/jpa/JpaBoardArticleCategoryRepository.kt
+++ b/board-system-board/board-database-adapter/src/main/kotlin/com/ttasjwi/board/system/board/infra/persistence/jpa/JpaBoardArticleCategoryRepository.kt
@@ -1,0 +1,9 @@
+package com.ttasjwi.board.system.board.infra.persistence.jpa
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JpaBoardArticleCategoryRepository : JpaRepository<JpaBoardArticleCategory, Long> {
+
+    fun existsByBoardIdAndName(boardId: Long, name: String): Boolean
+    fun existsByBoardIdAndSlug(boardId: Long, slug: String): Boolean
+}

--- a/board-system-board/board-database-adapter/src/test/kotlin/com/ttasjwi/board/system/board/infra/persistence/BoardArticleCategoryPersistenceAdapterTest.kt
+++ b/board-system-board/board-database-adapter/src/test/kotlin/com/ttasjwi/board/system/board/infra/persistence/BoardArticleCategoryPersistenceAdapterTest.kt
@@ -1,0 +1,194 @@
+package com.ttasjwi.board.system.board.infra.persistence
+
+import com.ttasjwi.board.system.board.domain.model.fixture.boardArticleCategoryFixture
+import com.ttasjwi.board.system.board.infra.test.BoardDataBaseIntegrationTest
+import com.ttasjwi.board.system.common.time.fixture.appDateTimeFixture
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("BoardArticleCategoryPersistenceAdapter 테스트")
+class BoardArticleCategoryPersistenceAdapterTest : BoardDataBaseIntegrationTest() {
+
+    @Nested
+    @DisplayName("save & find : 저장 후 조회 테스트")
+    inner class SaveAndFindTest {
+
+        @Test
+        @DisplayName("최초 생성 시 잘 저장되는 지 테스트")
+        fun testCreate() {
+            // given
+            val boardArticleCategory = boardArticleCategoryFixture(
+                boardArticleCategoryId = 123123677L,
+                name = "일반",
+                slug = "general",
+                boardId = 1234567899L,
+                allowSelfDelete = false,
+                allowLike = true,
+                allowDislike = true,
+                createdAt = appDateTimeFixture(hour = 12)
+            )
+
+            // when
+            boardArticleCategoryPersistenceAdapter.save(boardArticleCategory)
+            flushAndClearEntityManager()
+            val findBoardArticleCategory =
+                boardArticleCategoryPersistenceAdapter.findByIdOrNull(boardArticleCategory.boardArticleCategoryId)!!
+
+            // then
+            assertThat(findBoardArticleCategory.boardArticleCategoryId).isEqualTo(boardArticleCategory.boardArticleCategoryId)
+            assertThat(findBoardArticleCategory.boardId).isEqualTo(boardArticleCategory.boardId)
+            assertThat(findBoardArticleCategory.name).isEqualTo(boardArticleCategory.name)
+            assertThat(findBoardArticleCategory.slug).isEqualTo(boardArticleCategory.slug)
+            assertThat(findBoardArticleCategory.allowSelfDelete).isEqualTo(boardArticleCategory.allowSelfDelete)
+            assertThat(findBoardArticleCategory.allowLike).isEqualTo(boardArticleCategory.allowLike)
+            assertThat(findBoardArticleCategory.allowDislike).isEqualTo(boardArticleCategory.allowDislike)
+            assertThat(findBoardArticleCategory.createdAt).isEqualTo(boardArticleCategory.createdAt)
+        }
+
+
+        @Test
+        @DisplayName("수정한 결과물을 저장 시, 수정한 결과물 상태로 변경되는 지 테스트")
+        fun testModified() {
+            // given
+            val boardArticleCategory = boardArticleCategoryFixture(
+                boardArticleCategoryId = 123123677L,
+                name = "일반",
+                slug = "general",
+                boardId = 1234567899L,
+                allowSelfDelete = false,
+                allowLike = true,
+                allowDislike = true,
+                createdAt = appDateTimeFixture(hour = 12)
+            )
+            boardArticleCategoryPersistenceAdapter.save(boardArticleCategory)
+
+
+            val modifiedBoardArticleCategory = boardArticleCategoryFixture(
+                boardArticleCategoryId = boardArticleCategory.boardArticleCategoryId,
+                name = boardArticleCategory.name,
+                slug = boardArticleCategory.slug,
+                boardId = 1234567899L,
+                allowSelfDelete = true,
+                allowLike = false,
+                allowDislike = false,
+                createdAt = boardArticleCategory.createdAt,
+            )
+            boardArticleCategoryPersistenceAdapter.save(modifiedBoardArticleCategory)
+
+            flushAndClearEntityManager()
+            val findBoardArticleCategory = boardArticleCategoryPersistenceAdapter.findByIdOrNull(boardArticleCategory.boardArticleCategoryId)!!
+
+            // then
+            assertThat(findBoardArticleCategory.boardArticleCategoryId).isEqualTo(boardArticleCategory.boardArticleCategoryId)
+            assertThat(findBoardArticleCategory.boardId).isEqualTo(boardArticleCategory.boardId)
+            assertThat(findBoardArticleCategory.name).isEqualTo(boardArticleCategory.name)
+            assertThat(findBoardArticleCategory.slug).isEqualTo(boardArticleCategory.slug)
+            assertThat(findBoardArticleCategory.allowSelfDelete).isEqualTo(modifiedBoardArticleCategory.allowSelfDelete)
+            assertThat(findBoardArticleCategory.allowLike).isEqualTo(modifiedBoardArticleCategory.allowLike)
+            assertThat(findBoardArticleCategory.allowDislike).isEqualTo(modifiedBoardArticleCategory.allowDislike)
+            assertThat(findBoardArticleCategory.createdAt).isEqualTo(boardArticleCategory.createdAt)
+        }
+
+        @Test
+        @DisplayName("조회 결과물이 없으면 null 을 반환하는 지 테스트")
+        fun testNotFound() {
+            val findBoardArticleCategory = boardArticleCategoryPersistenceAdapter.findByIdOrNull(81233153L)
+
+            assertThat(findBoardArticleCategory).isNull()
+        }
+    }
+
+    @Nested
+    @DisplayName("existsByName : 게시글 카테고리 이름으로 존재 여부 확인")
+    inner class ExistsByNameTest {
+
+        @Test
+        @DisplayName("boardId, boardArticleCategoryName 이 일치하는 게시글 카테고리가 있으면 true 반환")
+        fun trueTest() {
+            // given
+            val boardArticleCategory = boardArticleCategoryPersistenceAdapter.save(
+                boardArticleCategoryFixture(
+                    boardArticleCategoryId = 123123677L,
+                    name = "일반",
+                    slug = "general",
+                    boardId = 1234567899L,
+                    allowSelfDelete = false,
+                    allowLike = true,
+                    allowDislike = true,
+                    createdAt = appDateTimeFixture(hour = 12)
+                )
+            )
+            flushAndClearEntityManager()
+
+            // when
+            val exists = boardArticleCategoryPersistenceAdapter.existsByName(
+                boardId = boardArticleCategory.boardId,
+                boardArticleCategoryName = boardArticleCategory.name
+            )
+            assertThat(exists).isTrue()
+        }
+
+
+        @Test
+        @DisplayName("boardId, boardArticleCategoryName 이 일치하는 게시글 카테고리가 없으면 false 반환")
+        fun falseTest() {
+            // given
+            // when
+            val exists = boardArticleCategoryPersistenceAdapter.existsByName(
+                boardId = 5555568L,
+                boardArticleCategoryName = "고양이"
+            )
+
+            // then
+            assertThat(exists).isFalse()
+        }
+    }
+
+    @Nested
+    @DisplayName("existsBySlug : 게시글 카테고리 슬러그로 존재 여부 확인")
+    inner class ExistsBySlugTest {
+
+        @Test
+        @DisplayName("boardId, boardArticleCategorySlug 가 일치하는 게시글 카테고리가 있으면 true 반환")
+        fun trueTest() {
+            // given
+            val boardArticleCategory = boardArticleCategoryPersistenceAdapter.save(
+                boardArticleCategoryFixture(
+                    boardArticleCategoryId = 123123677L,
+                    name = "일반",
+                    slug = "general",
+                    boardId = 1234567899L,
+                    allowSelfDelete = false,
+                    allowLike = true,
+                    allowDislike = true,
+                    createdAt = appDateTimeFixture(hour = 12)
+                )
+            )
+            flushAndClearEntityManager()
+
+            // when
+            val exists = boardArticleCategoryPersistenceAdapter.existsBySlug(
+                boardId = boardArticleCategory.boardId,
+                boardArticleCategorySlug = boardArticleCategory.slug
+            )
+            assertThat(exists).isTrue()
+        }
+
+
+        @Test
+        @DisplayName("boardId, boardArticleCategorySlug 가 일치하는 게시글 카테고리가 없으면 false 반환")
+        fun falseTest() {
+            // given
+            // when
+            val exists = boardArticleCategoryPersistenceAdapter.existsBySlug(
+                boardId = 5555568L,
+                boardArticleCategorySlug = "cat"
+            )
+
+            // then
+            assertThat(exists).isFalse()
+        }
+    }
+}

--- a/board-system-board/board-database-adapter/src/test/kotlin/com/ttasjwi/board/system/board/infra/persistence/BoardPersistenceAdapterTest.kt
+++ b/board-system-board/board-database-adapter/src/test/kotlin/com/ttasjwi/board/system/board/infra/persistence/BoardPersistenceAdapterTest.kt
@@ -20,14 +20,14 @@ class BoardPersistenceAdapterTest : BoardDataBaseIntegrationTest() {
             // given
             val savedBoard = boardPersistenceAdapter.save(
                 boardFixture(
-                    id = 1234L,
+                    boardId = 1234L,
                     name = "음식"
                 )
             )
 
             val changedBoard = boardPersistenceAdapter.save(
                 boardFixture(
-                    id = savedBoard.boardId,
+                    boardId = savedBoard.boardId,
                     name = "요리"
                 )
             )
@@ -54,7 +54,7 @@ class BoardPersistenceAdapterTest : BoardDataBaseIntegrationTest() {
             // given
             val board = boardPersistenceAdapter.save(
                 boardFixture(
-                    id = 12345677L,
+                    boardId = 12345677L,
                 )
             )
             flushAndClearEntityManager()

--- a/board-system-board/board-database-adapter/src/test/kotlin/com/ttasjwi/board/system/board/infra/test/BoardDataBaseIntegrationTest.kt
+++ b/board-system-board/board-database-adapter/src/test/kotlin/com/ttasjwi/board/system/board/infra/test/BoardDataBaseIntegrationTest.kt
@@ -1,5 +1,6 @@
 package com.ttasjwi.board.system.board.infra.test
 
+import com.ttasjwi.board.system.board.infra.persistence.BoardArticleCategoryPersistenceAdapter
 import com.ttasjwi.board.system.board.infra.persistence.BoardPersistenceAdapter
 import jakarta.persistence.EntityManager
 import org.springframework.beans.factory.annotation.Autowired
@@ -12,6 +13,9 @@ abstract class BoardDataBaseIntegrationTest {
 
     @Autowired
     protected lateinit var boardPersistenceAdapter: BoardPersistenceAdapter
+
+    @Autowired
+    protected lateinit var boardArticleCategoryPersistenceAdapter: BoardArticleCategoryPersistenceAdapter
 
     @Autowired
     private lateinit var entityManager: EntityManager

--- a/board-system-board/board-database-adapter/src/test/resources/test-schema.sql
+++ b/board-system-board/board-database-adapter/src/test/resources/test-schema.sql
@@ -24,3 +24,17 @@ CREATE TABLE IF NOT EXISTS boards(
     slug        VARCHAR(30) UNIQUE NOT NULL,
     created_at  DATETIME           NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS board_article_categories(
+    board_article_category_id BIGINT      NOT NULL PRIMARY KEY,
+    name                      VARCHAR(20) NOT NULL,
+    slug                      VARCHAR(8)  NOT NULL,
+    board_id                  BIGINT      NOT NULL,
+    allow_self_delete         BOOLEAN     NOT NULL,
+    allow_like                BOOLEAN     NOT NULL,
+    allow_dislike             BOOLEAN     NOT NULL,
+    created_at                DATETIME    NOT NULL,
+
+    CONSTRAINT uq_board_id_and_name UNIQUE (board_id, name),
+    CONSTRAINT uq_board_id_and_slug UNIQUE (board_id, slug)
+);

--- a/board-system-board/board-domain/src/main/kotlin/com/ttasjwi/board/system/board/domain/exception/BoardNotFoundException.kt
+++ b/board-system-board/board-domain/src/main/kotlin/com/ttasjwi/board/system/board/domain/exception/BoardNotFoundException.kt
@@ -1,0 +1,16 @@
+package com.ttasjwi.board.system.board.domain.exception
+
+import com.ttasjwi.board.system.common.exception.CustomException
+import com.ttasjwi.board.system.common.exception.ErrorStatus
+
+class BoardNotFoundException(
+    source: String,
+    argument: Any,
+) : CustomException(
+    status = ErrorStatus.NOT_FOUND,
+    code = "Error.BoardNotFound",
+    args = listOf(source, argument),
+    source = source,
+    debugMessage = "조건에 부합하는 게시판을 찾지 못 했습니다. ($source = $argument)"
+)
+

--- a/board-system-board/board-domain/src/main/kotlin/com/ttasjwi/board/system/board/domain/exception/DuplicateBoardArticleCategoryNameException.kt
+++ b/board-system-board/board-domain/src/main/kotlin/com/ttasjwi/board/system/board/domain/exception/DuplicateBoardArticleCategoryNameException.kt
@@ -1,0 +1,14 @@
+package com.ttasjwi.board.system.board.domain.exception
+
+import com.ttasjwi.board.system.common.exception.CustomException
+import com.ttasjwi.board.system.common.exception.ErrorStatus
+
+class DuplicateBoardArticleCategoryNameException(
+    boardArticleCategoryName: String,
+) : CustomException(
+    status = ErrorStatus.CONFLICT,
+    code = "Error.DuplicateBoardArticleCategoryName",
+    args = listOf(boardArticleCategoryName),
+    source = "boardArticleCategoryName",
+    debugMessage = "게시판 내에서 게시글 카테고리명이 중복됩니다. (boardArticleCategoryName = ${boardArticleCategoryName})"
+)

--- a/board-system-board/board-domain/src/main/kotlin/com/ttasjwi/board/system/board/domain/exception/DuplicateBoardArticleCategorySlugException.kt
+++ b/board-system-board/board-domain/src/main/kotlin/com/ttasjwi/board/system/board/domain/exception/DuplicateBoardArticleCategorySlugException.kt
@@ -1,0 +1,14 @@
+package com.ttasjwi.board.system.board.domain.exception
+
+import com.ttasjwi.board.system.common.exception.CustomException
+import com.ttasjwi.board.system.common.exception.ErrorStatus
+
+class DuplicateBoardArticleCategorySlugException(
+    boardArticleCategorySlug: String,
+) : CustomException(
+    status = ErrorStatus.CONFLICT,
+    code = "Error.DuplicateBoardArticleCategorySlug",
+    args = listOf(boardArticleCategorySlug),
+    source = "boardArticleCategorySlug",
+    debugMessage = "게시판 내에서 게시글 카테고리 슬러그가 중복됩니다. (boardArticleCategorySlug = ${boardArticleCategorySlug})"
+)

--- a/board-system-board/board-domain/src/main/kotlin/com/ttasjwi/board/system/board/domain/exception/InvalidBoardArticleCategoryNameFormatException.kt
+++ b/board-system-board/board-domain/src/main/kotlin/com/ttasjwi/board/system/board/domain/exception/InvalidBoardArticleCategoryNameFormatException.kt
@@ -6,7 +6,7 @@ import com.ttasjwi.board.system.common.exception.ErrorStatus
 
 class InvalidBoardArticleCategoryNameFormatException : CustomException(
     status = ErrorStatus.BAD_REQUEST,
-    code = "ErrorStatus.InvalidBoardArticleCategoryNameFormat",
+    code = "Error.InvalidBoardArticleCategoryNameFormat",
     args = listOf(BoardArticleCategoryNamePolicyImpl.MAX_LENGTH),
     source = "boardArticleCategoryName",
     debugMessage = "게시글 카테고리명이 유효하지 않습니다. 게시글 카테고리명은 양 끝 공백이 허용되지 않고, ${BoardArticleCategoryNamePolicyImpl.MAX_LENGTH} 자를 넘을 수 없습니다."

--- a/board-system-board/board-domain/src/main/kotlin/com/ttasjwi/board/system/board/domain/exception/InvalidBoardArticleCategoryNameFormatException.kt
+++ b/board-system-board/board-domain/src/main/kotlin/com/ttasjwi/board/system/board/domain/exception/InvalidBoardArticleCategoryNameFormatException.kt
@@ -1,0 +1,13 @@
+package com.ttasjwi.board.system.board.domain.exception
+
+import com.ttasjwi.board.system.board.domain.policy.BoardArticleCategoryNamePolicyImpl
+import com.ttasjwi.board.system.common.exception.CustomException
+import com.ttasjwi.board.system.common.exception.ErrorStatus
+
+class InvalidBoardArticleCategoryNameFormatException : CustomException(
+    status = ErrorStatus.BAD_REQUEST,
+    code = "ErrorStatus.InvalidBoardArticleCategoryNameFormat",
+    args = listOf(BoardArticleCategoryNamePolicyImpl.MAX_LENGTH),
+    source = "boardArticleCategoryName",
+    debugMessage = "게시글 카테고리명이 유효하지 않습니다. 게시글 카테고리명은 양 끝 공백이 허용되지 않고, ${BoardArticleCategoryNamePolicyImpl.MAX_LENGTH} 자를 넘을 수 없습니다."
+)

--- a/board-system-board/board-domain/src/main/kotlin/com/ttasjwi/board/system/board/domain/exception/InvalidBoardArticleCategorySlugFormatException.kt
+++ b/board-system-board/board-domain/src/main/kotlin/com/ttasjwi/board/system/board/domain/exception/InvalidBoardArticleCategorySlugFormatException.kt
@@ -1,0 +1,14 @@
+package com.ttasjwi.board.system.board.domain.exception
+
+import com.ttasjwi.board.system.board.domain.policy.BoardArticleCategorySlugPolicyImpl
+import com.ttasjwi.board.system.common.exception.CustomException
+import com.ttasjwi.board.system.common.exception.ErrorStatus
+
+class InvalidBoardArticleCategorySlugFormatException : CustomException(
+    status = ErrorStatus.BAD_REQUEST,
+    code = "Error.InvalidBoardArticleCategorySlugFormat",
+    args = listOf(BoardArticleCategorySlugPolicyImpl.MIN_LENGTH, BoardArticleCategorySlugPolicyImpl.MAX_LENGTH),
+    source = "boardArticleCategorySlug",
+    debugMessage = "게시글 카테고리 슬러그는 ${BoardArticleCategorySlugPolicyImpl.MIN_LENGTH} 자 이상 " +
+            "${BoardArticleCategorySlugPolicyImpl.MAX_LENGTH} 자 이하의 영어 또는 숫자만 허용됩니다."
+)

--- a/board-system-board/board-domain/src/main/kotlin/com/ttasjwi/board/system/board/domain/exception/NoBoardArticleCategoryCreateAuthorityException.kt
+++ b/board-system-board/board-domain/src/main/kotlin/com/ttasjwi/board/system/board/domain/exception/NoBoardArticleCategoryCreateAuthorityException.kt
@@ -1,0 +1,15 @@
+package com.ttasjwi.board.system.board.domain.exception
+
+import com.ttasjwi.board.system.common.exception.CustomException
+import com.ttasjwi.board.system.common.exception.ErrorStatus
+
+class NoBoardArticleCategoryCreateAuthorityException(
+    boardManagerId: Long,
+    creatorId: Long,
+) : CustomException(
+    status = ErrorStatus.FORBIDDEN,
+    code = "Error.NoBoardArticleCategoryCreateAuthority",
+    source = "boardArticleCreateAuthority",
+    args = emptyList(),
+    debugMessage = "카테고리를 추가할 권한이 없습니다. 게시판의 관리자가 아닙니다. (boardManagerId = $boardManagerId, creatorId = $creatorId)",
+)

--- a/board-system-board/board-domain/src/main/kotlin/com/ttasjwi/board/system/board/domain/model/BoardArticleCategory.kt
+++ b/board-system-board/board-domain/src/main/kotlin/com/ttasjwi/board/system/board/domain/model/BoardArticleCategory.kt
@@ -1,0 +1,80 @@
+package com.ttasjwi.board.system.board.domain.model
+
+import com.ttasjwi.board.system.common.time.AppDateTime
+import java.time.LocalDateTime
+
+class BoardArticleCategory(
+    val boardArticleCategoryId: Long,
+    val boardId: Long,
+    name: String,
+    val slug: String,
+    allowSelfDelete: Boolean,
+    allowLike: Boolean,
+    allowDislike: Boolean,
+    val createdAt: AppDateTime
+) {
+
+    var name: String = name
+        private set
+
+    var allowSelfDelete: Boolean = allowSelfDelete
+        private set
+
+    var allowLike: Boolean = allowLike
+        private set
+
+    var allowDislike: Boolean = allowDislike
+        private set
+
+    companion object {
+
+        fun create(
+            boardArticleCategoryId: Long,
+            boardId: Long,
+            name: String,
+            slug: String,
+            allowSelfDelete: Boolean,
+            allowLike: Boolean,
+            allowDislike: Boolean,
+            createdAt: AppDateTime
+        ): BoardArticleCategory {
+            return BoardArticleCategory(
+                boardArticleCategoryId = boardArticleCategoryId,
+                boardId = boardId,
+                name = name,
+                slug = slug,
+                allowSelfDelete = allowSelfDelete,
+                allowLike = allowLike,
+                allowDislike = allowDislike,
+                createdAt = createdAt
+            )
+        }
+
+        fun restore(
+            boardArticleCategoryId: Long,
+            boardId: Long,
+            name: String,
+            slug: String,
+            allowSelfDelete: Boolean,
+            allowLike: Boolean,
+            allowDislike: Boolean,
+            createdAt: LocalDateTime
+        ): BoardArticleCategory {
+            return BoardArticleCategory(
+                boardArticleCategoryId = boardArticleCategoryId,
+                boardId = boardId,
+                name = name,
+                slug = slug,
+                allowSelfDelete = allowSelfDelete,
+                allowLike = allowLike,
+                allowDislike = allowDislike,
+                createdAt = AppDateTime.from(createdAt)
+            )
+        }
+    }
+
+    override fun toString(): String {
+        return "BoardArticleCategory(boardArticleCategoryId=$boardArticleCategoryId, boardId=$boardId, slug='$slug', createdAt=$createdAt, name='$name', allowSelfDelete=$allowSelfDelete, allowLike=$allowLike, allowDislike=$allowDislike)"
+    }
+
+}

--- a/board-system-board/board-domain/src/main/kotlin/com/ttasjwi/board/system/board/domain/policy/BoardArticleCategoryNamePolicy.kt
+++ b/board-system-board/board-domain/src/main/kotlin/com/ttasjwi/board/system/board/domain/policy/BoardArticleCategoryNamePolicy.kt
@@ -1,0 +1,5 @@
+package com.ttasjwi.board.system.board.domain.policy
+
+interface BoardArticleCategoryNamePolicy {
+    fun validate(name: String): Result<String>
+}

--- a/board-system-board/board-domain/src/main/kotlin/com/ttasjwi/board/system/board/domain/policy/BoardArticleCategoryNamePolicyImpl.kt
+++ b/board-system-board/board-domain/src/main/kotlin/com/ttasjwi/board/system/board/domain/policy/BoardArticleCategoryNamePolicyImpl.kt
@@ -11,7 +11,7 @@ internal class BoardArticleCategoryNamePolicyImpl : BoardArticleCategoryNamePoli
         /**
          * 최대 20자
          */
-        const val MAX_LENGTH = 20
+        internal const val MAX_LENGTH = 20
     }
 
     override fun validate(name: String): Result<String> = kotlin.runCatching {

--- a/board-system-board/board-domain/src/main/kotlin/com/ttasjwi/board/system/board/domain/policy/BoardArticleCategoryNamePolicyImpl.kt
+++ b/board-system-board/board-domain/src/main/kotlin/com/ttasjwi/board/system/board/domain/policy/BoardArticleCategoryNamePolicyImpl.kt
@@ -1,0 +1,25 @@
+package com.ttasjwi.board.system.board.domain.policy
+
+import com.ttasjwi.board.system.board.domain.exception.InvalidBoardArticleCategoryNameFormatException
+import com.ttasjwi.board.system.common.annotation.component.DomainPolicy
+
+@DomainPolicy
+internal class BoardArticleCategoryNamePolicyImpl : BoardArticleCategoryNamePolicy {
+
+    companion object {
+
+        /**
+         * 최대 20자
+         */
+        const val MAX_LENGTH = 20
+    }
+
+    override fun validate(name: String): Result<String> = kotlin.runCatching {
+        if (name != name.trim() // 양끝 공백 허용 x
+            || name.length > MAX_LENGTH
+        ) {
+            throw InvalidBoardArticleCategoryNameFormatException()
+        }
+        name
+    }
+}

--- a/board-system-board/board-domain/src/main/kotlin/com/ttasjwi/board/system/board/domain/policy/BoardArticleCategorySlugPolicy.kt
+++ b/board-system-board/board-domain/src/main/kotlin/com/ttasjwi/board/system/board/domain/policy/BoardArticleCategorySlugPolicy.kt
@@ -1,0 +1,7 @@
+package com.ttasjwi.board.system.board.domain.policy
+
+interface BoardArticleCategorySlugPolicy {
+
+    fun validate(slug: String): Result<String>
+}
+

--- a/board-system-board/board-domain/src/main/kotlin/com/ttasjwi/board/system/board/domain/policy/BoardArticleCategorySlugPolicyImpl.kt
+++ b/board-system-board/board-domain/src/main/kotlin/com/ttasjwi/board/system/board/domain/policy/BoardArticleCategorySlugPolicyImpl.kt
@@ -1,0 +1,33 @@
+package com.ttasjwi.board.system.board.domain.policy
+
+import com.ttasjwi.board.system.board.domain.exception.InvalidBoardArticleCategorySlugFormatException
+import com.ttasjwi.board.system.common.annotation.component.DomainPolicy
+
+@DomainPolicy
+internal class BoardArticleCategorySlugPolicyImpl : BoardArticleCategorySlugPolicy {
+
+    companion object {
+
+        /**
+         * 최소 1자
+         */
+        const val MIN_LENGTH = 1
+
+        /**
+         * 최대 8자
+         */
+        const val MAX_LENGTH = 8
+
+        /**
+         * 영어 대소문자, 숫자만 허용.
+         */
+        val PATTERN = Regex("^[A-Za-z0-9]+\$")
+    }
+
+    override fun validate(slug: String): Result<String> = kotlin.runCatching {
+        if (slug.length < MIN_LENGTH || slug.length > MAX_LENGTH || !slug.matches(PATTERN)) {
+            throw InvalidBoardArticleCategorySlugFormatException()
+        }
+        slug
+    }
+}

--- a/board-system-board/board-domain/src/main/kotlin/com/ttasjwi/board/system/board/domain/policy/BoardArticleCategorySlugPolicyImpl.kt
+++ b/board-system-board/board-domain/src/main/kotlin/com/ttasjwi/board/system/board/domain/policy/BoardArticleCategorySlugPolicyImpl.kt
@@ -11,17 +11,17 @@ internal class BoardArticleCategorySlugPolicyImpl : BoardArticleCategorySlugPoli
         /**
          * 최소 1자
          */
-        const val MIN_LENGTH = 1
+        internal const val MIN_LENGTH = 1
 
         /**
          * 최대 8자
          */
-        const val MAX_LENGTH = 8
+        internal const val MAX_LENGTH = 8
 
         /**
          * 영어 대소문자, 숫자만 허용.
          */
-        val PATTERN = Regex("^[A-Za-z0-9]+\$")
+        private val PATTERN = Regex("^[A-Za-z0-9]+\$")
     }
 
     override fun validate(slug: String): Result<String> = kotlin.runCatching {

--- a/board-system-board/board-domain/src/test/kotlin/com/ttasjwi/board/system/board/domain/exception/BoardNotFoundExceptionTest.kt
+++ b/board-system-board/board-domain/src/test/kotlin/com/ttasjwi/board/system/board/domain/exception/BoardNotFoundExceptionTest.kt
@@ -1,0 +1,26 @@
+package com.ttasjwi.board.system.board.domain.exception
+
+import com.ttasjwi.board.system.common.exception.ErrorStatus
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("BoardNotFoundException 테스트")
+class BoardNotFoundExceptionTest {
+
+    @Test
+    @DisplayName("예외 값 테스트")
+    fun test() {
+        val source = "boardId"
+        val argument = 12334567899L
+        val exception = BoardNotFoundException(source = source, argument = argument)
+
+        assertThat(exception.status).isEqualTo(ErrorStatus.NOT_FOUND)
+        assertThat(exception.code).isEqualTo("Error.BoardNotFound")
+        assertThat(exception.source).isEqualTo(source)
+        assertThat(exception.args).containsExactly(source, argument)
+        assertThat(exception.message).isEqualTo(exception.debugMessage)
+        assertThat(exception.cause).isNull()
+        assertThat(exception.debugMessage).isEqualTo("조건에 부합하는 게시판을 찾지 못 했습니다. ($source = $argument)")
+    }
+}

--- a/board-system-board/board-domain/src/test/kotlin/com/ttasjwi/board/system/board/domain/exception/DuplicateBoardArticleCategoryNameExceptionTest.kt
+++ b/board-system-board/board-domain/src/test/kotlin/com/ttasjwi/board/system/board/domain/exception/DuplicateBoardArticleCategoryNameExceptionTest.kt
@@ -1,0 +1,27 @@
+package com.ttasjwi.board.system.board.domain.exception
+
+import com.ttasjwi.board.system.common.exception.ErrorStatus
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("DuplicateBoardArticleCategoryNameException 테스트")
+class DuplicateBoardArticleCategoryNameExceptionTest {
+
+    @Test
+    @DisplayName("예외 값 테스트")
+    fun test() {
+        val boardArticleCategoryName = "일반"
+        val exception = DuplicateBoardArticleCategoryNameException(
+            boardArticleCategoryName = boardArticleCategoryName,
+        )
+
+        assertThat(exception.status).isEqualTo(ErrorStatus.CONFLICT)
+        assertThat(exception.code).isEqualTo("Error.DuplicateBoardArticleCategoryName")
+        assertThat(exception.source).isEqualTo("boardArticleCategoryName")
+        assertThat(exception.args).containsExactly(boardArticleCategoryName)
+        assertThat(exception.message).isEqualTo(exception.debugMessage)
+        assertThat(exception.cause).isNull()
+        assertThat(exception.debugMessage).isEqualTo("게시판 내에서 게시글 카테고리명이 중복됩니다. (boardArticleCategoryName = ${boardArticleCategoryName})")
+    }
+}

--- a/board-system-board/board-domain/src/test/kotlin/com/ttasjwi/board/system/board/domain/exception/DuplicateBoardArticleCategorySlugExceptionTest.kt
+++ b/board-system-board/board-domain/src/test/kotlin/com/ttasjwi/board/system/board/domain/exception/DuplicateBoardArticleCategorySlugExceptionTest.kt
@@ -1,0 +1,27 @@
+package com.ttasjwi.board.system.board.domain.exception
+
+import com.ttasjwi.board.system.common.exception.ErrorStatus
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("DuplicateBoardArticleCategorySlugException 테스트")
+class DuplicateBoardArticleCategorySlugExceptionTest {
+
+    @Test
+    @DisplayName("예외 값 테스트")
+    fun test() {
+        val boardArticleCategorySlug = "general"
+        val exception = DuplicateBoardArticleCategorySlugException(
+            boardArticleCategorySlug = boardArticleCategorySlug,
+        )
+
+        assertThat(exception.status).isEqualTo(ErrorStatus.CONFLICT)
+        assertThat(exception.code).isEqualTo("Error.DuplicateBoardArticleCategorySlug")
+        assertThat(exception.source).isEqualTo("boardArticleCategorySlug")
+        assertThat(exception.args).containsExactly(boardArticleCategorySlug)
+        assertThat(exception.message).isEqualTo(exception.debugMessage)
+        assertThat(exception.cause).isNull()
+        assertThat(exception.debugMessage).isEqualTo("게시판 내에서 게시글 카테고리 슬러그가 중복됩니다. (boardArticleCategorySlug = ${boardArticleCategorySlug})")
+    }
+}

--- a/board-system-board/board-domain/src/test/kotlin/com/ttasjwi/board/system/board/domain/exception/InvalidBoardArticleCategoryNameFormatExceptionTest.kt
+++ b/board-system-board/board-domain/src/test/kotlin/com/ttasjwi/board/system/board/domain/exception/InvalidBoardArticleCategoryNameFormatExceptionTest.kt
@@ -1,0 +1,24 @@
+package com.ttasjwi.board.system.board.domain.exception
+
+import com.ttasjwi.board.system.board.domain.policy.BoardArticleCategoryNamePolicyImpl
+import com.ttasjwi.board.system.common.exception.ErrorStatus
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+class InvalidBoardArticleCategoryNameFormatExceptionTest {
+
+    @Test
+    @DisplayName("예외 기본값 테스트")
+    fun test() {
+        val exception = InvalidBoardArticleCategoryNameFormatException()
+
+        assertThat(exception.status).isEqualTo(ErrorStatus.BAD_REQUEST)
+        assertThat(exception.code).isEqualTo("Error.InvalidBoardArticleCategoryNameFormat")
+        assertThat(exception.source).isEqualTo("boardArticleCategoryName")
+        assertThat(exception.args).containsExactly(BoardArticleCategoryNamePolicyImpl.MAX_LENGTH)
+        assertThat(exception.message).isEqualTo(exception.debugMessage)
+        assertThat(exception.cause).isNull()
+        assertThat(exception.debugMessage).isEqualTo("게시글 카테고리명이 유효하지 않습니다. 게시글 카테고리명은 양 끝 공백이 허용되지 않고, ${BoardArticleCategoryNamePolicyImpl.MAX_LENGTH} 자를 넘을 수 없습니다.")
+    }
+}

--- a/board-system-board/board-domain/src/test/kotlin/com/ttasjwi/board/system/board/domain/exception/InvalidBoardArticleCategorySlugFormatExceptionTest.kt
+++ b/board-system-board/board-domain/src/test/kotlin/com/ttasjwi/board/system/board/domain/exception/InvalidBoardArticleCategorySlugFormatExceptionTest.kt
@@ -1,0 +1,31 @@
+package com.ttasjwi.board.system.board.domain.exception
+
+import com.ttasjwi.board.system.board.domain.policy.BoardArticleCategorySlugPolicyImpl
+import com.ttasjwi.board.system.common.exception.ErrorStatus
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+class InvalidBoardArticleCategorySlugFormatExceptionTest {
+
+    @Test
+    @DisplayName("예외 기본값 테스트")
+    fun test() {
+        val exception = InvalidBoardArticleCategorySlugFormatException()
+
+        assertThat(exception.status).isEqualTo(ErrorStatus.BAD_REQUEST)
+        assertThat(exception.code).isEqualTo("Error.InvalidBoardArticleCategorySlugFormat")
+        assertThat(exception.source).isEqualTo("boardArticleCategorySlug")
+        assertThat(exception.args).containsExactly(
+            BoardArticleCategorySlugPolicyImpl.MIN_LENGTH,
+            BoardArticleCategorySlugPolicyImpl.MAX_LENGTH
+        )
+        assertThat(exception.message).isEqualTo(exception.debugMessage)
+        assertThat(exception.cause).isNull()
+        assertThat(exception.debugMessage).isEqualTo(
+            "게시글 카테고리 슬러그는 ${BoardArticleCategorySlugPolicyImpl.MIN_LENGTH} 자 이상 " +
+                    "${BoardArticleCategorySlugPolicyImpl.MAX_LENGTH} 자 이하의 영어 또는 숫자만 허용됩니다."
+        )
+    }
+}
+

--- a/board-system-board/board-domain/src/test/kotlin/com/ttasjwi/board/system/board/domain/exception/NoBoardArticleCategoryCreateAuthorityExceptionTest.kt
+++ b/board-system-board/board-domain/src/test/kotlin/com/ttasjwi/board/system/board/domain/exception/NoBoardArticleCategoryCreateAuthorityExceptionTest.kt
@@ -1,0 +1,29 @@
+package com.ttasjwi.board.system.board.domain.exception
+
+import com.ttasjwi.board.system.common.exception.ErrorStatus
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("NoBoardArticleCategoryCreateAuthorityException 테스트")
+class NoBoardArticleCategoryCreateAuthorityExceptionTest {
+
+    @Test
+    @DisplayName("예외 값 테스트")
+    fun test() {
+        val boardManagerId = 12345L
+        val creatorId = 565443L
+        val exception = NoBoardArticleCategoryCreateAuthorityException(
+            boardManagerId = boardManagerId,
+            creatorId = creatorId,
+        )
+
+        assertThat(exception.status).isEqualTo(ErrorStatus.FORBIDDEN)
+        assertThat(exception.code).isEqualTo("Error.NoBoardArticleCategoryCreateAuthority")
+        assertThat(exception.source).isEqualTo("boardArticleCreateAuthority")
+        assertThat(exception.args).isEmpty()
+        assertThat(exception.message).isEqualTo(exception.debugMessage)
+        assertThat(exception.cause).isNull()
+        assertThat(exception.debugMessage).isEqualTo("카테고리를 추가할 권한이 없습니다. 게시판의 관리자가 아닙니다. (boardManagerId = $boardManagerId, creatorId = $creatorId)")
+    }
+}

--- a/board-system-board/board-domain/src/test/kotlin/com/ttasjwi/board/system/board/domain/model/BoardArticleCategoryTest.kt
+++ b/board-system-board/board-domain/src/test/kotlin/com/ttasjwi/board/system/board/domain/model/BoardArticleCategoryTest.kt
@@ -1,0 +1,104 @@
+package com.ttasjwi.board.system.board.domain.model
+
+import com.ttasjwi.board.system.common.time.fixture.appDateTimeFixture
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("BoardArticleCategory: 게시글 카테고리")
+class BoardArticleCategoryTest {
+
+    @Test
+    @DisplayName("create: 값을 통해 객체를 생성할 수 있다.")
+    fun createTest() {
+        val boardArticleCategoryId = 123434L
+        val name = "일반"
+        val slug = "general"
+        val boardId = 13L
+        val allowSelfDelete = true
+        val allowLike = false
+        val allowDislike = false
+        val createdAt = appDateTimeFixture(minute = 12)
+        val boardArticleCategory = BoardArticleCategory.create(
+            boardArticleCategoryId = boardArticleCategoryId,
+            name = name,
+            slug = slug,
+            boardId = boardId,
+            allowSelfDelete = allowSelfDelete,
+            allowLike = allowLike,
+            allowDislike = allowDislike,
+            createdAt = createdAt,
+        )
+
+        assertThat(boardArticleCategory.boardArticleCategoryId).isEqualTo(boardArticleCategoryId)
+        assertThat(boardArticleCategory.name).isEqualTo(name)
+        assertThat(boardArticleCategory.slug).isEqualTo(slug)
+        assertThat(boardArticleCategory.boardId).isEqualTo(boardId)
+        assertThat(boardArticleCategory.allowSelfDelete).isEqualTo(allowSelfDelete)
+        assertThat(boardArticleCategory.allowLike).isEqualTo(allowLike)
+        assertThat(boardArticleCategory.allowDislike).isEqualTo(allowDislike)
+        assertThat(boardArticleCategory.createdAt).isEqualTo(createdAt)
+    }
+
+    @Test
+    @DisplayName("restore: 값을 통해 객체를 복원할 수 있다.")
+    fun restore() {
+        val boardArticleCategoryId = 123434L
+        val name = "일반"
+        val slug = "general"
+        val boardId = 13L
+        val allowSelfDelete = true
+        val allowLike = false
+        val allowDislike = false
+        val createdAt = appDateTimeFixture(minute = 12).toLocalDateTime()
+        val boardArticleCategory = BoardArticleCategory.restore(
+            boardArticleCategoryId = boardArticleCategoryId,
+            name = name,
+            slug = slug,
+            boardId = boardId,
+            allowSelfDelete = allowSelfDelete,
+            allowLike = allowLike,
+            allowDislike = allowDislike,
+            createdAt = createdAt,
+        )
+
+        assertThat(boardArticleCategory.boardArticleCategoryId).isEqualTo(boardArticleCategoryId)
+        assertThat(boardArticleCategory.name).isEqualTo(name)
+        assertThat(boardArticleCategory.slug).isEqualTo(slug)
+        assertThat(boardArticleCategory.boardId).isEqualTo(boardId)
+        assertThat(boardArticleCategory.allowSelfDelete).isEqualTo(allowSelfDelete)
+        assertThat(boardArticleCategory.allowLike).isEqualTo(allowLike)
+        assertThat(boardArticleCategory.allowDislike).isEqualTo(allowDislike)
+        assertThat(boardArticleCategory.createdAt.toLocalDateTime()).isEqualTo(createdAt)
+    }
+
+
+    @Test
+    @DisplayName("toString(): 디버깅용 문자열 반환")
+    fun toStringTest() {
+        val boardArticleCategoryId = 123434L
+        val name = "일반"
+        val slug = "general"
+        val boardId = 13L
+        val allowSelfDelete = true
+        val allowLike = false
+        val allowDislike = false
+        val createdAt = appDateTimeFixture(minute = 12)
+        val boardArticleCategory = BoardArticleCategory.create(
+            boardArticleCategoryId = boardArticleCategoryId,
+            name = name,
+            slug = slug,
+            boardId = boardId,
+            allowSelfDelete = allowSelfDelete,
+            allowLike = allowLike,
+            allowDislike = allowDislike,
+            createdAt = createdAt,
+        )
+
+        val str = boardArticleCategory.toString()
+
+        assertThat(str).isEqualTo(
+            "BoardArticleCategory(boardArticleCategoryId=$boardArticleCategoryId, boardId=$boardId, slug='$slug', createdAt=$createdAt, name='$name', allowSelfDelete=$allowSelfDelete, allowLike=$allowLike, allowDislike=$allowDislike)"
+        )
+    }
+}

--- a/board-system-board/board-domain/src/test/kotlin/com/ttasjwi/board/system/board/domain/model/fixture/BoardArticleCategoryFixtureTest.kt
+++ b/board-system-board/board-domain/src/test/kotlin/com/ttasjwi/board/system/board/domain/model/fixture/BoardArticleCategoryFixtureTest.kt
@@ -1,0 +1,57 @@
+package com.ttasjwi.board.system.board.domain.model.fixture
+
+import com.ttasjwi.board.system.common.time.fixture.appDateTimeFixture
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("BoardArticleCategory 픽스쳐 테스트")
+class BoardArticleCategoryFixtureTest {
+
+    @Test
+    @DisplayName("인자 없이 생성해도 기본값을 가진다.")
+    fun test1() {
+        val boardArticleCategory = boardArticleCategoryFixture()
+
+        assertThat(boardArticleCategory.boardArticleCategoryId).isNotNull
+        assertThat(boardArticleCategory.name).isNotNull
+        assertThat(boardArticleCategory.slug).isNotNull
+        assertThat(boardArticleCategory.boardId).isNotNull
+        assertThat(boardArticleCategory.allowSelfDelete).isNotNull
+        assertThat(boardArticleCategory.allowLike).isNotNull
+        assertThat(boardArticleCategory.allowDislike).isNotNull
+        assertThat(boardArticleCategory.createdAt).isNotNull
+    }
+
+    @Test
+    @DisplayName("커스텀하게 인자를 지정할 수 있다.")
+    fun test2() {
+        val boardArticleCategoryId = 123434L
+        val name = "일반"
+        val slug = "general"
+        val boardId = 13L
+        val allowSelfDelete = true
+        val allowLike = false
+        val allowDislike = false
+        val createdAt = appDateTimeFixture(minute = 12)
+        val boardArticleCategory = boardArticleCategoryFixture(
+            boardArticleCategoryId = boardArticleCategoryId,
+            name = name,
+            slug = slug,
+            boardId = boardId,
+            allowSelfDelete = allowSelfDelete,
+            allowLike = allowLike,
+            allowDislike = allowDislike,
+            createdAt = createdAt,
+        )
+
+        assertThat(boardArticleCategory.boardArticleCategoryId).isEqualTo(boardArticleCategoryId)
+        assertThat(boardArticleCategory.name).isEqualTo(name)
+        assertThat(boardArticleCategory.slug).isEqualTo(slug)
+        assertThat(boardArticleCategory.boardId).isEqualTo(boardId)
+        assertThat(boardArticleCategory.allowSelfDelete).isEqualTo(allowSelfDelete)
+        assertThat(boardArticleCategory.allowLike).isEqualTo(allowLike)
+        assertThat(boardArticleCategory.allowDislike).isEqualTo(allowDislike)
+        assertThat(boardArticleCategory.createdAt).isEqualTo(createdAt)
+    }
+}

--- a/board-system-board/board-domain/src/test/kotlin/com/ttasjwi/board/system/board/domain/model/fixture/BoardFixtureTest.kt
+++ b/board-system-board/board-domain/src/test/kotlin/com/ttasjwi/board/system/board/domain/model/fixture/BoardFixtureTest.kt
@@ -31,7 +31,7 @@ class BoardFixtureTest {
         val slug = "economy"
         val createdAt = appDateTimeFixture()
         val board = boardFixture(
-            id = id,
+            boardId = id,
             name = name,
             description = description,
             managerId = managerId,

--- a/board-system-board/board-domain/src/test/kotlin/com/ttasjwi/board/system/board/domain/policy/BoardArticleCategoryNamePolicyImplTest.kt
+++ b/board-system-board/board-domain/src/test/kotlin/com/ttasjwi/board/system/board/domain/policy/BoardArticleCategoryNamePolicyImplTest.kt
@@ -1,0 +1,65 @@
+package com.ttasjwi.board.system.board.domain.policy
+
+import com.ttasjwi.board.system.board.domain.exception.InvalidBoardArticleCategoryNameFormatException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.*
+
+@DisplayName("BoardArticleCategoryNameImpl : 게시글 카테고리명 정책")
+class BoardArticleCategoryNamePolicyImplTest {
+
+    private lateinit var boarArticleCategoryNamePolicy: BoardArticleCategoryNamePolicy
+
+    @BeforeEach
+    fun setup() {
+        boarArticleCategoryNamePolicy = BoardArticleCategoryNamePolicyImpl()
+    }
+
+    @Nested
+    @DisplayName("validate : 유효성을 검증하고, 성공하면 원본값을 반환한 Result / 실패하면 예외를 담은 Result 반환")
+    inner class Validate {
+
+        @Test
+        @DisplayName("성공테스트")
+        fun test1() {
+            // given
+            val name = "a".repeat(BoardArticleCategoryNamePolicyImpl.MAX_LENGTH - 1)
+
+            // when
+            val result = boarArticleCategoryNamePolicy.validate(name)
+
+            // then
+            assertThat(result.isSuccess).isTrue()
+            assertThat(result.getOrThrow()).isEqualTo(name)
+        }
+
+        @Test
+        @DisplayName("양끝 공백 허용 안 함.")
+        fun test2() {
+            // given
+            val name = " 이름 "
+
+            // when
+            val result = boarArticleCategoryNamePolicy.validate(name)
+            // then
+            assertThat(result.isFailure).isTrue()
+            assertThrows<InvalidBoardArticleCategoryNameFormatException> { result.getOrThrow() }
+        }
+
+
+        @Test
+        @DisplayName("길이가 ${BoardArticleCategoryNamePolicyImpl.MAX_LENGTH} 자를 넘으면 안 된다.")
+        fun test3() {
+            // given
+            val name = "a".repeat(BoardArticleCategoryNamePolicyImpl.MAX_LENGTH + 1)
+
+            // when
+            val result = boarArticleCategoryNamePolicy.validate(name)
+
+            // then
+            assertThat(result.isFailure).isTrue()
+            assertThrows<InvalidBoardArticleCategoryNameFormatException> { result.getOrThrow() }
+        }
+
+    }
+
+}

--- a/board-system-board/board-domain/src/test/kotlin/com/ttasjwi/board/system/board/domain/policy/BoardArticleCategorySlugPolicyImplTest.kt
+++ b/board-system-board/board-domain/src/test/kotlin/com/ttasjwi/board/system/board/domain/policy/BoardArticleCategorySlugPolicyImplTest.kt
@@ -1,0 +1,82 @@
+package com.ttasjwi.board.system.board.domain.policy
+
+import com.ttasjwi.board.system.board.domain.exception.InvalidBoardArticleCategorySlugFormatException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.*
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+@DisplayName("BoardArticleSlugPolicyImpl: 게시글 카테고리 슬러그 도메인 정책")
+class BoardArticleSlugPolicyImplTest {
+
+    private lateinit var boardArticleCategorySlugPolicy: BoardArticleCategorySlugPolicy
+
+    @BeforeEach
+    fun setup() {
+        boardArticleCategorySlugPolicy = BoardArticleCategorySlugPolicyImpl()
+    }
+
+    @Nested
+    @DisplayName("validate: 유효성 검증 후, 유효하면 값을 그대로 담은 Result/ 유효하지 않으면 예외를 담은 Reuslt 를 반환한다.")
+    inner class Validate {
+
+        @Test
+        @DisplayName("길이 유효성: 양끝 공백을 제거했을 때 ${BoardArticleCategorySlugPolicyImpl.MIN_LENGTH}자 이상, ${BoardArticleCategorySlugPolicyImpl.MAX_LENGTH}자 이하")
+        fun test1() {
+            // given
+            val minLengthValue = "a".repeat(BoardArticleCategorySlugPolicyImpl.MIN_LENGTH)
+            val maxLengthValue = "a".repeat(BoardArticleCategorySlugPolicyImpl.MAX_LENGTH)
+
+            // when
+            val minLengthBoardName = boardArticleCategorySlugPolicy.validate(minLengthValue).getOrThrow()
+            val maxLengthBoardName = boardArticleCategorySlugPolicy.validate(maxLengthValue).getOrThrow()
+
+            // then
+            assertThat(minLengthBoardName).isEqualTo(minLengthValue)
+            assertThat(maxLengthBoardName).isEqualTo(maxLengthValue)
+        }
+
+        @Test
+        @DisplayName("양 끝 공백을 허용하지 않는다")
+        fun test2() {
+            val value = " ab0 "
+            assertThrows<InvalidBoardArticleCategorySlugFormatException> { boardArticleCategorySlugPolicy.validate(value).getOrThrow() }
+        }
+
+        @Test
+        @DisplayName("최소 글자수보다 글자수가 적으면 예외가 발생한다.")
+        fun test3() {
+            val value = "a".repeat(BoardArticleCategorySlugPolicyImpl.MIN_LENGTH - 1)
+            assertThrows<InvalidBoardArticleCategorySlugFormatException> { boardArticleCategorySlugPolicy.validate(value).getOrThrow() }
+        }
+
+        @Test
+        @DisplayName("최대 글자수보다 글자수가 많으면 예외가 발생한다.")
+        fun test4() {
+            val value = "a".repeat(BoardArticleCategorySlugPolicyImpl.MAX_LENGTH + 1)
+
+            assertThrows<InvalidBoardArticleCategorySlugFormatException> { boardArticleCategorySlugPolicy.validate(value).getOrThrow() }
+        }
+
+
+        @ParameterizedTest
+        @ValueSource(strings = ["abadfc", "1asSf4", "Abc4"])
+        @DisplayName("양 끝 공백을 제거했을 때, 영어, 숫자만 허용한다.")
+        fun test5(value: String) {
+            // given
+            // when
+            val name = boardArticleCategorySlugPolicy.validate(value).getOrThrow()
+
+            // then
+            assertThat(name).isEqualTo(value)
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = ["ㅇㅅ4ㅇ", "ㅔㅔㅔ", "ㅠㅠ<ㅠ", "a!asㅔ잉"])
+        @DisplayName("한글이나 특수문자 등, 영어/숫자가 아닌 문자는 허용되지 않는다.")
+        fun test6(value: String) {
+            assertThrows<InvalidBoardArticleCategorySlugFormatException> { boardArticleCategorySlugPolicy.validate(value).getOrThrow() }
+        }
+
+    }
+}

--- a/board-system-board/board-domain/src/test/kotlin/com/ttasjwi/board/system/board/domain/policy/fixture/BoardArticleCategoryNamePolicyFixtureTest.kt
+++ b/board-system-board/board-domain/src/test/kotlin/com/ttasjwi/board/system/board/domain/policy/fixture/BoardArticleCategoryNamePolicyFixtureTest.kt
@@ -1,0 +1,47 @@
+package com.ttasjwi.board.system.board.domain.policy.fixture
+
+import com.ttasjwi.board.system.common.exception.CustomException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.*
+
+class BoardArticleCategoryNamePolicyFixtureTest {
+
+    private lateinit var boardArticleCategoryNamePolicyFixture: BoardArticleCategoryNamePolicyFixture
+
+    @BeforeEach
+    fun setup() {
+        boardArticleCategoryNamePolicyFixture = BoardArticleCategoryNamePolicyFixture()
+    }
+
+    @Nested
+    @DisplayName("게시글 카테고리 슬러그 포맷을 검증한다.")
+    inner class Validate {
+
+        @Test
+        @DisplayName("성공 테스트")
+        fun success() {
+            // given
+            val name = "테스트이름"
+
+            // when
+            val validatedName = boardArticleCategoryNamePolicyFixture.validate(name).getOrThrow()
+
+            // then
+            assertThat(validatedName).isEqualTo(name)
+        }
+
+
+        @Test
+        @DisplayName("실패 테스트")
+        fun failure() {
+            // given
+            val name = BoardArticleCategoryNamePolicyFixture.ERROR_NAME
+
+            // when
+            val exception = assertThrows<CustomException> { boardArticleCategoryNamePolicyFixture.validate(name).getOrThrow() }
+
+            // then
+            assertThat(exception.message).isEqualTo("픽스쳐 예외 : 잘못된 게시글 카테고리 이름 포맷")
+        }
+    }
+}

--- a/board-system-board/board-domain/src/test/kotlin/com/ttasjwi/board/system/board/domain/policy/fixture/BoardArticleCategorySlugPolicyFixtureTest.kt
+++ b/board-system-board/board-domain/src/test/kotlin/com/ttasjwi/board/system/board/domain/policy/fixture/BoardArticleCategorySlugPolicyFixtureTest.kt
@@ -43,7 +43,7 @@ class BoardArticleCategorySlugPolicyFixtureTest {
             val exception = assertThrows<CustomException> { boardArticleCategorySlugPolicyFixture.validate(value).getOrThrow() }
 
             // then
-            assertThat(exception.message).isEqualTo("픽스쳐 예외 : 잘못된 게시글카테고리 슬러그 포맷")
+            assertThat(exception.message).isEqualTo("픽스쳐 예외 : 잘못된 게시글 카테고리 슬러그 포맷")
         }
     }
 }

--- a/board-system-board/board-domain/src/test/kotlin/com/ttasjwi/board/system/board/domain/policy/fixture/BoardArticleCategorySlugPolicyFixtureTest.kt
+++ b/board-system-board/board-domain/src/test/kotlin/com/ttasjwi/board/system/board/domain/policy/fixture/BoardArticleCategorySlugPolicyFixtureTest.kt
@@ -1,0 +1,49 @@
+package com.ttasjwi.board.system.board.domain.policy.fixture
+
+import com.ttasjwi.board.system.common.exception.CustomException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.*
+
+@DisplayName("BoardArticleCategorySlugPolicyFixture 테스트")
+class BoardArticleCategorySlugPolicyFixtureTest {
+
+
+    private lateinit var boardArticleCategorySlugPolicyFixture: BoardArticleCategorySlugPolicyFixture
+
+    @BeforeEach
+    fun setup() {
+        boardArticleCategorySlugPolicyFixture = BoardArticleCategorySlugPolicyFixture()
+    }
+
+    @Nested
+    @DisplayName("게시글 카테고리 슬러그 포맷을 검증한다.")
+    inner class Validate {
+
+        @Test
+        @DisplayName("성공 테스트")
+        fun success() {
+            // given
+            val value = "testslug"
+
+            // when
+            val slug = boardArticleCategorySlugPolicyFixture.validate(value).getOrThrow()
+
+            // then
+            assertThat(slug).isEqualTo(value)
+        }
+
+
+        @Test
+        @DisplayName("실패 테스트")
+        fun failure() {
+            // given
+            val value = BoardArticleCategorySlugPolicyFixture.ERROR_SLUG
+
+            // when
+            val exception = assertThrows<CustomException> { boardArticleCategorySlugPolicyFixture.validate(value).getOrThrow() }
+
+            // then
+            assertThat(exception.message).isEqualTo("픽스쳐 예외 : 잘못된 게시글카테고리 슬러그 포맷")
+        }
+    }
+}

--- a/board-system-board/board-domain/src/test/kotlin/com/ttasjwi/board/system/board/domain/policy/fixture/BoardDescriptionPolicyFixtureTest.kt
+++ b/board-system-board/board-domain/src/test/kotlin/com/ttasjwi/board/system/board/domain/policy/fixture/BoardDescriptionPolicyFixtureTest.kt
@@ -16,8 +16,8 @@ class BoardDescriptionPolicyFixtureTest {
     }
 
     @Nested
-    @DisplayName("게시판 설명을 생성한다.")
-    inner class Create {
+    @DisplayName("게시판 설명 포맷을 검증한다.")
+    inner class Validate {
 
 
         @Test

--- a/board-system-board/board-domain/src/testFixtures/kotlin/com/ttasjwi/board/system/board/domain/model/fixture/BoardArticleCategoryFixture.kt
+++ b/board-system-board/board-domain/src/testFixtures/kotlin/com/ttasjwi/board/system/board/domain/model/fixture/BoardArticleCategoryFixture.kt
@@ -1,0 +1,27 @@
+package com.ttasjwi.board.system.board.domain.model.fixture
+
+import com.ttasjwi.board.system.board.domain.model.BoardArticleCategory
+import com.ttasjwi.board.system.common.time.AppDateTime
+import com.ttasjwi.board.system.common.time.fixture.appDateTimeFixture
+
+fun boardArticleCategoryFixture(
+    boardArticleCategoryId: Long = 12345L,
+    name: String = "테스트",
+    slug: String = "testslug",
+    boardId: Long = 12455657L,
+    allowSelfDelete: Boolean = true,
+    allowLike: Boolean = true,
+    allowDislike: Boolean = true,
+    createdAt: AppDateTime = appDateTimeFixture()
+): BoardArticleCategory {
+    return BoardArticleCategory(
+        boardArticleCategoryId = boardArticleCategoryId,
+        name = name,
+        slug = slug,
+        boardId = boardId,
+        allowSelfDelete = allowSelfDelete,
+        allowLike = allowLike,
+        allowDislike = allowDislike,
+        createdAt = createdAt,
+    )
+}

--- a/board-system-board/board-domain/src/testFixtures/kotlin/com/ttasjwi/board/system/board/domain/model/fixture/BoardFixture.kt
+++ b/board-system-board/board-domain/src/testFixtures/kotlin/com/ttasjwi/board/system/board/domain/model/fixture/BoardFixture.kt
@@ -5,7 +5,7 @@ import com.ttasjwi.board.system.common.time.AppDateTime
 import com.ttasjwi.board.system.common.time.fixture.appDateTimeFixture
 
 fun boardFixture(
-    id: Long = 1L,
+    boardId: Long = 1L,
     name: String = "test",
     description: String = "게시판 설명",
     managerId: Long = 1L,
@@ -13,7 +13,7 @@ fun boardFixture(
     createdAt: AppDateTime = appDateTimeFixture()
 ): Board {
     return Board(
-        boardId = id,
+        boardId = boardId,
         name = name,
         description = description,
         managerId = managerId,

--- a/board-system-board/board-domain/src/testFixtures/kotlin/com/ttasjwi/board/system/board/domain/policy/fixture/BoardArticleCategoryNamePolicyFixture.kt
+++ b/board-system-board/board-domain/src/testFixtures/kotlin/com/ttasjwi/board/system/board/domain/policy/fixture/BoardArticleCategoryNamePolicyFixture.kt
@@ -1,0 +1,25 @@
+package com.ttasjwi.board.system.board.domain.policy.fixture
+
+import com.ttasjwi.board.system.board.domain.policy.BoardArticleCategoryNamePolicy
+import com.ttasjwi.board.system.common.exception.ErrorStatus
+import com.ttasjwi.board.system.common.exception.fixture.customExceptionFixture
+
+class BoardArticleCategoryNamePolicyFixture : BoardArticleCategoryNamePolicy {
+
+    companion object {
+        const val ERROR_NAME = "errorNAME!"
+    }
+
+    override fun validate(name: String): Result<String> = kotlin.runCatching {
+        if (name == ERROR_NAME) {
+            throw customExceptionFixture(
+                status = ErrorStatus.BAD_REQUEST,
+                code = "Error.InvalidBoardArticleCategoryNameFormat",
+                args = listOf(),
+                source = "boardArticleCategoryName",
+                debugMessage = "픽스쳐 예외 : 잘못된 게시글 카테고리 이름 포맷"
+            )
+        }
+        name
+    }
+}

--- a/board-system-board/board-domain/src/testFixtures/kotlin/com/ttasjwi/board/system/board/domain/policy/fixture/BoardArticleCategorySlugPolicyFixture.kt
+++ b/board-system-board/board-domain/src/testFixtures/kotlin/com/ttasjwi/board/system/board/domain/policy/fixture/BoardArticleCategorySlugPolicyFixture.kt
@@ -1,0 +1,25 @@
+package com.ttasjwi.board.system.board.domain.policy.fixture
+
+import com.ttasjwi.board.system.board.domain.policy.BoardArticleCategorySlugPolicy
+import com.ttasjwi.board.system.common.exception.ErrorStatus
+import com.ttasjwi.board.system.common.exception.fixture.customExceptionFixture
+
+class BoardArticleCategorySlugPolicyFixture : BoardArticleCategorySlugPolicy {
+
+    companion object {
+        const val ERROR_SLUG = "!ERRORSLUG"
+    }
+
+    override fun validate(slug: String): Result<String> = kotlin.runCatching {
+        if (slug == ERROR_SLUG) {
+            throw customExceptionFixture(
+                status = ErrorStatus.BAD_REQUEST,
+                code = "Error.InvalidBoardArticleCategorySlugFormat",
+                args = listOf(),
+                source = "boardArticleCategorySlug",
+                debugMessage = "픽스쳐 예외 : 잘못된 게시글카테고리 슬러그 포맷"
+            )
+        }
+        slug
+    }
+}

--- a/board-system-board/board-domain/src/testFixtures/kotlin/com/ttasjwi/board/system/board/domain/policy/fixture/BoardArticleCategorySlugPolicyFixture.kt
+++ b/board-system-board/board-domain/src/testFixtures/kotlin/com/ttasjwi/board/system/board/domain/policy/fixture/BoardArticleCategorySlugPolicyFixture.kt
@@ -17,7 +17,7 @@ class BoardArticleCategorySlugPolicyFixture : BoardArticleCategorySlugPolicy {
                 code = "Error.InvalidBoardArticleCategorySlugFormat",
                 args = listOf(),
                 source = "boardArticleCategorySlug",
-                debugMessage = "픽스쳐 예외 : 잘못된 게시글카테고리 슬러그 포맷"
+                debugMessage = "픽스쳐 예외 : 잘못된 게시글 카테고리 슬러그 포맷"
             )
         }
         slug

--- a/board-system-board/board-web-adapter/src/main/kotlin/com/ttasjwi/board/system/board/api/BoardArticleCategoryCreateController.kt
+++ b/board-system-board/board-web-adapter/src/main/kotlin/com/ttasjwi/board/system/board/api/BoardArticleCategoryCreateController.kt
@@ -1,0 +1,23 @@
+package com.ttasjwi.board.system.board.api
+
+import com.ttasjwi.board.system.board.domain.*
+import com.ttasjwi.board.system.common.annotation.auth.RequireAuthenticated
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class BoardArticleCategoryCreateController(
+    private val boardArticleCategoryCreateUseCase: BoardArticleCategoryCreateUseCase
+) {
+
+    @RequireAuthenticated
+    @PostMapping("/api/v1/boards/{boardId}/categories")
+    fun createBoardCategory(@PathVariable boardId: Long, @RequestBody request: BoardArticleCategoryCreateRequest): ResponseEntity<BoardArticleCategoryCreateResponse> {
+        val response = boardArticleCategoryCreateUseCase.create(boardId, request)
+        return ResponseEntity.status(HttpStatus.CREATED).body(response)
+    }
+}

--- a/board-system-board/board-web-adapter/src/test/kotlin/com/ttasjwi/board/system/board/api/BoardArticleCategoryCreateControllerTest.kt
+++ b/board-system-board/board-web-adapter/src/test/kotlin/com/ttasjwi/board/system/board/api/BoardArticleCategoryCreateControllerTest.kt
@@ -1,0 +1,52 @@
+package com.ttasjwi.board.system.board.api
+
+import com.ttasjwi.board.system.board.domain.BoardArticleCategoryCreateRequest
+import com.ttasjwi.board.system.board.domain.BoardArticleCategoryCreateResponse
+import com.ttasjwi.board.system.board.domain.BoardCreateRequest
+import com.ttasjwi.board.system.board.domain.BoardCreateResponse
+import com.ttasjwi.board.system.board.domain.fixture.BoardArticleCategoryCreateUseCaseFixture
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+
+@DisplayName("BoardArticleCategoryCreateController 테스트")
+class BoardArticleCategoryCreateControllerTest {
+
+    private lateinit var controller: BoardArticleCategoryCreateController
+
+    @BeforeEach
+    fun setup() {
+        controller = BoardArticleCategoryCreateController(BoardArticleCategoryCreateUseCaseFixture())
+    }
+
+    @Test
+    @DisplayName("유즈케이스를 통해 요청을 처리하고, 201 응답을 반환한다.")
+    fun test() {
+        // given
+        val boardId = 1L
+        val request = BoardArticleCategoryCreateRequest(
+            name = "고양이",
+            slug = "cat",
+            allowSelfDelete = true,
+            allowLike = true,
+            allowDislike = true,
+        )
+
+        // when
+        val responseEntity = controller.createBoardCategory(boardId, request)
+        val response = responseEntity.body as BoardArticleCategoryCreateResponse
+
+        // then
+        assertThat(responseEntity.statusCode.value()).isEqualTo(HttpStatus.CREATED.value())
+        assertThat(response.boardArticleCategoryId).isNotNull()
+        assertThat(response.boardId).isEqualTo(boardId.toString())
+        assertThat(response.name).isEqualTo(request.name)
+        assertThat(response.slug).isEqualTo(request.slug)
+        assertThat(response.allowSelfDelete).isEqualTo(request.allowSelfDelete)
+        assertThat(response.allowLike).isEqualTo(request.allowLike)
+        assertThat(response.allowDislike).isEqualTo(request.allowDislike)
+        assertThat(response.createdAt).isNotNull()
+    }
+}


### PR DESCRIPTION

# JIRA 티켓
- [BRD-94]

---

# 개요
- 게시판 관리자는 게시판 별로 게시글 카테고리를 생성할 수 있다.
- 모든 사용자들은 게시글을 올릴 때 카테고리를 반드시 하나 지정해야한다.
- 게시글들은 반드시 하나의 카테고리에 속한다.
- 한 카테고리에는 여러 개시글들이 속할 수 있다.

[BRD-94]: https://ttasjwi.atlassian.net/browse/BRD-94?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ