### PR TITLE
Feature: (BRD-155) 게시글 좋아요 API 사양 변경(게시글 Id 전달방식)

### DIFF
--- a/board-system-app/src/docs/asciidoc/article-like-api.adoc
+++ b/board-system-app/src/docs/asciidoc/article-like-api.adoc
@@ -3,7 +3,7 @@
 === 게시글 좋아요
 ==== 기본정보
 - 메서드 : POST
-- URL : `/api/v1/article-likes`
+- URL : `/api/v1/articles/{articleId}/likes`
 - 권한 : 인증된 사용자 누구든지
 - 인증방식 : 액세스 토큰
 
@@ -12,7 +12,7 @@
 
 ==== 요청
 include::{snippets}/article-like-create-success/request-headers.adoc[]
-include::{snippets}/article-like-create-success/request-fields.adoc[]
+include::{snippets}/article-like-create-success/path-parameters.adoc[]
 
 ==== 응답
 include::{snippets}/article-like-create-success/response-fields.adoc[]

--- a/board-system-article-like/article-like-application-input-port/src/main/kotlin/com/ttasjwi/board/system/articlelike/domain/ArticleLikeCreateUseCase.kt
+++ b/board-system-article-like/article-like-application-input-port/src/main/kotlin/com/ttasjwi/board/system/articlelike/domain/ArticleLikeCreateUseCase.kt
@@ -3,12 +3,8 @@ package com.ttasjwi.board.system.articlelike.domain
 import java.time.ZonedDateTime
 
 interface ArticleLikeCreateUseCase {
-    fun like(request: ArticleLikeCreateRequest): ArticleLikeCreateResponse
+    fun like(articleId: Long): ArticleLikeCreateResponse
 }
-
-data class ArticleLikeCreateRequest(
-    val articleId: Long?,
-)
 
 data class ArticleLikeCreateResponse(
     val articleLikeId: String,

--- a/board-system-article-like/article-like-application-service/src/main/kotlin/com/ttasjwi/board/system/articlelike/domain/ArticleLikeCreateUseCaseImpl.kt
+++ b/board-system-article-like/article-like-application-service/src/main/kotlin/com/ttasjwi/board/system/articlelike/domain/ArticleLikeCreateUseCaseImpl.kt
@@ -11,8 +11,8 @@ internal class ArticleLikeCreateUseCaseImpl(
     private val processor: ArticleLikeCreateProcessor,
 ) : ArticleLikeCreateUseCase {
 
-    override fun like(request: ArticleLikeCreateRequest) : ArticleLikeCreateResponse {
-        val command = commandMapper.mapToCommand(request)
+    override fun like(articleId: Long): ArticleLikeCreateResponse {
+        val command = commandMapper.mapToCommand(articleId)
         val articleLike = processor.like(command)
         return makeResponse(articleLike)
     }

--- a/board-system-article-like/article-like-application-service/src/main/kotlin/com/ttasjwi/board/system/articlelike/domain/mapper/ArticleLikeCreateCommandMapper.kt
+++ b/board-system-article-like/article-like-application-service/src/main/kotlin/com/ttasjwi/board/system/articlelike/domain/mapper/ArticleLikeCreateCommandMapper.kt
@@ -1,11 +1,8 @@
 package com.ttasjwi.board.system.articlelike.domain.mapper
 
-import com.ttasjwi.board.system.articlelike.domain.ArticleLikeCreateRequest
 import com.ttasjwi.board.system.articlelike.domain.dto.ArticleLikeCreateCommand
 import com.ttasjwi.board.system.common.annotation.component.ApplicationCommandMapper
 import com.ttasjwi.board.system.common.auth.AuthUserLoader
-import com.ttasjwi.board.system.common.exception.NullArgumentException
-import com.ttasjwi.board.system.common.exception.ValidationExceptionCollector
 import com.ttasjwi.board.system.common.time.TimeManager
 
 @ApplicationCommandMapper
@@ -14,25 +11,11 @@ internal class ArticleLikeCreateCommandMapper(
     private val timeManager: TimeManager,
 ) {
 
-    fun mapToCommand(request: ArticleLikeCreateRequest): ArticleLikeCreateCommand {
-        val exceptionCollector = ValidationExceptionCollector()
-
-        val articleId = getArticleId(request.articleId, exceptionCollector)
-
-        exceptionCollector.throwIfNotEmpty()
-
+    fun mapToCommand(articleId: Long): ArticleLikeCreateCommand {
         return ArticleLikeCreateCommand(
-            articleId = articleId!!,
+            articleId = articleId,
             likeUser = authUserLoader.loadCurrentAuthUser()!!,
             currentTime = timeManager.now()
         )
-    }
-
-    private fun getArticleId(articleId: Long?, exceptionCollector: ValidationExceptionCollector): Long? {
-        if (articleId == null) {
-            exceptionCollector.addCustomExceptionOrThrow(NullArgumentException("articleId"))
-            return null
-        }
-        return articleId
     }
 }

--- a/board-system-article-like/article-like-application-service/src/test/kotlin/com/ttasjwi/board/system/articlelike/domain/ArticleLikeCreateUseCaseImplTest.kt
+++ b/board-system-article-like/article-like-application-service/src/test/kotlin/com/ttasjwi/board/system/articlelike/domain/ArticleLikeCreateUseCaseImplTest.kt
@@ -10,7 +10,7 @@ import com.ttasjwi.board.system.common.auth.Role
 import com.ttasjwi.board.system.common.auth.fixture.authUserFixture
 import com.ttasjwi.board.system.common.time.AppDateTime
 import com.ttasjwi.board.system.common.time.fixture.appDateTimeFixture
-import org.assertj.core.api.Assertions.*
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -29,7 +29,7 @@ class ArticleLikeCreateUseCaseImplTest {
         val container = TestContainer.create()
         articleLikeCreateUseCase = container.articleLikeCreateUseCase
 
-        currentTime = appDateTimeFixture(minute= 8)
+        currentTime = appDateTimeFixture(minute = 8)
         container.timeManagerFixture.changeCurrentTime(currentTime)
 
         authUser = authUserFixture(userId = 13L, role = Role.USER)
@@ -58,16 +58,12 @@ class ArticleLikeCreateUseCaseImplTest {
             )
         )
 
-        val request = ArticleLikeCreateRequest(
-            articleId = article.articleId,
-        )
-
         // when
-        val response = articleLikeCreateUseCase.like(request)
+        val response = articleLikeCreateUseCase.like(article.articleId)
 
         // then
         assertThat(response.articleLikeId).isNotNull()
-        assertThat(response.articleId).isEqualTo(request.articleId!!.toString())
+        assertThat(response.articleId).isEqualTo(article.articleId.toString())
         assertThat(response.userId).isEqualTo(authUser.userId.toString())
         assertThat(response.createdAt).isEqualTo(currentTime.toZonedDateTime())
     }

--- a/board-system-article-like/article-like-application-service/src/test/kotlin/com/ttasjwi/board/system/articlelike/domain/mapper/ArticleLikeCreateCommandMapperTest.kt
+++ b/board-system-article-like/article-like-application-service/src/test/kotlin/com/ttasjwi/board/system/articlelike/domain/mapper/ArticleLikeCreateCommandMapperTest.kt
@@ -1,19 +1,15 @@
 package com.ttasjwi.board.system.articlelike.domain.mapper
 
-import com.ttasjwi.board.system.articlelike.domain.ArticleLikeCreateRequest
 import com.ttasjwi.board.system.articlelike.domain.test.support.TestContainer
 import com.ttasjwi.board.system.common.auth.AuthUser
 import com.ttasjwi.board.system.common.auth.Role
 import com.ttasjwi.board.system.common.auth.fixture.authUserFixture
-import com.ttasjwi.board.system.common.exception.NullArgumentException
-import com.ttasjwi.board.system.common.exception.ValidationExceptionCollector
 import com.ttasjwi.board.system.common.time.AppDateTime
 import com.ttasjwi.board.system.common.time.fixture.appDateTimeFixture
-import org.assertj.core.api.Assertions.*
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 
 @DisplayName("[article-like-application-service] ArticleLikeCreateCommandMapper 테스트")
 class ArticleLikeCreateCommandMapperTest {
@@ -27,7 +23,7 @@ class ArticleLikeCreateCommandMapperTest {
         val container = TestContainer.create()
         articleLikeCreateCommandMapper = container.articleLikeCreateCommandMapper
 
-        currentTime = appDateTimeFixture(minute= 8)
+        currentTime = appDateTimeFixture(minute = 8)
         container.timeManagerFixture.changeCurrentTime(currentTime)
 
         authUser = authUserFixture(userId = 13L, role = Role.USER)
@@ -39,38 +35,15 @@ class ArticleLikeCreateCommandMapperTest {
     @DisplayName("성공 테스트")
     fun testSuccess() {
         // given
-        val request = ArticleLikeCreateRequest(
-            articleId = 5L
-        )
+        val articleId = 5L
 
         // when
-        val command = articleLikeCreateCommandMapper.mapToCommand(request)
+        val command = articleLikeCreateCommandMapper.mapToCommand(articleId)
 
         // then
-        assertThat(command.articleId).isEqualTo(request.articleId)
+        assertThat(command.articleId).isEqualTo(articleId)
         assertThat(command.likeUser).isEqualTo(authUser)
         assertThat(command.currentTime).isEqualTo(currentTime)
     }
 
-
-    @Test
-    @DisplayName("articleId 가 null 이면 예외 발생")
-    fun testArticleIdNull() {
-        // given
-        val request = ArticleLikeCreateRequest(
-            articleId = null
-        )
-
-        // when
-        val exceptionCollector = assertThrows<ValidationExceptionCollector> {
-            articleLikeCreateCommandMapper.mapToCommand(request)
-        }
-
-        // then
-        val exceptions = exceptionCollector.getExceptions()
-
-        assertThat(exceptions.size).isEqualTo(1)
-        assertThat(exceptions[0]).isInstanceOf(NullArgumentException::class.java)
-        assertThat(exceptions[0].source).isEqualTo("articleId")
-    }
 }

--- a/board-system-article-like/article-like-web-adapter/src/main/kotlin/com/ttasjwi/board/system/articlelike/api/ArticleLikeCreateController.kt
+++ b/board-system-article-like/article-like-web-adapter/src/main/kotlin/com/ttasjwi/board/system/articlelike/api/ArticleLikeCreateController.kt
@@ -1,13 +1,12 @@
 package com.ttasjwi.board.system.articlelike.api
 
-import com.ttasjwi.board.system.articlelike.domain.ArticleLikeCreateRequest
 import com.ttasjwi.board.system.articlelike.domain.ArticleLikeCreateResponse
 import com.ttasjwi.board.system.articlelike.domain.ArticleLikeCreateUseCase
 import com.ttasjwi.board.system.common.annotation.auth.RequireAuthenticated
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -16,9 +15,9 @@ class ArticleLikeCreateController(
 ) {
 
     @RequireAuthenticated
-    @PostMapping("/api/v1/article-likes")
-    fun like(@RequestBody request: ArticleLikeCreateRequest): ResponseEntity<ArticleLikeCreateResponse> {
-        val response = articleLikeCreateUseCase.like(request)
+    @PostMapping("/api/v1/articles/{articleId}/likes")
+    fun like(@PathVariable("articleId") articleId: Long): ResponseEntity<ArticleLikeCreateResponse> {
+        val response = articleLikeCreateUseCase.like(articleId)
         return ResponseEntity.status(HttpStatus.CREATED).body(response)
     }
 }


### PR DESCRIPTION
# JIRA 티켓
- [BRD-155]

---

# 개요
- 기존 게시글 좋아요 API 는 요청 body 를 통해 좋아요 대상 게시글 식별자를 전달했다.
- API 사양을 변경하여, 요청 경로변수에 게시글 식별자를 전달하도록 한다.

[BRD-155]: https://ttasjwi.atlassian.net/browse/BRD-155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ