### PR TITLE
Feature: (BRD-138) 댓글 목록 조회 API 구현 (페이징)

### DIFF
--- a/board-system-app/src/docs/asciidoc/article-comment-api.adoc
+++ b/board-system-app/src/docs/asciidoc/article-comment-api.adoc
@@ -45,3 +45,29 @@ include::{snippets}/article-comment-read-success/response-fields.adoc[]
 ==== 예시
 include::{snippets}/article-comment-read-success/http-request.adoc[]
 include::{snippets}/article-comment-read-success/http-response.adoc[]
+
+
+=== 게시글 댓글 목록 조회(페이지)
+==== 기본정보
+- 메서드 : GET
+- URL : `/api/v1/article-comments`
+- 권한 : 누구든지
+
+게시글의 댓글 목록을 페이지 단위로 조회합니다.
+
+==== 요청
+include::{snippets}/article-comment-page-read-success/query-parameters.adoc[]
+
+==== 응답
+include::{snippets}/article-comment-page-read-success/response-fields.adoc[]
+
+===== 응답 참고사항 : `deleteStatus` 필드?
+댓글 관련 응답에서는, 댓글의 삭제 상태를 설명하는 `deleteStatus` 필드가 포함됩니다. 이 `deleteStatus` 는 다음 유형이 있습니다.
+
+- `NOT_DELETED`: 댓글이 삭제되지 않은 댓글일 경우
+- `DELETED_BY_WRITER`: 댓글이 댓글 작성자 본인에 의해 삭제된 댓글일 경우
+- `DELETED_BY_MANAGER`: 댓글이 관리자에 의해 삭제된 댓글일 경우
+
+==== 예시
+include::{snippets}/article-comment-page-read-success/http-request.adoc[]
+include::{snippets}/article-comment-page-read-success/http-response.adoc[]

--- a/board-system-app/src/main/resources/local-schema.sql
+++ b/board-system-app/src/main/resources/local-schema.sql
@@ -57,7 +57,7 @@ CREATE TABLE IF NOT EXISTS article_comments(
     article_id                     BIGINT        NOT NULL,
     root_parent_comment_id         BIGINT        NOT NULL,
     writer_id                      BIGINT        NOT NULL,
-    writer_nickname                VARCHAR(15)   NOT NULL UNIQUE,
+    writer_nickname                VARCHAR(15)   NOT NULL,
     parent_comment_writer_id       BIGINT,
     parent_comment_writer_nickname VARCHAR(15),
     delete_status                  VARCHAR(20)   NOT NULL,

--- a/board-system-app/src/test/resources/test-schema.sql
+++ b/board-system-app/src/test/resources/test-schema.sql
@@ -98,7 +98,7 @@ CREATE TABLE IF NOT EXISTS article_comments(
     article_id                     BIGINT        NOT NULL,
     root_parent_comment_id         BIGINT        NOT NULL,
     writer_id                      BIGINT        NOT NULL,
-    writer_nickname                VARCHAR(15)   NOT NULL UNIQUE,
+    writer_nickname                VARCHAR(15)   NOT NULL,
     parent_comment_writer_id       BIGINT,
     parent_comment_writer_nickname VARCHAR(15),
     delete_status                  VARCHAR(20)   NOT NULL,

--- a/board-system-article-comment/article-comment-application-input-port/src/main/kotlin/com/ttasjwi/board/system/articlecomment/domain/ArticleCommentPageReadUseCase.kt
+++ b/board-system-article-comment/article-comment-application-input-port/src/main/kotlin/com/ttasjwi/board/system/articlecomment/domain/ArticleCommentPageReadUseCase.kt
@@ -1,0 +1,43 @@
+package com.ttasjwi.board.system.articlecomment.domain
+
+import java.time.ZonedDateTime
+
+interface ArticleCommentPageReadUseCase {
+    fun readAllPage(request: ArticleCommentPageReadRequest): ArticleCommentPageReadResponse
+}
+
+data class ArticleCommentPageReadRequest(
+    val articleId: Long?,
+    val page: Long?,
+    val pageSize: Long?
+)
+
+data class ArticleCommentPageReadResponse(
+    val page: Long,
+    val pageSize: Long,
+    val pageGroupSize: Long,
+    val pageGroupStart: Long,
+    val pageGroupEnd: Long,
+    val hasNextPage: Boolean,
+    val hasNextPageGroup: Boolean,
+    val comments: List<CommentItem>,
+) {
+
+    data class CommentItem(
+        val deleteStatus: String,
+        val data: Data?,
+    ) {
+        data class Data(
+            val articleCommentId: String,
+            val content: String,
+            val articleId: String,
+            val rootParentCommentId: String,
+            val writerId: String,
+            val writerNickname: String,
+            val parentCommentWriterId: String?,
+            val parentCommentWriterNickname: String?,
+            val createdAt: ZonedDateTime,
+            val modifiedAt: ZonedDateTime,
+        )
+    }
+}

--- a/board-system-article-comment/article-comment-application-output-port/src/main/kotlin/com/ttasjwi/board/system/articlecomment/domain/port/ArticleCommentPersistencePort.kt
+++ b/board-system-article-comment/article-comment-application-output-port/src/main/kotlin/com/ttasjwi/board/system/articlecomment/domain/port/ArticleCommentPersistencePort.kt
@@ -6,4 +6,7 @@ interface ArticleCommentPersistencePort {
 
     fun save(articleComment: ArticleComment): ArticleComment
     fun findById(articleCommentId: Long): ArticleComment?
+
+    fun findAllPage(articleId: Long, offset: Long, limit: Long): List<ArticleComment>
+    fun count(articleId: Long, limit: Long): Long
 }

--- a/board-system-article-comment/article-comment-application-output-port/src/test/kotlin/com/ttasjwi/board/system/articlecomment/domain/port/fixture/ArticleCommentPersistencePortFixtureTest.kt
+++ b/board-system-article-comment/article-comment-application-output-port/src/test/kotlin/com/ttasjwi/board/system/articlecomment/domain/port/fixture/ArticleCommentPersistencePortFixtureTest.kt
@@ -59,4 +59,122 @@ class ArticleCommentPersistencePortFixtureTest {
             assertThat(findArticleComment).isNull()
         }
     }
+
+    @Test
+    @DisplayName("findAllPage: OffSet부터 시작하여, pageSize 만큼의 댓글을 가져온다.")
+    fun findAllPageTest() {
+        // given
+        val articleId = 1234566L
+
+        for (i in 1..10) {
+            val commentId = i.toLong()
+            val comment = if (commentId <= 5L) {
+                articleCommentFixture(
+                    articleCommentId = commentId,
+                    rootParentCommentId = commentId,
+                    articleId = articleId,
+                )
+            } else {
+                articleCommentFixture(
+                    articleCommentId = commentId,
+                    rootParentCommentId = commentId - 5L,
+                    articleId = articleId,
+                )
+            }
+            articleCommentPersistencePortFixture.save(comment)
+        }
+
+        // when
+        val articles = articleCommentPersistencePortFixture.findAllPage(
+            articleId = articleId,
+            offset = 3,
+            limit = 3,
+        )
+
+        // then
+        // 1
+        // └ 6
+        // 2
+        // --------------------- 여기서부터
+        // └ 7
+        // 3
+        // └ 8
+        // ----------------------- 여기까지
+        // 4
+        // └ 9
+        // 5
+        // └ 10
+        val articleCommentIds = articles.map { it.articleCommentId }
+
+        assertThat(articleCommentIds.size).isEqualTo(3)
+        assertThat(articleCommentIds).containsExactly(7, 3, 8)
+    }
+
+    @Nested
+    @DisplayName("count: 최대 limit 건까지 범위 내에서 댓글의 갯수를 센다.")
+    inner class CountTest {
+
+        @Test
+        @DisplayName("댓글 갯수가 limit 보다 같거나, 많으면, limit 만큼 갯수를 센다.")
+        fun test1() {
+            // given
+            val articleId = 1234566L
+
+            for (i in 1..10) {
+                val commentId = i.toLong()
+                val comment = if (commentId <= 5L) {
+                    articleCommentFixture(
+                        articleCommentId = commentId,
+                        rootParentCommentId = commentId,
+                        articleId = articleId,
+                    )
+                } else {
+                    articleCommentFixture(
+                        articleCommentId = commentId,
+                        rootParentCommentId = commentId - 5L,
+                        articleId = articleId,
+                    )
+                }
+                articleCommentPersistencePortFixture.save(comment)
+            }
+
+            // when
+            val count = articleCommentPersistencePortFixture.count(articleId, 9)
+
+            // then
+            assertThat(count).isEqualTo(9)
+        }
+
+
+        @Test
+        @DisplayName("댓글 갯수가 limit 보다 적으면 댓글 갯수까지만큼 센다.")
+        fun test2() {
+            // given
+            val articleId = 1234566L
+
+            for (i in 1..10) {
+                val commentId = i.toLong()
+                val comment = if (commentId <= 5L) {
+                    articleCommentFixture(
+                        articleCommentId = commentId,
+                        rootParentCommentId = commentId,
+                        articleId = articleId,
+                    )
+                } else {
+                    articleCommentFixture(
+                        articleCommentId = commentId,
+                        rootParentCommentId = commentId - 5L,
+                        articleId = articleId,
+                    )
+                }
+                articleCommentPersistencePortFixture.save(comment)
+            }
+
+            // when
+            val count = articleCommentPersistencePortFixture.count(articleId, 15)
+
+            // then
+            assertThat(count).isEqualTo(10)
+        }
+    }
 }

--- a/board-system-article-comment/article-comment-application-output-port/src/testFixtures/kotlin/com/ttasjwi/board/system/articlecomment/domain/port/fixture/ArticleCommentPersistencePortFixture.kt
+++ b/board-system-article-comment/article-comment-application-output-port/src/testFixtures/kotlin/com/ttasjwi/board/system/articlecomment/domain/port/fixture/ArticleCommentPersistencePortFixture.kt
@@ -15,4 +15,23 @@ class ArticleCommentPersistencePortFixture : ArticleCommentPersistencePort {
     override fun findById(articleCommentId: Long): ArticleComment? {
         return storage[articleCommentId]
     }
+
+    override fun findAllPage(articleId: Long, offset: Long, limit: Long): List<ArticleComment> {
+        return storage.values
+            .filter { it.articleId == articleId }
+            .sortedWith(
+                compareBy<ArticleComment> { it.rootParentCommentId }
+                    .thenBy { it.articleCommentId }
+            )
+            .drop(offset.toInt())
+            .take(limit.toInt())
+    }
+
+    override fun count(articleId: Long, limit: Long): Long {
+        return storage.values
+            .filter { it.articleId == articleId }
+            .take(limit.toInt())
+            .count()
+            .toLong()
+    }
 }

--- a/board-system-article-comment/article-comment-application-service/src/main/kotlin/com/ttasjwi/board/system/articlecomment/domain/ArticleCommentPageReadUseCaseImpl.kt
+++ b/board-system-article-comment/article-comment-application-service/src/main/kotlin/com/ttasjwi/board/system/articlecomment/domain/ArticleCommentPageReadUseCaseImpl.kt
@@ -1,0 +1,17 @@
+package com.ttasjwi.board.system.articlecomment.domain
+
+import com.ttasjwi.board.system.articlecomment.domain.mapper.ArticleCommentPageReadQueryMapper
+import com.ttasjwi.board.system.articlecomment.domain.processor.ArticleCommentPageReadProcessor
+import com.ttasjwi.board.system.common.annotation.component.UseCase
+
+@UseCase
+internal class ArticleCommentPageReadUseCaseImpl(
+    private val queryMapper: ArticleCommentPageReadQueryMapper,
+    private val processor: ArticleCommentPageReadProcessor
+) : ArticleCommentPageReadUseCase {
+
+    override fun readAllPage(request: ArticleCommentPageReadRequest): ArticleCommentPageReadResponse {
+        val query = queryMapper.mapToQuery(request)
+        return processor.readAllPage(query)
+    }
+}

--- a/board-system-article-comment/article-comment-application-service/src/main/kotlin/com/ttasjwi/board/system/articlecomment/domain/dto/ArticleCommentPageReadQuery.kt
+++ b/board-system-article-comment/article-comment-application-service/src/main/kotlin/com/ttasjwi/board/system/articlecomment/domain/dto/ArticleCommentPageReadQuery.kt
@@ -1,0 +1,7 @@
+package com.ttasjwi.board.system.articlecomment.domain.dto
+
+data class ArticleCommentPageReadQuery(
+    val articleId: Long,
+    val page: Long,
+    val pageSize: Long
+)

--- a/board-system-article-comment/article-comment-application-service/src/main/kotlin/com/ttasjwi/board/system/articlecomment/domain/mapper/ArticleCommentPageReadQueryMapper.kt
+++ b/board-system-article-comment/article-comment-application-service/src/main/kotlin/com/ttasjwi/board/system/articlecomment/domain/mapper/ArticleCommentPageReadQueryMapper.kt
@@ -1,0 +1,59 @@
+package com.ttasjwi.board.system.articlecomment.domain.mapper
+
+import com.ttasjwi.board.system.articlecomment.domain.ArticleCommentPageReadRequest
+import com.ttasjwi.board.system.articlecomment.domain.dto.ArticleCommentPageReadQuery
+import com.ttasjwi.board.system.articlecomment.domain.exception.InvalidArticleCommentPageSizeException
+import com.ttasjwi.board.system.common.annotation.component.ApplicationQueryMapper
+import com.ttasjwi.board.system.common.exception.NullArgumentException
+import com.ttasjwi.board.system.common.exception.ValidationExceptionCollector
+
+@ApplicationQueryMapper
+internal class ArticleCommentPageReadQueryMapper {
+
+    companion object {
+        internal const val MIN_PAGE_SIZE = 1L
+        internal const val MAX_PAGE_SIZE = 50L
+    }
+
+    fun mapToQuery(request: ArticleCommentPageReadRequest): ArticleCommentPageReadQuery {
+        val exceptionCollector = ValidationExceptionCollector()
+        val articleId = getArticleId(request.articleId, exceptionCollector)
+        val page = getPage(request.page, exceptionCollector)
+        val pageSize = getPageSize(request.pageSize, exceptionCollector)
+        exceptionCollector.throwIfNotEmpty()
+
+        return ArticleCommentPageReadQuery(
+            articleId = articleId!!,
+            page = page!!,
+            pageSize = pageSize!!
+        )
+    }
+
+    private fun getArticleId(articleId: Long?, exceptionCollector: ValidationExceptionCollector): Long? {
+        if (articleId == null) {
+            exceptionCollector.addCustomExceptionOrThrow(NullArgumentException("articleId"))
+            return null
+        }
+        return articleId
+    }
+
+    private fun getPage(page: Long?, exceptionCollector: ValidationExceptionCollector): Long? {
+        if (page == null) {
+            exceptionCollector.addCustomExceptionOrThrow(NullArgumentException("page"))
+            return null
+        }
+        return page
+    }
+
+    private fun getPageSize(pageSize: Long?, exceptionCollector: ValidationExceptionCollector): Long? {
+        if (pageSize == null) {
+            exceptionCollector.addCustomExceptionOrThrow(NullArgumentException("pageSize"))
+            return null
+        }
+        if (pageSize < MIN_PAGE_SIZE || pageSize > MAX_PAGE_SIZE) {
+            exceptionCollector.addCustomExceptionOrThrow(InvalidArticleCommentPageSizeException(pageSize, MIN_PAGE_SIZE, MAX_PAGE_SIZE))
+            return null
+        }
+        return pageSize
+    }
+}

--- a/board-system-article-comment/article-comment-application-service/src/main/kotlin/com/ttasjwi/board/system/articlecomment/domain/processor/ArticleCommentPageReadProcessor.kt
+++ b/board-system-article-comment/article-comment-application-service/src/main/kotlin/com/ttasjwi/board/system/articlecomment/domain/processor/ArticleCommentPageReadProcessor.kt
@@ -1,0 +1,87 @@
+package com.ttasjwi.board.system.articlecomment.domain.processor
+
+import com.ttasjwi.board.system.articlecomment.domain.ArticleCommentPageReadResponse
+import com.ttasjwi.board.system.articlecomment.domain.dto.ArticleCommentPageReadQuery
+import com.ttasjwi.board.system.articlecomment.domain.model.ArticleComment
+import com.ttasjwi.board.system.articlecomment.domain.port.ArticleCommentPersistencePort
+import com.ttasjwi.board.system.common.annotation.component.ApplicationProcessor
+import com.ttasjwi.board.system.common.page.PagingInfo
+import com.ttasjwi.board.system.common.page.calculateOffset
+import com.ttasjwi.board.system.common.page.calculatePageLimit
+
+@ApplicationProcessor
+internal class ArticleCommentPageReadProcessor(
+    private val articleCommentPersistencePort: ArticleCommentPersistencePort
+) {
+
+    companion object {
+        internal const val ARTICLE_COMMENT_PAGE_GROUP_SIZE = 10L
+    }
+
+    fun readAllPage(query: ArticleCommentPageReadQuery): ArticleCommentPageReadResponse {
+        val commentCount = readCommentCount(query)
+        val comments = readComments(query)
+
+        val pagingInfo = PagingInfo.from(
+            page = query.page,
+            pageSize = query.pageSize,
+            totalCount = commentCount,
+            pageGroupSize = ARTICLE_COMMENT_PAGE_GROUP_SIZE
+        )
+
+        return makeResponse(pagingInfo, comments)
+    }
+
+    private fun readCommentCount(query: ArticleCommentPageReadQuery) = articleCommentPersistencePort.count(
+        articleId = query.articleId,
+        limit = calculatePageLimit(
+            page = query.page,
+            pageSize = query.pageSize,
+            movablePageCount = ARTICLE_COMMENT_PAGE_GROUP_SIZE
+        )
+    )
+
+    private fun readComments(query: ArticleCommentPageReadQuery) =
+        articleCommentPersistencePort.findAllPage(
+            articleId = query.articleId,
+            offset = calculateOffset(
+                page = query.page,
+                pageSize = query.pageSize
+            ),
+            limit = query.pageSize
+        )
+
+    private fun makeResponse(
+        pagingInfo: PagingInfo,
+        comments: List<ArticleComment>
+    ) = ArticleCommentPageReadResponse(
+        page = pagingInfo.page,
+        pageSize = pagingInfo.pageSize,
+        pageGroupSize = pagingInfo.pageGroupSize,
+        pageGroupStart = pagingInfo.pageGroupStart,
+        pageGroupEnd = pagingInfo.pageGroupEnd,
+        hasNextPage = pagingInfo.hasNextPage,
+        hasNextPageGroup = pagingInfo.hasNextPageGroup,
+        comments = comments.map { it.toCommentItem() }
+    )
+
+    private fun ArticleComment.toCommentItem(): ArticleCommentPageReadResponse.CommentItem {
+        return ArticleCommentPageReadResponse.CommentItem(
+            deleteStatus = this.deleteStatus.name,
+            data = if (!this.isDeleted()) {
+                ArticleCommentPageReadResponse.CommentItem.Data(
+                    articleCommentId = this.articleCommentId.toString(),
+                    content = this.content,
+                    articleId = this.articleId.toString(),
+                    rootParentCommentId = this.rootParentCommentId.toString(),
+                    writerId = this.writerId.toString(),
+                    writerNickname = this.writerNickname,
+                    parentCommentWriterId = this.parentCommentWriterId?.toString(),
+                    parentCommentWriterNickname = this.parentCommentWriterNickname,
+                    createdAt = this.createdAt.toZonedDateTime(),
+                    modifiedAt = this.modifiedAt.toZonedDateTime(),
+                )
+            } else null
+        )
+    }
+}

--- a/board-system-article-comment/article-comment-application-service/src/test/kotlin/com/ttasjwi/board/system/articlecomment/domain/ArticleCommentPageReadUseCaseImplTest.kt
+++ b/board-system-article-comment/article-comment-application-service/src/test/kotlin/com/ttasjwi/board/system/articlecomment/domain/ArticleCommentPageReadUseCaseImplTest.kt
@@ -1,0 +1,76 @@
+package com.ttasjwi.board.system.articlecomment.domain
+
+import com.ttasjwi.board.system.articlecomment.domain.model.ArticleCommentDeleteStatus
+import com.ttasjwi.board.system.articlecomment.domain.model.fixture.articleCommentFixture
+import com.ttasjwi.board.system.articlecomment.domain.port.fixture.ArticleCommentPersistencePortFixture
+import com.ttasjwi.board.system.articlecomment.domain.processor.ArticleCommentPageReadProcessor
+import com.ttasjwi.board.system.articlecomment.domain.test.support.TestContainer
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+
+@DisplayName("[article-comment-application-service] ArticleCommentPageReadUseCase 테스트")
+class ArticleCommentPageReadUseCaseImplTest {
+
+    private lateinit var useCase: ArticleCommentPageReadUseCase
+    private lateinit var articleCommentPersistencePortFixture: ArticleCommentPersistencePortFixture
+
+    @BeforeEach
+    fun setUp() {
+        val container = TestContainer.create()
+        useCase = container.articleCommentPageReadUseCase
+        articleCommentPersistencePortFixture = container.articleCommentPersistencePortFixture
+    }
+    @Test
+    @DisplayName("성공테스트")
+    fun testSuccess() {
+        // given
+        val articleId = 1234566L
+
+        for (i in 1..100) {
+            val commentId = i.toLong()
+            val comment = if (commentId <= 50L) {
+                articleCommentFixture(
+                    articleCommentId = commentId,
+                    rootParentCommentId = commentId,
+                    articleId = articleId,
+                    deleteStatus = ArticleCommentDeleteStatus.NOT_DELETED
+                )
+            } else {
+                articleCommentFixture(
+                    articleCommentId = commentId,
+                    rootParentCommentId = commentId - 50L,
+                    articleId = articleId,
+                    deleteStatus = ArticleCommentDeleteStatus.NOT_DELETED
+                )
+            }
+            articleCommentPersistencePortFixture.save(comment)
+        }
+
+        val request = ArticleCommentPageReadRequest(
+            articleId = articleId,
+            page = 2L,
+            pageSize = 3L
+        )
+
+        // when
+        val response = useCase.readAllPage(request)
+        val articleCommentIds = response.comments.map { it.data!!.articleCommentId }
+        val deleteStatuses = response.comments.map { it.deleteStatus }.toSet()
+
+        assertThat(response.page).isEqualTo(request.page)
+        assertThat(response.pageSize).isEqualTo(request.pageSize)
+        assertThat(response.pageGroupSize).isEqualTo(ArticleCommentPageReadProcessor.ARTICLE_COMMENT_PAGE_GROUP_SIZE)
+        assertThat(response.pageGroupStart).isEqualTo(1)
+        assertThat(response.pageGroupEnd).isEqualTo(10L)
+        assertThat(response.hasNextPage).isTrue()
+        assertThat(response.hasNextPageGroup).isTrue()
+        assertThat(response.comments).hasSize(request.pageSize!!.toInt())
+
+        // 1 51 2 / 52 3 53 / ...
+        assertThat(articleCommentIds).containsExactly("52", "3", "53")
+        assertThat(deleteStatuses).containsExactly(ArticleCommentDeleteStatus.NOT_DELETED.name)
+    }
+}

--- a/board-system-article-comment/article-comment-application-service/src/test/kotlin/com/ttasjwi/board/system/articlecomment/domain/mapper/ArticleCommentPageReadQueryMapperTest.kt
+++ b/board-system-article-comment/article-comment-application-service/src/test/kotlin/com/ttasjwi/board/system/articlecomment/domain/mapper/ArticleCommentPageReadQueryMapperTest.kt
@@ -1,0 +1,165 @@
+package com.ttasjwi.board.system.articlecomment.domain.mapper
+
+import com.ttasjwi.board.system.articlecomment.domain.ArticleCommentPageReadRequest
+import com.ttasjwi.board.system.articlecomment.domain.exception.InvalidArticleCommentPageSizeException
+import com.ttasjwi.board.system.articlecomment.domain.test.support.TestContainer
+import com.ttasjwi.board.system.common.exception.NullArgumentException
+import com.ttasjwi.board.system.common.exception.ValidationExceptionCollector
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+@DisplayName("[article-comment-application-service] ArticleCommentPageReadQueryMapper 테스트 ")
+class ArticleCommentPageReadQueryMapperTest {
+
+    private lateinit var queryMapper: ArticleCommentPageReadQueryMapper
+
+    @BeforeEach
+    fun setup() {
+        val container = TestContainer.create()
+        queryMapper = container.articleCommentPageReadQueryMapper
+    }
+
+
+    @Test
+    @DisplayName("성공 테스트")
+    fun testSuccess() {
+        // given
+        val request = ArticleCommentPageReadRequest(
+            articleId = 1L,
+            page = 3L,
+            pageSize = 10L
+        )
+
+        // when
+        val query = queryMapper.mapToQuery(request)
+
+        // then
+        assertThat(query.articleId).isEqualTo(request.articleId)
+        assertThat(query.page).isEqualTo(request.page)
+        assertThat(query.pageSize).isEqualTo(request.pageSize)
+    }
+
+    @Test
+    @DisplayName("articleId 가 null 이면 예외 발생")
+    fun articleIdNullTest() {
+        // given
+        val request = ArticleCommentPageReadRequest(
+            articleId = null,
+            page = 3,
+            pageSize = 10
+        )
+
+        // when
+        val exceptionCollector = assertThrows<ValidationExceptionCollector> {
+            queryMapper.mapToQuery(request)
+        }
+
+        // then
+        val exceptions = exceptionCollector.getExceptions()
+        assertThat(exceptions.size).isEqualTo(1)
+        assertThat(exceptions[0]).isInstanceOf(NullArgumentException::class.java)
+        assertThat(exceptions[0].source).isEqualTo("articleId")
+    }
+
+    @Test
+    @DisplayName("page 가 null 이면 예외 발생")
+    fun pageNullTest() {
+        // given
+        val request = ArticleCommentPageReadRequest(
+            articleId = 1234L,
+            page = null,
+            pageSize = 10
+        )
+
+        // when
+        val exceptionCollector = assertThrows<ValidationExceptionCollector> {
+            queryMapper.mapToQuery(request)
+        }
+
+        // then
+        val exceptions = exceptionCollector.getExceptions()
+        assertThat(exceptions.size).isEqualTo(1)
+        assertThat(exceptions[0]).isInstanceOf(NullArgumentException::class.java)
+        assertThat(exceptions[0].source).isEqualTo("page")
+    }
+
+
+    @Test
+    @DisplayName("pageSize 가 null 이면 예외 발생")
+    fun pageSizeNullTest() {
+        // given
+        val request = ArticleCommentPageReadRequest(
+            articleId = 1234L,
+            page = 1,
+            pageSize = null
+        )
+
+        // when
+        val exceptionCollector = assertThrows<ValidationExceptionCollector> {
+            queryMapper.mapToQuery(request)
+        }
+
+        // then
+        val exceptions = exceptionCollector.getExceptions()
+        assertThat(exceptions.size).isEqualTo(1)
+        assertThat(exceptions[0]).isInstanceOf(NullArgumentException::class.java)
+        assertThat(exceptions[0].source).isEqualTo("pageSize")
+    }
+
+    @Test
+    @DisplayName("pageSize 범위가 최소 pageSize 범위보다 작으면 예외 발생")
+    fun invalidPageSizeTest1() {
+        // given
+        val request = ArticleCommentPageReadRequest(
+            articleId = 1234L,
+            page = 1,
+            pageSize = ArticleCommentPageReadQueryMapper.MIN_PAGE_SIZE - 1L
+        )
+
+        // when
+        val exceptionCollector = assertThrows<ValidationExceptionCollector> {
+            queryMapper.mapToQuery(request)
+        }
+
+        // then
+        val exceptions = exceptionCollector.getExceptions()
+        assertThat(exceptions.size).isEqualTo(1)
+        assertThat(exceptions[0]).isInstanceOf(InvalidArticleCommentPageSizeException::class.java)
+        assertThat(exceptions[0].source).isEqualTo("pageSize")
+        assertThat(exceptions[0].args).containsExactly(
+            request.pageSize,
+            ArticleCommentPageReadQueryMapper.MIN_PAGE_SIZE,
+            ArticleCommentPageReadQueryMapper.MAX_PAGE_SIZE
+        )
+    }
+
+    @Test
+    @DisplayName("pageSize 범위가 최대 pageSize 범위를 넘으면 예외 발생")
+    fun invalidPageSizeTest2() {
+        // given
+        val request = ArticleCommentPageReadRequest(
+            articleId = 1234L,
+            page = 1,
+            pageSize = ArticleCommentPageReadQueryMapper.MAX_PAGE_SIZE + 1L
+        )
+
+        // when
+        val exceptionCollector = assertThrows<ValidationExceptionCollector> {
+            queryMapper.mapToQuery(request)
+        }
+
+        // then
+        val exceptions = exceptionCollector.getExceptions()
+        assertThat(exceptions.size).isEqualTo(1)
+        assertThat(exceptions[0]).isInstanceOf(InvalidArticleCommentPageSizeException::class.java)
+        assertThat(exceptions[0].source).isEqualTo("pageSize")
+        assertThat(exceptions[0].args).containsExactly(
+            request.pageSize,
+            ArticleCommentPageReadQueryMapper.MIN_PAGE_SIZE,
+            ArticleCommentPageReadQueryMapper.MAX_PAGE_SIZE
+        )
+    }
+}

--- a/board-system-article-comment/article-comment-application-service/src/test/kotlin/com/ttasjwi/board/system/articlecomment/domain/processor/ArticleCommentPageReadProcessorTest.kt
+++ b/board-system-article-comment/article-comment-application-service/src/test/kotlin/com/ttasjwi/board/system/articlecomment/domain/processor/ArticleCommentPageReadProcessorTest.kt
@@ -1,0 +1,136 @@
+package com.ttasjwi.board.system.articlecomment.domain.processor
+
+import com.ttasjwi.board.system.articlecomment.domain.dto.ArticleCommentPageReadQuery
+import com.ttasjwi.board.system.articlecomment.domain.model.ArticleComment
+import com.ttasjwi.board.system.articlecomment.domain.model.ArticleCommentDeleteStatus
+import com.ttasjwi.board.system.articlecomment.domain.model.fixture.articleCommentFixture
+import com.ttasjwi.board.system.articlecomment.domain.port.fixture.ArticleCommentPersistencePortFixture
+import com.ttasjwi.board.system.articlecomment.domain.test.support.TestContainer
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+
+@DisplayName("[article-comment-application-service] ArticleCommentPageReadProcessor 테스트")
+class ArticleCommentPageReadProcessorTest {
+
+    private lateinit var processor: ArticleCommentPageReadProcessor
+    private lateinit var articleCommentPersistencePortFixture: ArticleCommentPersistencePortFixture
+
+    @BeforeEach
+    fun setup() {
+        val container = TestContainer.create()
+        processor = container.articleCommentPageReadProcessor
+        articleCommentPersistencePortFixture = container.articleCommentPersistencePortFixture
+    }
+
+    @Test
+    @DisplayName("성공테스트")
+    fun testSuccess() {
+        // given
+        val articleId = 1234566L
+
+        for (i in 1..100) {
+            val commentId = i.toLong()
+            val comment = if (commentId <= 50L) {
+                articleCommentFixture(
+                    articleCommentId = commentId,
+                    rootParentCommentId = commentId,
+                    articleId = articleId,
+                    deleteStatus = ArticleCommentDeleteStatus.NOT_DELETED
+                )
+            } else {
+                articleCommentFixture(
+                    articleCommentId = commentId,
+                    rootParentCommentId = commentId - 50L,
+                    articleId = articleId,
+                    deleteStatus = ArticleCommentDeleteStatus.NOT_DELETED
+                )
+            }
+            articleCommentPersistencePortFixture.save(comment)
+        }
+
+        val query = ArticleCommentPageReadQuery(
+            articleId = articleId,
+            page = 2L,
+            pageSize = 3L
+        )
+
+        // when
+        val response = processor.readAllPage(query)
+        val articleCommentIds = response.comments.map { it.data!!.articleCommentId }
+        val deleteStatuses = response.comments.map { it.deleteStatus }.toSet()
+
+        assertThat(response.page).isEqualTo(query.page)
+        assertThat(response.pageSize).isEqualTo(query.pageSize)
+        assertThat(response.pageGroupSize).isEqualTo(ArticleCommentPageReadProcessor.ARTICLE_COMMENT_PAGE_GROUP_SIZE)
+        assertThat(response.pageGroupStart).isEqualTo(1)
+        assertThat(response.pageGroupEnd).isEqualTo(10L)
+        assertThat(response.hasNextPage).isTrue()
+        assertThat(response.hasNextPageGroup).isTrue()
+        assertThat(response.comments).hasSize(query.pageSize.toInt())
+
+        // 1 51 2 / 52 3 53 / ...
+        assertThat(articleCommentIds).containsExactly("52", "3", "53")
+        assertThat(deleteStatuses).containsExactly(ArticleCommentDeleteStatus.NOT_DELETED.name)
+    }
+
+
+    @Test
+    @DisplayName("삭제된 댓글은 노출되지 않는다.")
+    fun testDeleted() {
+        // given
+        val articleId = 1234566L
+
+        for (i in 1..100) {
+            val commentId = i.toLong()
+            val comment = if (commentId <= 50L) {
+                articleCommentFixture(
+                    articleCommentId = commentId,
+                    rootParentCommentId = commentId,
+                    articleId = articleId,
+                    deleteStatus = ArticleCommentDeleteStatus.DELETED_BY_WRITER
+                )
+            } else {
+                articleCommentFixture(
+                    articleCommentId = commentId,
+                    rootParentCommentId = commentId - 50L,
+                    articleId = articleId,
+                    deleteStatus = ArticleCommentDeleteStatus.NOT_DELETED
+                )
+            }
+            articleCommentPersistencePortFixture.save(comment)
+        }
+
+        val query = ArticleCommentPageReadQuery(
+            articleId = articleId,
+            page = 2L,
+            pageSize = 3L
+        )
+
+        // when
+        val response = processor.readAllPage(query)
+        val articleCommentIds = response.comments.mapNotNull {
+            it.data?.articleCommentId
+        }
+        val deleteStatuses = response.comments.map { it.deleteStatus }
+
+        assertThat(response.page).isEqualTo(query.page)
+        assertThat(response.pageSize).isEqualTo(query.pageSize)
+        assertThat(response.pageGroupSize).isEqualTo(ArticleCommentPageReadProcessor.ARTICLE_COMMENT_PAGE_GROUP_SIZE)
+        assertThat(response.pageGroupStart).isEqualTo(1)
+        assertThat(response.pageGroupEnd).isEqualTo(10L)
+        assertThat(response.hasNextPage).isTrue()
+        assertThat(response.hasNextPageGroup).isTrue()
+        assertThat(response.comments).hasSize(query.pageSize.toInt())
+
+        // 1 51 2 / [52 3(삭제됨) 53] / ...
+        assertThat(articleCommentIds).containsExactly("52", "53")
+        assertThat(deleteStatuses).containsExactly(
+            ArticleCommentDeleteStatus.NOT_DELETED.name,
+            ArticleCommentDeleteStatus.DELETED_BY_WRITER.name,
+            ArticleCommentDeleteStatus.NOT_DELETED.name
+        )
+    }
+}

--- a/board-system-article-comment/article-comment-application-service/src/test/kotlin/com/ttasjwi/board/system/articlecomment/domain/test/support/TestContainer.kt
+++ b/board-system-article-comment/article-comment-application-service/src/test/kotlin/com/ttasjwi/board/system/articlecomment/domain/test/support/TestContainer.kt
@@ -1,15 +1,15 @@
 package com.ttasjwi.board.system.articlecomment.domain.test.support
 
-import com.ttasjwi.board.system.articlecomment.domain.ArticleCommentCreateUseCase
+import com.ttasjwi.board.system.articlecomment.domain.*
 import com.ttasjwi.board.system.articlecomment.domain.ArticleCommentCreateUseCaseImpl
-import com.ttasjwi.board.system.articlecomment.domain.ArticleCommentReadUseCase
-import com.ttasjwi.board.system.articlecomment.domain.ArticleCommentReadUseCaseImpl
 import com.ttasjwi.board.system.articlecomment.domain.mapper.ArticleCommentCreateCommandMapper
+import com.ttasjwi.board.system.articlecomment.domain.mapper.ArticleCommentPageReadQueryMapper
 import com.ttasjwi.board.system.articlecomment.domain.policy.fixture.ArticleCommentContentPolicyFixture
 import com.ttasjwi.board.system.articlecomment.domain.port.fixture.ArticleCommentPersistencePortFixture
 import com.ttasjwi.board.system.articlecomment.domain.port.fixture.ArticleCommentWriterNicknamePersistencePortFixture
 import com.ttasjwi.board.system.articlecomment.domain.port.fixture.ArticlePersistencePortFixture
 import com.ttasjwi.board.system.articlecomment.domain.processor.ArticleCommentCreateProcessor
+import com.ttasjwi.board.system.articlecomment.domain.processor.ArticleCommentPageReadProcessor
 import com.ttasjwi.board.system.common.auth.fixture.AuthUserLoaderFixture
 import com.ttasjwi.board.system.common.time.fixture.TimeManagerFixture
 
@@ -56,12 +56,22 @@ internal class TestContainer private constructor() {
         )
     }
 
+    val articleCommentPageReadQueryMapper: ArticleCommentPageReadQueryMapper by lazy {
+        ArticleCommentPageReadQueryMapper()
+    }
+
     // processor
     val articleCommentCreateProcessor: ArticleCommentCreateProcessor by lazy {
         ArticleCommentCreateProcessor(
             articleCommentPersistencePort = articleCommentPersistencePortFixture,
             articlePersistencePort = articlePersistencePortFixture,
             articleCommentWriterNicknamePersistencePort = articleCommentWriterNicknamePersistencePortFixture,
+        )
+    }
+
+    val articleCommentPageReadProcessor: ArticleCommentPageReadProcessor by lazy {
+        ArticleCommentPageReadProcessor(
+            articleCommentPersistencePort = articleCommentPersistencePortFixture,
         )
     }
 
@@ -76,6 +86,13 @@ internal class TestContainer private constructor() {
     val articleCommentReadUseCase: ArticleCommentReadUseCase by lazy {
         ArticleCommentReadUseCaseImpl(
             articleCommentPersistencePort = articleCommentPersistencePortFixture
+        )
+    }
+
+    val articleCommentPageReadUseCase: ArticleCommentPageReadUseCase by lazy {
+        ArticleCommentPageReadUseCaseImpl(
+            queryMapper = articleCommentPageReadQueryMapper,
+            processor = articleCommentPageReadProcessor,
         )
     }
 }

--- a/board-system-article-comment/article-comment-database-adapter/src/main/kotlin/com/ttasjwi/board/system/articlecomment/infra/persistence/ArticleCommentPersistenceAdapter.kt
+++ b/board-system-article-comment/article-comment-database-adapter/src/main/kotlin/com/ttasjwi/board/system/articlecomment/infra/persistence/ArticleCommentPersistenceAdapter.kt
@@ -21,4 +21,14 @@ class ArticleCommentPersistenceAdapter(
     override fun findById(articleCommentId: Long): ArticleComment? {
         return jpaArticleCommentRepository.findByIdOrNull(articleCommentId)?.restoreDomain()
     }
+
+    override fun findAllPage(articleId: Long, offset: Long, limit: Long): List<ArticleComment> {
+        return jpaArticleCommentRepository
+            .findAllPage(articleId, offset, limit)
+            .map { it.restoreDomain() }
+    }
+
+    override fun count(articleId: Long, limit: Long): Long {
+        return jpaArticleCommentRepository.count(articleId, limit)
+    }
 }

--- a/board-system-article-comment/article-comment-database-adapter/src/main/kotlin/com/ttasjwi/board/system/articlecomment/infra/persistence/jpa/JpaArticleComment.kt
+++ b/board-system-article-comment/article-comment-database-adapter/src/main/kotlin/com/ttasjwi/board/system/articlecomment/infra/persistence/jpa/JpaArticleComment.kt
@@ -36,7 +36,7 @@ class JpaArticleComment(
 
     @Enumerated(EnumType.STRING)
     @Column(name = "delete_status")
-    var deleteStaus: ArticleCommentDeleteStatus,
+    var deleteStatus: ArticleCommentDeleteStatus,
 
     @Column(name = "created_at")
     val createdAt: LocalDateTime,
@@ -57,7 +57,7 @@ class JpaArticleComment(
                 writerNickname = articleComment.writerNickname,
                 parentCommentWriterId = articleComment.parentCommentWriterId,
                 parentCommentWriterNickname = articleComment.parentCommentWriterNickname,
-                deleteStaus = articleComment.deleteStatus,
+                deleteStatus = articleComment.deleteStatus,
                 createdAt = articleComment.createdAt.toLocalDateTime(),
                 modifiedAt = articleComment.modifiedAt.toLocalDateTime()
             )
@@ -74,7 +74,7 @@ class JpaArticleComment(
             writerNickname = this.writerNickname,
             parentCommentWriterId = this.parentCommentWriterId,
             parentCommentWriterNickname = this.parentCommentWriterNickname,
-            deleteStatus = this.deleteStaus,
+            deleteStatus = this.deleteStatus,
             createdAt = this.createdAt,
             modifiedAt = this.modifiedAt,
         )

--- a/board-system-article-comment/article-comment-database-adapter/src/main/kotlin/com/ttasjwi/board/system/articlecomment/infra/persistence/jpa/JpaArticleCommentRepository.kt
+++ b/board-system-article-comment/article-comment-database-adapter/src/main/kotlin/com/ttasjwi/board/system/articlecomment/infra/persistence/jpa/JpaArticleCommentRepository.kt
@@ -1,7 +1,54 @@
 package com.ttasjwi.board.system.articlecomment.infra.persistence.jpa
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 
 @Repository("articleCommentJpaArticleCommentRepository")
-interface JpaArticleCommentRepository : JpaRepository<JpaArticleComment, Long>
+interface JpaArticleCommentRepository : JpaRepository<JpaArticleComment, Long> {
+
+    @Query(
+        """
+        WITH cte AS (
+            SELECT article_comment_id
+            FROM article_comments
+            WHERE article_id = :articleId
+            LIMIT :limit
+        )
+        SELECT COUNT(*)
+        FROM cte
+        """, nativeQuery = true
+    )
+    fun count(
+        @Param("articleId")articleId: Long,
+        @Param("limit") limit: Long
+    ): Long
+
+    @Query(
+        """
+            SELECT 
+                article_comment_id,
+                content,
+                article_id,
+                root_parent_comment_id,
+                writer_id,
+                writer_nickname,
+                parent_comment_writer_id,
+                parent_comment_writer_nickname,
+                delete_status,
+                created_at,
+                modified_at
+            FROM article_comments
+            WHERE article_id = :articleId
+            ORDER BY root_parent_comment_id , article_comment_id
+            LIMIT :limit OFFSET :offset
+        """
+        , nativeQuery = true
+    )
+    fun findAllPage(
+        @Param("articleId") articleId: Long,
+        @Param("offset") offset: Long,
+        @Param("limit") limit: Long
+    ): List<JpaArticleComment>
+}

--- a/board-system-article-comment/article-comment-database-adapter/src/test/kotlin/com/ttasjwi/board/system/articlecomment/infra/persistence/ArticleCommentPersistenceAdapterTest.kt
+++ b/board-system-article-comment/article-comment-database-adapter/src/test/kotlin/com/ttasjwi/board/system/articlecomment/infra/persistence/ArticleCommentPersistenceAdapterTest.kt
@@ -51,4 +51,123 @@ class ArticleCommentPersistenceAdapterTest : ArticleCommentDataBaseIntegrationTe
             assertThat(findArticleComment).isNull()
         }
     }
+
+    @Test
+    @DisplayName("findAllPage: OffSet부터 시작하여, pageSize 만큼의 댓글을 가져온다.")
+    fun findAllPageTest() {
+        // given
+        val articleId = 1234566L
+
+        for (i in 1..10) {
+            val commentId = i.toLong()
+            val comment = if (commentId <= 5L) {
+                articleCommentFixture(
+                    articleCommentId = commentId,
+                    rootParentCommentId = commentId,
+                    articleId = articleId,
+                )
+            } else {
+                articleCommentFixture(
+                    articleCommentId = commentId,
+                    rootParentCommentId = commentId - 5L,
+                    articleId = articleId,
+                )
+            }
+            articleCommentPersistenceAdapter.save(comment)
+        }
+
+        // when
+        val articles = articleCommentPersistenceAdapter.findAllPage(
+            articleId = articleId,
+            offset = 3,
+            limit = 3,
+        )
+
+        // then
+        // 1
+        // └ 6
+        // 2
+        // --------------------- 여기서부터
+        // └ 7
+        // 3
+        // └ 8
+        // ----------------------- 여기까지
+        // 4
+        // └ 9
+        // 5
+        // └ 10
+        val articleCommentIds = articles.map { it.articleCommentId }
+
+        assertThat(articleCommentIds.size).isEqualTo(3)
+        assertThat(articleCommentIds).containsExactly(7, 3, 8)
+    }
+
+    @Nested
+    @DisplayName("count: 최대 limit 건까지 범위 내에서 댓글의 갯수를 센다.")
+    inner class CountTest {
+
+
+        @Test
+        @DisplayName("댓글 갯수가 limit 보다 같거나, 많으면, limit 만큼 갯수를 센다.")
+        fun test1() {
+            // given
+            val articleId = 1234566L
+
+            for (i in 1..10) {
+                val commentId = i.toLong()
+                val comment = if (commentId <= 5L) {
+                    articleCommentFixture(
+                        articleCommentId = commentId,
+                        rootParentCommentId = commentId,
+                        articleId = articleId,
+                    )
+                } else {
+                    articleCommentFixture(
+                        articleCommentId = commentId,
+                        rootParentCommentId = commentId - 5L,
+                        articleId = articleId,
+                    )
+                }
+                articleCommentPersistenceAdapter.save(comment)
+            }
+
+            // when
+            val count = articleCommentPersistenceAdapter.count(articleId, 9)
+
+            // then
+            assertThat(count).isEqualTo(9)
+        }
+
+
+        @Test
+        @DisplayName("댓글 갯수가 limit 보다 적으면 댓글 갯수까지만큼 센다.")
+        fun test2() {
+            // given
+            val articleId = 1234566L
+
+            for (i in 1..10) {
+                val commentId = i.toLong()
+                val comment = if (commentId <= 5L) {
+                    articleCommentFixture(
+                        articleCommentId = commentId,
+                        rootParentCommentId = commentId,
+                        articleId = articleId,
+                    )
+                } else {
+                    articleCommentFixture(
+                        articleCommentId = commentId,
+                        rootParentCommentId = commentId - 5L,
+                        articleId = articleId,
+                    )
+                }
+                articleCommentPersistenceAdapter.save(comment)
+            }
+
+            // when
+            val count = articleCommentPersistenceAdapter.count(articleId, 15)
+
+            // then
+            assertThat(count).isEqualTo(10)
+        }
+    }
 }

--- a/board-system-article-comment/article-comment-database-adapter/src/test/resources/test-schema.sql
+++ b/board-system-article-comment/article-comment-database-adapter/src/test/resources/test-schema.sql
@@ -98,7 +98,7 @@ CREATE TABLE IF NOT EXISTS article_comments(
     article_id                     BIGINT        NOT NULL,
     root_parent_comment_id         BIGINT        NOT NULL,
     writer_id                      BIGINT        NOT NULL,
-    writer_nickname                VARCHAR(15)   NOT NULL UNIQUE,
+    writer_nickname                VARCHAR(15)   NOT NULL,
     parent_comment_writer_id       BIGINT,
     parent_comment_writer_nickname VARCHAR(15),
     delete_status                  VARCHAR(20)   NOT NULL,

--- a/board-system-article-comment/article-comment-domain/src/main/kotlin/com/ttasjwi/board/system/articlecomment/domain/exception/InvalidArticleCommentPageSizeException.kt
+++ b/board-system-article-comment/article-comment-domain/src/main/kotlin/com/ttasjwi/board/system/articlecomment/domain/exception/InvalidArticleCommentPageSizeException.kt
@@ -1,0 +1,16 @@
+package com.ttasjwi.board.system.articlecomment.domain.exception
+
+import com.ttasjwi.board.system.common.exception.CustomException
+import com.ttasjwi.board.system.common.exception.ErrorStatus
+
+class InvalidArticleCommentPageSizeException(
+    pageSize: Long,
+    minPageSize: Long,
+    maxPageSize: Long,
+): CustomException(
+    status = ErrorStatus.BAD_REQUEST,
+    code = "Error.InvalidArticleCommentPageSize",
+    args = listOf(pageSize, minPageSize, maxPageSize),
+    source = "pageSize",
+    debugMessage = "댓글 목록 페이지 크기가 유효하지 않습니다. (요청 크기= $pageSize, 최소 크기=$minPageSize, 최대 크기= $maxPageSize)"
+)

--- a/board-system-article-comment/article-comment-domain/src/test/kotlin/com/ttasjwi/board/system/articlecomment/domain/exception/InvalidArticleCommentPageSizeExceptionTest.kt
+++ b/board-system-article-comment/article-comment-domain/src/test/kotlin/com/ttasjwi/board/system/articlecomment/domain/exception/InvalidArticleCommentPageSizeExceptionTest.kt
@@ -1,0 +1,33 @@
+package com.ttasjwi.board.system.articlecomment.domain.exception
+
+import com.ttasjwi.board.system.common.exception.ErrorStatus
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("[article-comment-domain] InvalidArticleCommentPageSizeException")
+class InvalidArticleCommentPageSizeExceptionTest {
+
+    @Test
+    @DisplayName("기본값 테스트")
+    fun test() {
+        // given
+        val pageSize = 55L
+        val minPageSize = 1L
+        val maxPageSize = 50L
+
+        // when
+        val exception = InvalidArticleCommentPageSizeException(
+            pageSize = pageSize,
+            minPageSize = minPageSize,
+            maxPageSize = maxPageSize
+        )
+
+        // then
+        assertThat(exception.status).isEqualTo(ErrorStatus.BAD_REQUEST)
+        assertThat(exception.code).isEqualTo("Error.InvalidArticleCommentPageSize")
+        assertThat(exception.args).containsExactly(pageSize, minPageSize, maxPageSize)
+        assertThat(exception.source).isEqualTo("pageSize")
+        assertThat(exception.message).isEqualTo("댓글 목록 페이지 크기가 유효하지 않습니다. (요청 크기= $pageSize, 최소 크기=$minPageSize, 최대 크기= $maxPageSize)")
+    }
+}

--- a/board-system-article-comment/article-comment-web-adapter/src/main/kotlin/com/ttasjwi/board/system/articlecomment/api/ArticleCommentPageReadController.kt
+++ b/board-system-article-comment/article-comment-web-adapter/src/main/kotlin/com/ttasjwi/board/system/articlecomment/api/ArticleCommentPageReadController.kt
@@ -1,0 +1,23 @@
+package com.ttasjwi.board.system.articlecomment.api
+
+import com.ttasjwi.board.system.articlecomment.domain.ArticleCommentPageReadRequest
+import com.ttasjwi.board.system.articlecomment.domain.ArticleCommentPageReadResponse
+import com.ttasjwi.board.system.articlecomment.domain.ArticleCommentPageReadUseCase
+import com.ttasjwi.board.system.common.annotation.auth.PermitAll
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ModelAttribute
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class ArticleCommentPageReadController(
+    private val useCase: ArticleCommentPageReadUseCase
+) {
+
+    @PermitAll
+    @GetMapping("/api/v1/article-comments")
+    fun readAllPage(@ModelAttribute request: ArticleCommentPageReadRequest): ResponseEntity<ArticleCommentPageReadResponse> {
+        val response = useCase.readAllPage(request)
+        return ResponseEntity.ok(response)
+    }
+}

--- a/board-system-article-comment/article-comment-web-adapter/src/test/kotlin/com/ttasjwi/board/system/articlecomment/api/ArticleCommentCreateControllerTest.kt
+++ b/board-system-article-comment/article-comment-web-adapter/src/test/kotlin/com/ttasjwi/board/system/articlecomment/api/ArticleCommentCreateControllerTest.kt
@@ -20,7 +20,7 @@ import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.req
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-@DisplayName("[article-web-adapter] ArticleCreateController 테스트")
+@DisplayName("[article-comment-web-adapter] ArticleCommentCreateController 테스트")
 @WebMvcTest(ArticleCommentCreateController::class)
 class ArticleCommentCreateControllerTest : ArticleCommentRestDocsTest() {
 

--- a/board-system-article-comment/article-comment-web-adapter/src/test/kotlin/com/ttasjwi/board/system/articlecomment/api/ArticleCommentPageReadControllerTest.kt
+++ b/board-system-article-comment/article-comment-web-adapter/src/test/kotlin/com/ttasjwi/board/system/articlecomment/api/ArticleCommentPageReadControllerTest.kt
@@ -1,0 +1,230 @@
+package com.ttasjwi.board.system.articlecomment.api
+
+import com.ninjasquad.springmockk.MockkBean
+import com.ttasjwi.board.system.articlecomment.domain.ArticleCommentPageReadRequest
+import com.ttasjwi.board.system.articlecomment.domain.ArticleCommentPageReadResponse
+import com.ttasjwi.board.system.articlecomment.domain.ArticleCommentPageReadUseCase
+import com.ttasjwi.board.system.articlecomment.test.base.ArticleCommentRestDocsTest
+import com.ttasjwi.board.system.common.time.fixture.appDateTimeFixture
+import com.ttasjwi.board.system.test.util.*
+import io.mockk.every
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.HttpMethod
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.request
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.util.LinkedMultiValueMap
+
+@DisplayName("[article-comment-web-adapter] ArticleCommentPageReadController 테스트")
+@WebMvcTest(ArticleCommentPageReadController::class)
+class ArticleCommentPageReadControllerTest : ArticleCommentRestDocsTest() {
+
+    @MockkBean
+    private lateinit var articleCommentPageReadUseCase: ArticleCommentPageReadUseCase
+
+    @Test
+    @DisplayName("성공 테스트")
+    fun testSuccess() {
+        // given
+        val url = "/api/v1/article-comments"
+        val articleId = 12345666L
+
+        val request = ArticleCommentPageReadRequest(
+            articleId = articleId,
+            page = 2L,
+            pageSize = 5L,
+        )
+
+        val response = ArticleCommentPageReadResponse(
+            page = request.page!!,
+            pageSize = request.pageSize!!,
+            pageGroupSize = 10,
+            pageGroupStart = 1,
+            pageGroupEnd = 10,
+            hasNextPage = true,
+            hasNextPageGroup = true,
+            comments = listOf(
+                ArticleCommentPageReadResponse.CommentItem(
+                    deleteStatus = "NOT_DELETED",
+                    data = ArticleCommentPageReadResponse.CommentItem.Data(
+                        articleCommentId = "53",
+                        content = "3번 댓글에 대한 대댓글",
+                        articleId = articleId.toString(),
+                        rootParentCommentId = "3",
+                        writerId = "53",
+                        writerNickname = "53번작성자",
+                        parentCommentWriterId = "3",
+                        parentCommentWriterNickname = "3번작성자",
+                        createdAt = appDateTimeFixture(minute = 8).toZonedDateTime(),
+                        modifiedAt = appDateTimeFixture(minute = 9).toZonedDateTime()
+                    )
+                ),
+                ArticleCommentPageReadResponse.CommentItem(
+                    deleteStatus = "DELETED_BY_WRITER",
+                    data = null,
+                ),
+                ArticleCommentPageReadResponse.CommentItem(
+                    deleteStatus = "NOT_DELETED",
+                    data = ArticleCommentPageReadResponse.CommentItem.Data(
+                        articleCommentId = "54",
+                        content = "4번 댓글에 대한 대댓글",
+                        articleId = articleId.toString(),
+                        rootParentCommentId = "4",
+                        writerId = "54",
+                        writerNickname = "54번작성자",
+                        parentCommentWriterId = "4",
+                        parentCommentWriterNickname = "4번작성자",
+                        createdAt = appDateTimeFixture(minute = 16).toZonedDateTime(),
+                        modifiedAt = appDateTimeFixture(minute = 16).toZonedDateTime()
+                    )
+                ),
+                ArticleCommentPageReadResponse.CommentItem(
+                    deleteStatus = "NOT_DELETED",
+                    data = ArticleCommentPageReadResponse.CommentItem.Data(
+                        articleCommentId = "5",
+                        content = "5번 댓글",
+                        articleId = articleId.toString(),
+                        rootParentCommentId = "5",
+                        writerId = "5",
+                        writerNickname = "5번작성자",
+                        parentCommentWriterId = null,
+                        parentCommentWriterNickname = null,
+                        createdAt = appDateTimeFixture(minute = 23).toZonedDateTime(),
+                        modifiedAt = appDateTimeFixture(minute = 23).toZonedDateTime()
+                    )
+                ),
+                ArticleCommentPageReadResponse.CommentItem(
+                    deleteStatus = "NOT_DELETED",
+                    data = ArticleCommentPageReadResponse.CommentItem.Data(
+                        articleCommentId = "55",
+                        content = "5번 댓글에 대한 대댓글",
+                        articleId = articleId.toString(),
+                        rootParentCommentId = "5",
+                        writerId = "55",
+                        writerNickname = "55번작성자",
+                        parentCommentWriterId = "5",
+                        parentCommentWriterNickname = "5번작성자",
+                        createdAt = appDateTimeFixture(minute = 29).toZonedDateTime(),
+                        modifiedAt = appDateTimeFixture(minute = 29).toZonedDateTime()
+                    )
+                ),
+            )
+        )
+
+        every { articleCommentPageReadUseCase.readAllPage(request) } returns response
+
+        // when
+        mockMvc
+            .perform(
+                request(HttpMethod.GET, url)
+                    .queryParams(
+                        LinkedMultiValueMap<String, String?>().apply {
+                            this["articleId"] = request.articleId.toString()
+                            this["page"] = request.page.toString()
+                            this["pageSize"] = request.pageSize.toString()
+                        }
+                    )
+            )
+            .andExpectAll(
+                status().isOk,
+                jsonPath("$.page").value(response.page),
+                jsonPath("$.pageSize").value(response.pageSize),
+                jsonPath("$.pageGroupSize").value(response.pageGroupSize),
+                jsonPath("$.pageGroupStart").value(response.pageGroupStart),
+                jsonPath("$.pageGroupEnd").value(response.pageGroupEnd),
+                jsonPath("$.hasNextPage").value(response.hasNextPage),
+                jsonPath("$.hasNextPageGroup").value(response.hasNextPageGroup),
+                jsonPath("$.comments").isNotEmpty(),
+                jsonPath("$.comments[0].deleteStatus").value(response.comments[0].deleteStatus),
+                jsonPath("$.comments[0].data.articleCommentId").value(response.comments[0].data!!.articleCommentId),
+                jsonPath("$.comments[0].data.content").value(response.comments[0].data!!.content),
+                jsonPath("$.comments[0].data.articleId").value(response.comments[0].data!!.articleId),
+                jsonPath("$.comments[0].data.rootParentCommentId").value(response.comments[0].data!!.rootParentCommentId),
+                jsonPath("$.comments[0].data.writerId").value(response.comments[0].data!!.writerId),
+                jsonPath("$.comments[0].data.writerNickname").value(response.comments[0].data!!.writerNickname),
+                jsonPath("$.comments[0].data.parentCommentWriterId").value(response.comments[0].data!!.parentCommentWriterId),
+                jsonPath("$.comments[0].data.parentCommentWriterNickname").value(response.comments[0].data!!.parentCommentWriterNickname),
+                jsonPath("$.comments[0].data.createdAt").value("2025-01-01T00:08:00+09:00"),
+                jsonPath("$.comments[0].data.modifiedAt").value("2025-01-01T00:09:00+09:00"),
+            )
+            .andDocument(
+                identifier = "article-comment-page-read-success",
+                queryParameters(
+                    "articleId"
+                            paramMeans "게시글 식별자(Id)",
+                    "page"
+                            paramMeans "페이지",
+                    "pageSize"
+                            paramMeans "한 페이지 당 댓글 수"
+                            constraint "1 이상 50 이하만 허용"
+                ),
+                responseBody(
+                    "page"
+                            type NUMBER
+                            means "현재 페이지",
+                    "pageSize"
+                            type NUMBER
+                            means "한 페이지 당 댓글 수",
+                    "pageGroupSize"
+                            type NUMBER
+                            means "페이지 그룹(예: 1-10페이지, 11-20페이지,...) 의 크기 단위",
+                    "pageGroupStart"
+                            type NUMBER
+                            means "페이지 그룹의 시작페이지 번호(예: 21)",
+                    "pageGroupEnd"
+                            type NUMBER
+                            means "페이지 그룹의 끝페이지 번호(예: 30)",
+                    "hasNextPage"
+                            type BOOLEAN
+                            means "다음 페이지의 존재 여부 부울값",
+                    "hasNextPageGroup"
+                            type BOOLEAN
+                            means "다음 페이지 그룹의 존재 여부 부울값",
+                    "comments"
+                            subSectionType "Comment[]"
+                            means "댓글 목록",
+                    "comments[*].deleteStatus"
+                            type STRING
+                            means "댓글이 삭제됐는지, 삭제됐다면 어떤 사유로 삭제됐는지 나타내는 문자열(하단 참고)",
+                    "comments[*].data"
+                            subSectionType "Comment.Data"
+                            means "댓글 데이터(삭제되지 않았을 때만 노출됨)"
+                            isOptional true,
+                    "comments[*].data.articleCommentId"
+                            type STRING
+                            means "게시글 댓글의 식별자(Id)",
+                    "comments[*].data.content"
+                            type STRING
+                            means "게시글 댓글 내용",
+                    "comments[*].data.articleId"
+                            type STRING
+                            means "게시글의 식별자(Id)",
+                    "comments[*].data.rootParentCommentId"
+                            type STRING
+                            means "최상위 부모 댓글의 식별자(Id), 댓글 자신의 식별자와 이 값이 일치하면 루트 댓글",
+                    "comments[*].data.writerId"
+                            type STRING
+                            means "댓글 작성자의 식별자(Id)",
+                    "comments[*].data.writerNickname"
+                            type STRING
+                            means "댓글 작성시점의 작성자 닉네임",
+                    "comments[*].data.parentCommentWriterId"
+                            type STRING
+                            means "(부모댓글이 있을 경우) 부모 댓글 작성자의 식별자(Id)"
+                            isOptional true,
+                    "comments[*].data.parentCommentWriterNickname"
+                            type STRING
+                            means "(부모댓글이 있을 경우) 부모 댓글 작성자의 댓글 작성시점 닉네임(Nickname)"
+                            isOptional true,
+                    "comments[*].data.createdAt"
+                            type DATETIME
+                            means "댓글 작성 시각",
+                    "comments[*].data.modifiedAt"
+                            type DATETIME
+                            means "댓글의 마지막 수정 시각",
+                )
+            )
+    }
+}

--- a/board-system-article-comment/article-comment-web-adapter/src/test/kotlin/com/ttasjwi/board/system/articlecomment/api/ArticleCommentReadControllerTest.kt
+++ b/board-system-article-comment/article-comment-web-adapter/src/test/kotlin/com/ttasjwi/board/system/articlecomment/api/ArticleCommentReadControllerTest.kt
@@ -16,7 +16,7 @@ import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.req
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-@DisplayName("[article-web-adapter] ArticleReadController 테스트")
+@DisplayName("[article-comment-web-adapter] ArticleCommentReadController 테스트")
 @WebMvcTest(ArticleCommentReadController::class)
 class ArticleCommentReadControllerTest : ArticleCommentRestDocsTest() {
 

--- a/board-system-article/article-application-service/src/main/kotlin/com/ttasjwi/board/system/article/domain/processor/ArticlePageReadProcessor.kt
+++ b/board-system-article/article-application-service/src/main/kotlin/com/ttasjwi/board/system/article/domain/processor/ArticlePageReadProcessor.kt
@@ -7,7 +7,7 @@ import com.ttasjwi.board.system.article.domain.model.Article
 import com.ttasjwi.board.system.article.domain.port.ArticlePersistencePort
 import com.ttasjwi.board.system.common.annotation.component.ApplicationProcessor
 import com.ttasjwi.board.system.common.page.PagingInfo
-import com.ttasjwi.board.system.common.page.calculateOffSet
+import com.ttasjwi.board.system.common.page.calculateOffset
 import com.ttasjwi.board.system.common.page.calculatePageLimit
 
 @ApplicationProcessor
@@ -45,7 +45,7 @@ class ArticlePageReadProcessor(
     private fun readArticles(query: ArticlePageReadQuery) =
         articlePersistencePort.findAllPage(
             boardId = query.boardId,
-            offSet = calculateOffSet(
+            offSet = calculateOffset(
                 page = query.page,
                 pageSize = query.pageSize
             ),

--- a/board-system-article/article-database-adapter/src/test/resources/test-schema.sql
+++ b/board-system-article/article-database-adapter/src/test/resources/test-schema.sql
@@ -98,7 +98,7 @@ CREATE TABLE IF NOT EXISTS article_comments(
     article_id                     BIGINT        NOT NULL,
     root_parent_comment_id         BIGINT        NOT NULL,
     writer_id                      BIGINT        NOT NULL,
-    writer_nickname                VARCHAR(15)   NOT NULL UNIQUE,
+    writer_nickname                VARCHAR(15)   NOT NULL,
     parent_comment_writer_id       BIGINT,
     parent_comment_writer_nickname VARCHAR(15),
     delete_status                  VARCHAR(20)   NOT NULL,

--- a/board-system-board/board-database-adapter/src/test/resources/test-schema.sql
+++ b/board-system-board/board-database-adapter/src/test/resources/test-schema.sql
@@ -98,7 +98,7 @@ CREATE TABLE IF NOT EXISTS article_comments(
     article_id                     BIGINT        NOT NULL,
     root_parent_comment_id         BIGINT        NOT NULL,
     writer_id                      BIGINT        NOT NULL,
-    writer_nickname                VARCHAR(15)   NOT NULL UNIQUE,
+    writer_nickname                VARCHAR(15)   NOT NULL,
     parent_comment_writer_id       BIGINT,
     parent_comment_writer_nickname VARCHAR(15),
     delete_status                  VARCHAR(20)   NOT NULL,

--- a/board-system-common/core/src/main/kotlin/com/ttasjwi/board/system/common/page/PageReadUtil.kt
+++ b/board-system-common/core/src/main/kotlin/com/ttasjwi/board/system/common/page/PageReadUtil.kt
@@ -4,6 +4,6 @@ fun calculatePageLimit(page: Long, pageSize: Long, movablePageCount: Long): Long
     (((page - 1) / movablePageCount) + 1) * pageSize * movablePageCount + 1
 
 
-fun calculateOffSet(page: Long, pageSize: Long): Long =
+fun calculateOffset(page: Long, pageSize: Long): Long =
     (page - 1) * pageSize
 

--- a/board-system-common/core/src/test/kotlin/com/ttasjwi/board/system/common/page/PageReadUtilTest.kt
+++ b/board-system-common/core/src/test/kotlin/com/ttasjwi/board/system/common/page/PageReadUtilTest.kt
@@ -52,8 +52,8 @@ class PageReadUtilTest {
     }
 
     @Nested
-    @DisplayName("calculateOffSet: 페이징 조회를 시작할 OffSet 을 계산한다.")
-    inner class CalculateOffSetTest {
+    @DisplayName("calculateOffset: 페이징 조회를 시작할 OffSet 을 계산한다.")
+    inner class CalculateOffsetTest {
 
         @Test
         @DisplayName("페이지당 5개 게시글, 1페이지 시작일 경우 OffSet 은 0")
@@ -63,10 +63,10 @@ class PageReadUtilTest {
             val pageSize = 5L
 
             // when
-            val offSet = calculateOffSet(page, pageSize)
+            val offset = calculateOffset(page, pageSize)
 
             // then
-            assertThat(offSet).isEqualTo(0)
+            assertThat(offset).isEqualTo(0)
         }
 
         @Test
@@ -77,10 +77,10 @@ class PageReadUtilTest {
             val pageSize = 5L
 
             // when
-            val offSet = calculateOffSet(page, pageSize)
+            val offset = calculateOffset(page, pageSize)
 
             // then
-            assertThat(offSet).isEqualTo(5)
+            assertThat(offset).isEqualTo(5)
         }
 
         @Test
@@ -91,10 +91,10 @@ class PageReadUtilTest {
             val pageSize = 10L
 
             // when
-            val offSet = calculateOffSet(page, pageSize)
+            val offset = calculateOffset(page, pageSize)
 
             // then
-            assertThat(offSet).isEqualTo(90)
+            assertThat(offset).isEqualTo(90)
         }
     }
 }

--- a/board-system-user/user-database-adapter/src/test/resources/test-schema.sql
+++ b/board-system-user/user-database-adapter/src/test/resources/test-schema.sql
@@ -105,3 +105,17 @@ CREATE TABLE IF NOT EXISTS article_comments(
     created_at                     DATETIME      NOT NULL,
     modified_at                    DATETIME      NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS article_comments(
+    article_comment_id             BIGINT        NOT NULL PRIMARY KEY,
+    content                        VARCHAR(3000) NOT NULL,
+    article_id                     BIGINT        NOT NULL,
+    root_parent_comment_id         BIGINT        NOT NULL,
+    writer_id                      BIGINT        NOT NULL,
+    writer_nickname                VARCHAR(15)   NOT NULL,
+    parent_comment_writer_id       BIGINT,
+    parent_comment_writer_nickname VARCHAR(15),
+    delete_status                  VARCHAR(20)   NOT NULL,
+    created_at                     DATETIME      NOT NULL,
+    modified_at                    DATETIME      NOT NULL
+);


### PR DESCRIPTION
# JIRA 티켓
- [BRD-138]

---

# 개요
- 댓글 목록 조회 API 구현 (페이징)
- 댓글은 최대 2depth 까지만 허용
- 대댓글들은 모두 하나의 루트 댓글에 대한 대댓글로 취급
- 대댓글은, 부모댓글의 작성자 아이디 / 작성자 닉네임 정보(작성 시점)를 가지고 있음.

---

# 데이터베이스 설계?
- 인덱스를 다음과 같이 설계하면 될듯.
  - [게시글 아이디 오름차순] - [루트 부모댓글 아이디 오름차순] - [댓글 아이디 오름차순]




[BRD-138]: https://ttasjwi.atlassian.net/browse/BRD-138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ