### PR TITLE
Feature: (BRD-120) 게시글 단건조회 기능 구현

### DIFF
--- a/board-system-article/article-application-input-port/src/main/kotlin/com/ttasjwi/board/system/article/domain/ArticleReadUseCase.kt
+++ b/board-system-article/article-application-input-port/src/main/kotlin/com/ttasjwi/board/system/article/domain/ArticleReadUseCase.kt
@@ -1,0 +1,19 @@
+package com.ttasjwi.board.system.article.domain
+
+import java.time.ZonedDateTime
+
+interface ArticleReadUseCase {
+    fun read(articleId: Long): ArticleReadResponse
+}
+
+data class ArticleReadResponse(
+    val articleId: String,
+    val title: String,
+    val content: String,
+    val boardId: String,
+    val articleCategoryId: String,
+    val writerId: String,
+    val writerNickname: String,
+    val createdAt: ZonedDateTime,
+    val modifiedAt: ZonedDateTime,
+)

--- a/board-system-article/article-application-input-port/src/test/kotlin/com/ttasjwi/board/system/article/domain/fixture/ArticleReadUseCaseFixtureTest.kt
+++ b/board-system-article/article-application-input-port/src/test/kotlin/com/ttasjwi/board/system/article/domain/fixture/ArticleReadUseCaseFixtureTest.kt
@@ -1,0 +1,39 @@
+package com.ttasjwi.board.system.article.domain.fixture
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("ArticleReadUseCaseFixture: 게시글 조회 유즈케이스 픽스쳐")
+class ArticleReadUseCaseFixtureTest {
+
+    private lateinit var useCaseFixture: ArticleReadUseCaseFixture
+
+    @BeforeEach
+    fun setup() {
+        useCaseFixture = ArticleReadUseCaseFixture()
+    }
+
+
+    @Test
+    @DisplayName("요청을 받고, 응답를 반환한다.")
+    fun testSuccess() {
+        // given
+        val articleId = 12345L
+
+        // when
+        val response = useCaseFixture.read(articleId)
+
+        // then
+        assertThat(response.articleId).isEqualTo(articleId.toString())
+        assertThat(response.title).isNotNull()
+        assertThat(response.content).isNotNull()
+        assertThat(response.boardId).isNotNull()
+        assertThat(response.articleCategoryId).isNotNull()
+        assertThat(response.writerId).isNotNull()
+        assertThat(response.writerNickname).isNotNull()
+        assertThat(response.createdAt).isNotNull()
+        assertThat(response.modifiedAt).isNotNull()
+    }
+}

--- a/board-system-article/article-application-input-port/src/testFixtures/kotlin/com/ttasjwi/board/system/article/domain/fixture/ArticleReadUseCaseFixture.kt
+++ b/board-system-article/article-application-input-port/src/testFixtures/kotlin/com/ttasjwi/board/system/article/domain/fixture/ArticleReadUseCaseFixture.kt
@@ -1,0 +1,22 @@
+package com.ttasjwi.board.system.article.domain.fixture
+
+import com.ttasjwi.board.system.article.domain.ArticleReadResponse
+import com.ttasjwi.board.system.article.domain.ArticleReadUseCase
+import com.ttasjwi.board.system.common.time.fixture.appDateTimeFixture
+
+class ArticleReadUseCaseFixture : ArticleReadUseCase {
+
+    override fun read(articleId: Long): ArticleReadResponse {
+        return ArticleReadResponse(
+            articleId = articleId.toString(),
+            title = "제목",
+            content = "본문",
+            boardId = "131433451451",
+            articleCategoryId = "87364535667",
+            writerId = "155557",
+            writerNickname = "땃쥐",
+            createdAt = appDateTimeFixture(minute = 5).toZonedDateTime(),
+            modifiedAt = appDateTimeFixture(minute = 5).toZonedDateTime()
+        )
+    }
+}

--- a/board-system-article/article-application-service/src/main/kotlin/com/ttasjwi/board/system/article/domain/ArticleReadUseCaseImpl.kt
+++ b/board-system-article/article-application-service/src/main/kotlin/com/ttasjwi/board/system/article/domain/ArticleReadUseCaseImpl.kt
@@ -1,0 +1,39 @@
+package com.ttasjwi.board.system.article.domain
+
+import com.ttasjwi.board.system.article.domain.exception.ArticleNotFoundException
+import com.ttasjwi.board.system.article.domain.model.Article
+import com.ttasjwi.board.system.article.domain.port.ArticlePersistencePort
+import com.ttasjwi.board.system.common.annotation.component.UseCase
+
+@UseCase
+internal class ArticleReadUseCaseImpl(
+    private val articlePersistencePort: ArticlePersistencePort
+) : ArticleReadUseCase {
+
+    override fun read(articleId: Long): ArticleReadResponse {
+        val article = getArticleOrThrow(articleId)
+        return makeResponse(article)
+    }
+
+    private fun getArticleOrThrow(articleId: Long): Article {
+        return articlePersistencePort.findByIdOrNull(articleId)
+            ?: throw ArticleNotFoundException(
+                source = "articleId",
+                argument = articleId
+            )
+    }
+
+    private fun makeResponse(article: Article): ArticleReadResponse {
+        return ArticleReadResponse(
+            articleId = article.articleId.toString(),
+            title = article.title,
+            content = article.content,
+            boardId = article.boardId.toString(),
+            articleCategoryId = article.articleCategoryId.toString(),
+            writerId = article.writerId.toString(),
+            writerNickname = article.writerNickname,
+            createdAt = article.createdAt.toZonedDateTime(),
+            modifiedAt = article.modifiedAt.toZonedDateTime(),
+        )
+    }
+}

--- a/board-system-article/article-application-service/src/test/kotlin/com/ttasjwi/board/system/article/domain/ArticleReadUseCaseImplTest.kt
+++ b/board-system-article/article-application-service/src/test/kotlin/com/ttasjwi/board/system/article/domain/ArticleReadUseCaseImplTest.kt
@@ -1,0 +1,60 @@
+package com.ttasjwi.board.system.article.domain
+
+import com.ttasjwi.board.system.article.domain.exception.ArticleNotFoundException
+import com.ttasjwi.board.system.article.domain.model.fixture.articleFixture
+import com.ttasjwi.board.system.article.domain.port.fixture.ArticlePersistencePortFixture
+import com.ttasjwi.board.system.article.domain.test.support.TestContainer
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+@DisplayName("[article-application-service] ArticleReadUseCaseImpl : 게시글 조회 유즈케이스 구현체")
+class ArticleReadUseCaseImplTest {
+
+    private lateinit var articleReadUseCase: ArticleReadUseCase
+    private lateinit var articlePersistencePortFixture: ArticlePersistencePortFixture
+
+    @BeforeEach
+    fun setup() {
+        val container = TestContainer.create()
+        articleReadUseCase = container.articleReadUseCase
+        articlePersistencePortFixture = container.articlePersistencePortFixture
+    }
+
+    @Test
+    @DisplayName("성공 테스트")
+    fun successTest() {
+        // given
+        val article = articlePersistencePortFixture.save(articleFixture())
+        val articleId = article.articleId
+
+        // when
+        val response = articleReadUseCase.read(articleId)
+
+        // then
+        assertThat(response.articleId).isEqualTo(articleId.toString())
+        assertThat(response.title).isEqualTo(article.title)
+        assertThat(response.content).isEqualTo(article.content)
+        assertThat(response.boardId).isEqualTo(article.boardId.toString())
+        assertThat(response.articleCategoryId).isEqualTo(article.articleCategoryId.toString())
+        assertThat(response.writerId).isEqualTo(article.writerId.toString())
+        assertThat(response.writerNickname).isEqualTo(article.writerNickname)
+        assertThat(response.createdAt).isEqualTo(article.createdAt.toZonedDateTime())
+        assertThat(response.modifiedAt).isEqualTo(article.modifiedAt.toZonedDateTime())
+    }
+
+    @Test
+    @DisplayName("조회 실패 테스트")
+    fun articleNotFoundTest() {
+        // given
+        val articleId = 5858959595L
+
+        // when
+        val ex = assertThrows<ArticleNotFoundException> { articleReadUseCase.read(articleId) }
+
+        // then
+        assertThat(ex.debugMessage).isEqualTo("조건에 부합하는 게시글을 찾지 못 했습니다. (articleId = $articleId)")
+    }
+}

--- a/board-system-article/article-application-service/src/test/kotlin/com/ttasjwi/board/system/article/domain/test/support/TestContainer.kt
+++ b/board-system-article/article-application-service/src/test/kotlin/com/ttasjwi/board/system/article/domain/test/support/TestContainer.kt
@@ -2,6 +2,8 @@ package com.ttasjwi.board.system.article.domain.test.support
 
 import com.ttasjwi.board.system.article.domain.ArticleCreateUseCase
 import com.ttasjwi.board.system.article.domain.ArticleCreateUseCaseImpl
+import com.ttasjwi.board.system.article.domain.ArticleReadUseCase
+import com.ttasjwi.board.system.article.domain.ArticleReadUseCaseImpl
 import com.ttasjwi.board.system.article.domain.mapper.ArticleCreateCommandMapper
 import com.ttasjwi.board.system.article.domain.policy.fixture.ArticleContentPolicyFixture
 import com.ttasjwi.board.system.article.domain.policy.fixture.ArticleTitlePolicyFixture
@@ -56,6 +58,12 @@ internal class TestContainer private constructor() {
         ArticleCreateUseCaseImpl(
             commandMapper = articleCreateCommandMapper,
             processor = articleCreateProcessor,
+        )
+    }
+
+    val articleReadUseCase: ArticleReadUseCase by lazy {
+        ArticleReadUseCaseImpl(
+            articlePersistencePort = articlePersistencePortFixture,
         )
     }
 }

--- a/board-system-article/article-domain/src/main/kotlin/com/ttasjwi/board/system/article/domain/exception/ArticleNotFoundException.kt
+++ b/board-system-article/article-domain/src/main/kotlin/com/ttasjwi/board/system/article/domain/exception/ArticleNotFoundException.kt
@@ -1,0 +1,15 @@
+package com.ttasjwi.board.system.article.domain.exception
+
+import com.ttasjwi.board.system.common.exception.CustomException
+import com.ttasjwi.board.system.common.exception.ErrorStatus
+
+class ArticleNotFoundException(
+    source: String,
+    argument: Any,
+) : CustomException(
+    status = ErrorStatus.NOT_FOUND,
+    code = "Error.ArticleNotFound",
+    source = source,
+    args = listOf(source, argument),
+    debugMessage = "조건에 부합하는 게시글을 찾지 못 했습니다. ($source = $argument)",
+)

--- a/board-system-article/article-domain/src/test/kotlin/com/ttasjwi/board/system/article/domain/exception/ArticleNotFoundExceptionTest.kt
+++ b/board-system-article/article-domain/src/test/kotlin/com/ttasjwi/board/system/article/domain/exception/ArticleNotFoundExceptionTest.kt
@@ -5,25 +5,25 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 
-@DisplayName("ArticleCategoryNotFoundException: 게시글 카테고리를 찾지 못했을 때 발생하는 예외")
-class ArticleCategoryNotFoundExceptionTest {
+@DisplayName("ArticleNotFoundException: 게시글을 찾지 못했을 때 발생하는 예외")
+class ArticleNotFoundExceptionTest {
     @Test
     @DisplayName("예외 기본값 테스트")
     fun test() {
-        val source = "articleCategoryId"
-        val argument = 124556799L
+        val source = "articleId"
+        val argument = 12455674599L
 
-        val exception = ArticleCategoryNotFoundException(
+        val exception = ArticleNotFoundException(
             source = source,
             argument = argument,
         )
 
         assertThat(exception.status).isEqualTo(ErrorStatus.NOT_FOUND)
-        assertThat(exception.code).isEqualTo("Error.ArticleCategoryNotFound")
-        assertThat(exception.source).isEqualTo("articleCategoryId")
+        assertThat(exception.code).isEqualTo("Error.ArticleNotFound")
+        assertThat(exception.source).isEqualTo(source)
         assertThat(exception.args).containsExactly(source, argument)
         assertThat(exception.message).isEqualTo(exception.debugMessage)
         assertThat(exception.cause).isNull()
-        assertThat(exception.debugMessage).isEqualTo("조건에 부합하는 게시글 카테고리를 찾지 못 했습니다. ($source = $argument)")
+        assertThat(exception.debugMessage).isEqualTo("조건에 부합하는 게시글을 찾지 못 했습니다. ($source = $argument)")
     }
 }

--- a/board-system-article/article-web-adapter/src/main/kotlin/com/ttasjwi/board/system/article/api/ArticleReadController.kt
+++ b/board-system-article/article-web-adapter/src/main/kotlin/com/ttasjwi/board/system/article/api/ArticleReadController.kt
@@ -1,0 +1,22 @@
+package com.ttasjwi.board.system.article.api
+
+import com.ttasjwi.board.system.article.domain.ArticleReadResponse
+import com.ttasjwi.board.system.article.domain.ArticleReadUseCase
+import com.ttasjwi.board.system.common.annotation.auth.PermitAll
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class ArticleReadController(
+    private val articleReadUseCase: ArticleReadUseCase,
+) {
+
+    @PermitAll
+    @GetMapping("/api/v1/articles/{articleId}")
+    fun read(@PathVariable("articleId") articleId: Long): ResponseEntity<ArticleReadResponse> {
+        val response = articleReadUseCase.read(articleId)
+        return ResponseEntity.ok(response)
+    }
+}

--- a/board-system-article/article-web-adapter/src/test/kotlin/com/ttasjwi/board/system/article/api/ArticleReadControllerTest.kt
+++ b/board-system-article/article-web-adapter/src/test/kotlin/com/ttasjwi/board/system/article/api/ArticleReadControllerTest.kt
@@ -1,0 +1,43 @@
+package com.ttasjwi.board.system.article.api
+
+import com.ttasjwi.board.system.article.domain.ArticleReadResponse
+import com.ttasjwi.board.system.article.domain.fixture.ArticleReadUseCaseFixture
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+
+@DisplayName("[article-web-adapter] ArticleReadController: 게시글 조회 컨트롤러")
+class ArticleReadControllerTest {
+
+    private lateinit var controller: ArticleReadController
+
+    @BeforeEach
+    fun setup() {
+        controller = ArticleReadController(ArticleReadUseCaseFixture())
+    }
+
+    @Test
+    @DisplayName("유즈케이스를 통해 요청을 처리하고, 200 응답을 반환한다.")
+    fun test() {
+        // given
+        val articleId = 1245567L
+
+        // when
+        val responseEntity = controller.read(articleId)
+        val response = responseEntity.body as ArticleReadResponse
+
+        // then
+        assertThat(responseEntity.statusCode.value()).isEqualTo(HttpStatus.OK.value())
+        assertThat(response.articleId).isEqualTo(articleId.toString())
+        assertThat(response.title).isNotNull()
+        assertThat(response.content).isNotNull()
+        assertThat(response.boardId).isNotNull()
+        assertThat(response.articleCategoryId).isNotNull()
+        assertThat(response.writerId).isNotNull()
+        assertThat(response.writerNickname).isNotNull()
+        assertThat(response.createdAt).isNotNull()
+        assertThat(response.writerId).isNotNull()
+    }
+}


### PR DESCRIPTION
# JIRA 티켓
- [BRD-120]

---

# 개요
- 사용자는 누구든지(비회원, 회원) 특정 게시글을 조회할 수 있다.
- 이후 정책 추가에 따라, 관리자에 의해 차단된 게시글인 경우 특정 게시글에 접근이 불허될 수 있다.
- 조회수 증가는 별도의 API를 통해 구현할 예정이다.
- 이후 별도의 게시글 조회 최적화 서비스 기능을 통해, 게시글 조회기능을 확장시킬 계획이다.

---


[BRD-120]: https://ttasjwi.atlassian.net/browse/BRD-120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ