### PR TITLE
Fix: (BRD-153) 게시글 좋아요수 동시성 문제 해결

### DIFF
--- a/board-system-app/build.gradle.kts
+++ b/board-system-app/build.gradle.kts
@@ -8,7 +8,6 @@ dependencies {
     // core
     implementation(project(":board-system-common:core"))
     testImplementation(testFixtures(project(":board-system-common:core")))
-    testImplementation(project(":board-system-common:token"))
 
     // email-sender
     implementation(project(":board-system-email-sender"))
@@ -54,8 +53,6 @@ dependencies {
     implementation("org.springframework.security:spring-security-config")
     implementation("org.springframework.security:spring-security-web")
 
-
-    testImplementation("org.springframework:spring-tx")
     implementation(project(":board-system-infrastructure:jwt"))
     implementation(project(":board-system-infrastructure:database-support"))
     implementation(project(":board-system-infrastructure:web-support"))

--- a/board-system-app/build.gradle.kts
+++ b/board-system-app/build.gradle.kts
@@ -5,7 +5,10 @@ plugins {
 val asciidoctorExt: Configuration by configurations.creating
 
 dependencies {
+    // core
     implementation(project(":board-system-common:core"))
+    testImplementation(testFixtures(project(":board-system-common:core")))
+    testImplementation(project(":board-system-common:token"))
 
     // email-sender
     implementation(project(":board-system-email-sender"))
@@ -23,11 +26,15 @@ dependencies {
     implementation(project(":board-system-board:board-web-adapter"))
     implementation(project(":board-system-board:board-application-service"))
     implementation(project(":board-system-board:board-database-adapter"))
+    testImplementation(testFixtures(project(":board-system-board:board-domain")))
+    testImplementation(project(":board-system-board:board-application-output-port"))
 
     // article
     implementation(project(":board-system-article:article-web-adapter"))
     implementation(project(":board-system-article:article-application-service"))
     implementation(project(":board-system-article:article-database-adapter"))
+    testImplementation(testFixtures(project(":board-system-article:article-domain")))
+    testImplementation(project(":board-system-article:article-application-output-port"))
 
     // article-comment
     implementation(project(":board-system-article-comment:article-comment-web-adapter"))
@@ -38,6 +45,7 @@ dependencies {
     implementation(project(":board-system-article-like:article-like-web-adapter"))
     implementation(project(":board-system-article-like:article-like-application-service"))
     implementation(project(":board-system-article-like:article-like-database-adapter"))
+    testImplementation(project(":board-system-article-like:article-like-application-input-port"))
 
     // aop
     implementation("org.springframework.boot:spring-boot-starter-aop")
@@ -46,6 +54,8 @@ dependencies {
     implementation("org.springframework.security:spring-security-config")
     implementation("org.springframework.security:spring-security-web")
 
+
+    testImplementation("org.springframework:spring-tx")
     implementation(project(":board-system-infrastructure:jwt"))
     implementation(project(":board-system-infrastructure:database-support"))
     implementation(project(":board-system-infrastructure:web-support"))

--- a/board-system-app/src/test/kotlin/com/ttasjwi/board/system/app/articlelike/api/ArticleLikeCountIntegrationTest.kt
+++ b/board-system-app/src/test/kotlin/com/ttasjwi/board/system/app/articlelike/api/ArticleLikeCountIntegrationTest.kt
@@ -41,7 +41,7 @@ class ArticleLikeCountIntegrationTest {
     @DisplayName("좋아요 수 동시성 테스트 : 동시 사용자가 많을 때, 좋아요 수")
     fun likeCountConcurrencyTest() {
         val executorService = Executors.newFixedThreadPool(100)
-        likeCountTest(executorService, 111L, 111L, 111L)
+        likeCountTest(executorService, 1234567L, 1234567L, 1234567L)
         executorService.shutdown()
     }
 
@@ -86,7 +86,7 @@ class ArticleLikeCountIntegrationTest {
         println("count = ${response.likeCount}")
         println("--------------------------------------------------------------------------")
 
-        assertThat(response.likeCount).isNotEqualTo(userCount)
+        assertThat(response.likeCount).isEqualTo(userCount.toLong())
     }
 
     private fun like(articleId: Long, userId: Long) {

--- a/board-system-app/src/test/kotlin/com/ttasjwi/board/system/app/articlelike/api/ArticleLikeCountIntegrationTest.kt
+++ b/board-system-app/src/test/kotlin/com/ttasjwi/board/system/app/articlelike/api/ArticleLikeCountIntegrationTest.kt
@@ -21,7 +21,7 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
-//@Disabled // 수동테스트용(테스트 해보고 싶을 경우 주석처리)
+@Disabled // 수동테스트용(테스트 해보고 싶을 경우 주석처리)
 @SpringBootTest
 @DisplayName("[app] 게시글 좋아요 수 통합테스트")
 class ArticleLikeCountIntegrationTest {
@@ -46,7 +46,7 @@ class ArticleLikeCountIntegrationTest {
     fun likeCountConcurrencyTest() {
         val threadCount = 100
         val userCount = 3000
-        val boardArticleArticleCategoryId = 5555325L
+        val boardArticleArticleCategoryId = 13413413413L
 
         val executorService = Executors.newFixedThreadPool(threadCount)
 
@@ -143,7 +143,7 @@ class ArticleLikeCountIntegrationTest {
         println("count = ${response.likeCount}")
         println("--------------------------------------------------------------------------")
 
-        assertThat(response.likeCount).isNotEqualTo(0)
+        assertThat(response.likeCount).isEqualTo(0)
     }
 
 

--- a/board-system-app/src/test/kotlin/com/ttasjwi/board/system/app/articlelike/api/ArticleLikeCountIntegrationTest.kt
+++ b/board-system-app/src/test/kotlin/com/ttasjwi/board/system/app/articlelike/api/ArticleLikeCountIntegrationTest.kt
@@ -1,0 +1,134 @@
+package com.ttasjwi.board.system.app.articlelike.api
+
+import com.ttasjwi.board.system.article.domain.model.fixture.articleFixture
+import com.ttasjwi.board.system.article.domain.port.ArticlePersistencePort
+import com.ttasjwi.board.system.articlelike.domain.ArticleLikeCountReadUseCase
+import com.ttasjwi.board.system.articlelike.domain.ArticleLikeCreateUseCase
+import com.ttasjwi.board.system.board.domain.model.fixture.articleCategoryFixture
+import com.ttasjwi.board.system.board.domain.port.ArticleCategoryPersistencePort
+import com.ttasjwi.board.system.common.auth.Role
+import com.ttasjwi.board.system.common.auth.fixture.authUserFixture
+import com.ttasjwi.board.system.common.infra.websupport.auth.security.AuthUserAuthentication
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.security.core.context.SecurityContextHolder
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+
+@Disabled // 수동테스트용(테스트 해보고 싶을 경우 주석처리)
+@SpringBootTest
+@DisplayName("[app] 게시글 좋아요 수 통합테스트")
+class ArticleLikeCountIntegrationTest {
+
+    @Autowired
+    private lateinit var articlePersistencePort: ArticlePersistencePort
+
+    @Autowired
+    private lateinit var articleCategoryPersistencePort: ArticleCategoryPersistencePort
+
+    @Autowired
+    private lateinit var articleLikeUseCase: ArticleLikeCreateUseCase
+
+    @Autowired
+    private lateinit var articleLikeCountReadUseCase: ArticleLikeCountReadUseCase
+
+    @Test
+    @DisplayName("좋아요 수 동시성 테스트 : 동시 사용자가 많을 때, 좋아요 수")
+    fun likeCountConcurrencyTest() {
+        val executorService = Executors.newFixedThreadPool(100)
+        likeCountTest(executorService, 111L, 111L, 111L)
+        executorService.shutdown()
+    }
+
+    private fun likeCountTest(
+        executorService: ExecutorService,
+        boardId: Long,
+        articleId: Long,
+        articleCategoryId: Long
+    ) {
+
+        val userCount = 3000
+        prepareArticleCategory(boardId, articleCategoryId)
+        prepareArticle(boardId, articleCategoryId, articleId)
+
+        val latch = CountDownLatch(userCount)
+        println("--------------------------------------------------------------------------")
+        println("start")
+        val start = System.nanoTime()
+        for (i in 1..userCount) {
+            val userId = i.toLong()
+
+            executorService.execute {
+                try {
+                    like(articleId, userId)
+                } catch (e: Exception) {
+                    println("Error for userId=$userId: ${e.message}")
+                } finally {
+                    latch.countDown()
+                }
+            }
+
+        }
+        latch.await()
+        val end = System.nanoTime()
+        println("time = ${(end - start) / 100_0000} ms")
+
+        val response = articleLikeCountReadUseCase.readLikeCount(
+            articleId = articleId,
+        )
+
+        println("end")
+        println("count = ${response.likeCount}")
+        println("--------------------------------------------------------------------------")
+
+        assertThat(response.likeCount).isNotEqualTo(userCount)
+    }
+
+    private fun like(articleId: Long, userId: Long) {
+        setAuthUser(userId)
+        articleLikeUseCase.like(articleId)
+    }
+
+    private fun setAuthUser(userId: Long) {
+        val authentication = AuthUserAuthentication.from(
+            authUser = authUserFixture(
+                userId = userId,
+                role = Role.USER
+            )
+        )
+        val securityContext = SecurityContextHolder.getContextHolderStrategy().createEmptyContext()
+        securityContext.authentication = authentication
+        SecurityContextHolder.getContextHolderStrategy().context = securityContext
+    }
+
+    private fun prepareArticle(boardId: Long, articleCategoryId: Long, articleId: Long) {
+        articlePersistencePort.save(
+            articleFixture(
+                articleId = articleId,
+                title = "article-title-$articleId",
+                content = "article-content-$articleId",
+                boardId = boardId,
+                articleCategoryId = articleCategoryId,
+                writerId = 1L
+            )
+        )
+    }
+
+    private fun prepareArticleCategory(boardId: Long, articleCategoryId: Long) {
+        articleCategoryPersistencePort.save(
+            articleCategoryFixture(
+                articleCategoryId = articleCategoryId,
+                name = "테스트",
+                slug = "test",
+                boardId = boardId,
+                allowLike = true,
+                allowDislike = true
+            )
+        )
+    }
+}

--- a/board-system-article-comment/article-comment-database-adapter/src/main/kotlin/com/ttasjwi/board/system/articlecomment/infra/persistence/ArticlePersistenceAdapter.kt
+++ b/board-system-article-comment/article-comment-database-adapter/src/main/kotlin/com/ttasjwi/board/system/articlecomment/infra/persistence/ArticlePersistenceAdapter.kt
@@ -6,7 +6,7 @@ import com.ttasjwi.board.system.articlecomment.infra.persistence.jpa.JpaArticleR
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 
-@Component
+@Component("articleCommentArticlePersistenceAdapter")
 class ArticlePersistenceAdapter(
     private val jpaArticleRepository: JpaArticleRepository
 ) : ArticlePersistencePort {

--- a/board-system-article-comment/article-comment-database-adapter/src/test/resources/test-schema.sql
+++ b/board-system-article-comment/article-comment-database-adapter/src/test/resources/test-schema.sql
@@ -115,9 +115,8 @@ CREATE TABLE IF NOT EXISTS article_likes(
 );
 
 CREATE TABLE IF NOT EXISTS article_like_counts(
-    article_like_count_id BIGINT NOT NULL PRIMARY KEY,
-    article_id            BIGINT NOT NULL UNIQUE,
-    like_count            BIGINT NOT NULL
+    article_id BIGINT NOT NULL PRIMARY KEY,
+    like_count BIGINT NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS article_dislikes(

--- a/board-system-article-like/article-like-application-output-port/src/main/kotlin/com/ttasjwi/board/system/articlelike/domain/port/ArticleLikeCountPersistencePort.kt
+++ b/board-system-article-like/article-like-application-output-port/src/main/kotlin/com/ttasjwi/board/system/articlelike/domain/port/ArticleLikeCountPersistencePort.kt
@@ -4,6 +4,7 @@ import com.ttasjwi.board.system.articlelike.domain.model.ArticleLikeCount
 
 interface ArticleLikeCountPersistencePort {
 
+    fun increase(articleId: Long)
     fun save(articleLikeCount: ArticleLikeCount): ArticleLikeCount
     fun findByIdOrNull(articleId: Long): ArticleLikeCount?
 }

--- a/board-system-article-like/article-like-application-output-port/src/main/kotlin/com/ttasjwi/board/system/articlelike/domain/port/ArticleLikeCountPersistencePort.kt
+++ b/board-system-article-like/article-like-application-output-port/src/main/kotlin/com/ttasjwi/board/system/articlelike/domain/port/ArticleLikeCountPersistencePort.kt
@@ -5,6 +5,6 @@ import com.ttasjwi.board.system.articlelike.domain.model.ArticleLikeCount
 interface ArticleLikeCountPersistencePort {
 
     fun increase(articleId: Long)
-    fun save(articleLikeCount: ArticleLikeCount): ArticleLikeCount
+    fun decrease(articleId: Long)
     fun findByIdOrNull(articleId: Long): ArticleLikeCount?
 }

--- a/board-system-article-like/article-like-application-output-port/src/test/kotlin/com/ttasjwi/board/system/articlelike/domain/port/fixture/ArticleLikeCountPersistencePortFixtureTest.kt
+++ b/board-system-article-like/article-like-application-output-port/src/test/kotlin/com/ttasjwi/board/system/articlelike/domain/port/fixture/ArticleLikeCountPersistencePortFixtureTest.kt
@@ -1,6 +1,5 @@
 package com.ttasjwi.board.system.articlelike.domain.port.fixture
 
-import com.ttasjwi.board.system.articlelike.domain.model.fixture.articleLikeCountFixture
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -59,28 +58,33 @@ class ArticleLikeCountPersistencePortFixtureTest {
     }
 
     @Nested
-    @DisplayName("findByIdOrNull : articleId 값으로 좋아요 수 조회")
-    inner class FindByIdOrNullTest {
+    @DisplayName("decrease: 좋아요 수 감소")
+    inner class DecreaseTest {
 
         @Test
-        @DisplayName("성공 테스트")
-        fun test1() {
+        @DisplayName("두번 좋아요 수 증가 후, 좋아요수 감소 테스트")
+        fun test() {
             // given
-            val articleId = 13L
-            val articleLikeCount = articleLikeCountFixture(
-                articleId = articleId,
-                likeCount = 1345L
-            )
-            articleLikeCountPersistencePortFixture.save(articleLikeCount)
+            val articleId = 5857L
 
             // when
-            val findArticleLikeCount = articleLikeCountPersistencePortFixture.findByIdOrNull(articleId)!!
+            articleLikeCountPersistencePortFixture.increase(articleId)
+            articleLikeCountPersistencePortFixture.increase(articleId)
+            articleLikeCountPersistencePortFixture.decrease(articleId)
 
             // then
-            assertThat(findArticleLikeCount.articleId).isEqualTo(articleLikeCount.articleId)
-            assertThat(findArticleLikeCount.likeCount).isEqualTo(articleLikeCount.likeCount)
+            val articleLikeCount = articleLikeCountPersistencePortFixture.findByIdOrNull(articleId)!!
+
+            assertThat(articleLikeCount.articleId).isEqualTo(articleId)
+            assertThat(articleLikeCount.likeCount).isEqualTo(1)
         }
 
+    }
+
+
+    @Nested
+    @DisplayName("findByIdOrNull : articleId 값으로 좋아요 수 조회")
+    inner class FindByIdOrNullTest {
 
         @Test
         @DisplayName("조회 실패시 null 반환 테스트")

--- a/board-system-article-like/article-like-application-output-port/src/test/kotlin/com/ttasjwi/board/system/articlelike/domain/port/fixture/ArticleLikeCountPersistencePortFixtureTest.kt
+++ b/board-system-article-like/article-like-application-output-port/src/test/kotlin/com/ttasjwi/board/system/articlelike/domain/port/fixture/ArticleLikeCountPersistencePortFixtureTest.kt
@@ -18,6 +18,47 @@ class ArticleLikeCountPersistencePortFixtureTest {
     }
 
     @Nested
+    @DisplayName("increase: 좋아요 수 증가")
+    inner class IncreaseTest {
+
+        @Test
+        @DisplayName("최초 좋아요 테스트")
+        fun test1() {
+            // given
+            val articleId = 5857L
+
+            // when
+            articleLikeCountPersistencePortFixture.increase(articleId)
+
+
+            // then
+            val articleLikeCount = articleLikeCountPersistencePortFixture.findByIdOrNull(articleId)!!
+
+            assertThat(articleLikeCount.articleId).isEqualTo(articleId)
+            assertThat(articleLikeCount.likeCount).isEqualTo(1)
+        }
+
+        @Test
+        @DisplayName("첫번째 이후 좋아요 테스트")
+        fun test2() {
+            // given
+            val articleId = 5857L
+
+            // when
+            articleLikeCountPersistencePortFixture.increase(articleId)
+            articleLikeCountPersistencePortFixture.increase(articleId)
+
+
+            // then
+            val articleLikeCount = articleLikeCountPersistencePortFixture.findByIdOrNull(articleId)!!
+
+            assertThat(articleLikeCount.articleId).isEqualTo(articleId)
+            assertThat(articleLikeCount.likeCount).isEqualTo(2)
+        }
+
+    }
+
+    @Nested
     @DisplayName("findByIdOrNull : articleId 값으로 좋아요 수 조회")
     inner class FindByIdOrNullTest {
 

--- a/board-system-article-like/article-like-application-output-port/src/testFixtures/kotlin/com/ttasjwi/board/system/articlelike/domain/port/fixture/ArticleLikeCountPersistencePortFixture.kt
+++ b/board-system-article-like/article-like-application-output-port/src/testFixtures/kotlin/com/ttasjwi/board/system/articlelike/domain/port/fixture/ArticleLikeCountPersistencePortFixture.kt
@@ -12,6 +12,15 @@ class ArticleLikeCountPersistencePortFixture : ArticleLikeCountPersistencePort {
         return articleLikeCount
     }
 
+    override fun increase(articleId: Long) {
+        if (!storage.containsKey(articleId)) {
+            storage[articleId] = ArticleLikeCount(articleId, 1)
+        } else {
+            val articleLikeCount = storage[articleId]!!
+            storage[articleId] = ArticleLikeCount(articleId, articleLikeCount.likeCount + 1)
+        }
+    }
+
     override fun findByIdOrNull(articleId: Long): ArticleLikeCount? {
         return storage[articleId]
     }

--- a/board-system-article-like/article-like-application-output-port/src/testFixtures/kotlin/com/ttasjwi/board/system/articlelike/domain/port/fixture/ArticleLikeCountPersistencePortFixture.kt
+++ b/board-system-article-like/article-like-application-output-port/src/testFixtures/kotlin/com/ttasjwi/board/system/articlelike/domain/port/fixture/ArticleLikeCountPersistencePortFixture.kt
@@ -1,24 +1,26 @@
 package com.ttasjwi.board.system.articlelike.domain.port.fixture
 
 import com.ttasjwi.board.system.articlelike.domain.model.ArticleLikeCount
+import com.ttasjwi.board.system.articlelike.domain.model.fixture.articleLikeCountFixture
 import com.ttasjwi.board.system.articlelike.domain.port.ArticleLikeCountPersistencePort
 
 class ArticleLikeCountPersistencePortFixture : ArticleLikeCountPersistencePort {
 
     private val storage = mutableMapOf<Long, ArticleLikeCount>()
 
-    override fun save(articleLikeCount: ArticleLikeCount): ArticleLikeCount {
-        storage[articleLikeCount.articleId] = articleLikeCount
-        return articleLikeCount
-    }
-
     override fun increase(articleId: Long) {
         if (!storage.containsKey(articleId)) {
             storage[articleId] = ArticleLikeCount(articleId, 1)
         } else {
             val articleLikeCount = storage[articleId]!!
-            storage[articleId] = ArticleLikeCount(articleId, articleLikeCount.likeCount + 1)
+            storage[articleId] = articleLikeCountFixture(articleId, articleLikeCount.likeCount + 1)
         }
+    }
+
+    override fun decrease(articleId: Long) {
+        // 전제 : articleId 의 articleLikeCount 가 있어야함 (애플리케이션 로직에서 보장)
+        val articleLikeCount = storage[articleId]!!
+        storage[articleLikeCount.articleId] = articleLikeCountFixture(articleId, articleLikeCount.likeCount - 1)
     }
 
     override fun findByIdOrNull(articleId: Long): ArticleLikeCount? {

--- a/board-system-article-like/article-like-application-service/src/main/kotlin/com/ttasjwi/board/system/articlelike/domain/processor/ArticleLikeCancelProcessor.kt
+++ b/board-system-article-like/article-like-application-service/src/main/kotlin/com/ttasjwi/board/system/articlelike/domain/processor/ArticleLikeCancelProcessor.kt
@@ -61,9 +61,6 @@ internal class ArticleLikeCancelProcessor(
      * 게시글 좋아요 수 감소
      */
     private fun decreaseArticleLikeCount(articleId: Long) {
-        val articleLikeCount = articleLikeCountPersistencePort.findByIdOrNull(articleId = articleId)
-            ?: throw IllegalStateException("게시글 좋아요 수가 저장되어 있지 않음(articleId = $articleId)") // 서버 에러
-        articleLikeCount.decrease()
-        articleLikeCountPersistencePort.save(articleLikeCount)
+        articleLikeCountPersistencePort.decrease(articleId)
     }
 }

--- a/board-system-article-like/article-like-application-service/src/main/kotlin/com/ttasjwi/board/system/articlelike/domain/processor/ArticleLikeCreateProcessor.kt
+++ b/board-system-article-like/article-like-application-service/src/main/kotlin/com/ttasjwi/board/system/articlelike/domain/processor/ArticleLikeCreateProcessor.kt
@@ -70,7 +70,6 @@ internal class ArticleLikeCreateProcessor(
         }
     }
 
-
     private fun createArticleLikeAndSave(command: ArticleLikeCreateCommand): ArticleLike {
         val articleLike = ArticleLike.create(
             articleLikeId = idGenerator.nextId(),
@@ -82,19 +81,7 @@ internal class ArticleLikeCreateProcessor(
         return articleLike
     }
 
-
     private fun upsertArticleLikeCount(articleId: Long) {
-        val articleLikeCount = articleLikeCountPersistencePort.findByIdOrNull(articleId = articleId)
-            ?: ArticleLikeCount.init(articleId)
-        articleLikeCount.increase()
-
-        // 동시성 문제가 발생할 여지가 있음.
-        // A 트랜잭션이 좋아요수를 조회
-        // B 트랜잭션이 좋아요수를 조회
-        // A 트랜잭션이 조회한 좋아요수를 기반으로 좋아요수 증가 커밋
-        // B 트랜잭션이 조회한 좋아요수를 기반으로 좋아요수 증가 커밋
-        // 이렇게 동시 요청자수가 2명일 경우 좋아요수가  2 증가해야하지만, 실제로는 1 증가할 수 있는 것이다.
-        // 동시요청자수가 100명, 1000명 늘어나게 될 경우 좋아요수의 정확도가 실제 좋아요 갯수와 많이 어긋나게 된다.
-        articleLikeCountPersistencePort.save(articleLikeCount)
+        articleLikeCountPersistencePort.increase(articleId)
     }
 }

--- a/board-system-article-like/article-like-application-service/src/test/kotlin/com/ttasjwi/board/system/articlelike/domain/ArticleLikeCancelUseCaseImplTest.kt
+++ b/board-system-article-like/article-like-application-service/src/test/kotlin/com/ttasjwi/board/system/articlelike/domain/ArticleLikeCancelUseCaseImplTest.kt
@@ -63,12 +63,7 @@ class ArticleLikeCancelUseCaseImplTest {
             )
         )
 
-        articleLikeCountPersistencePortFixture.save(
-            articleLikeCountFixture(
-                articleId = article.articleId,
-                likeCount = 13L
-            )
-        )
+        articleLikeCountPersistencePortFixture.increase(article.articleId)
 
         // when
         val response = articleLikeCancelUseCase.cancelLike(article.articleId)

--- a/board-system-article-like/article-like-application-service/src/test/kotlin/com/ttasjwi/board/system/articlelike/domain/ArticleLikeCountReadUseCaseImplTest.kt
+++ b/board-system-article-like/article-like-application-service/src/test/kotlin/com/ttasjwi/board/system/articlelike/domain/ArticleLikeCountReadUseCaseImplTest.kt
@@ -36,19 +36,14 @@ class ArticleLikeCountReadUseCaseImplTest {
                 articleId = 134151235L,
             )
         )
-        val articleLikeCount = articleLikeCountPersistencePortFixture.save(
-            articleLikeCountFixture(
-                articleId = article.articleId,
-                likeCount = 31412L,
-            )
-        )
+        articleLikeCountPersistencePortFixture.increase(article.articleId)
 
         // when
         val response = articleLikeCountReadUseCase.readLikeCount(article.articleId)
 
         // then
         assertThat(response.articleId).isEqualTo(article.articleId.toString())
-        assertThat(response.likeCount).isEqualTo(articleLikeCount.likeCount)
+        assertThat(response.likeCount).isEqualTo(1L)
     }
 
     @Test

--- a/board-system-article-like/article-like-application-service/src/test/kotlin/com/ttasjwi/board/system/articlelike/domain/processor/ArticleLikeCreateProcessorTest.kt
+++ b/board-system-article-like/article-like-application-service/src/test/kotlin/com/ttasjwi/board/system/articlelike/domain/processor/ArticleLikeCreateProcessorTest.kt
@@ -6,7 +6,6 @@ import com.ttasjwi.board.system.articlelike.domain.exception.ArticleLikeNotAllow
 import com.ttasjwi.board.system.articlelike.domain.exception.ArticleNotFoundException
 import com.ttasjwi.board.system.articlelike.domain.model.fixture.articleCategoryFixture
 import com.ttasjwi.board.system.articlelike.domain.model.fixture.articleFixture
-import com.ttasjwi.board.system.articlelike.domain.model.fixture.articleLikeCountFixture
 import com.ttasjwi.board.system.articlelike.domain.model.fixture.articleLikeFixture
 import com.ttasjwi.board.system.articlelike.domain.port.fixture.ArticleCategoryPersistencePortFixture
 import com.ttasjwi.board.system.articlelike.domain.port.fixture.ArticleLikeCountPersistencePortFixture
@@ -114,12 +113,7 @@ class ArticleLikeCreateProcessorTest {
             )
         )
 
-        articleLikeCountPersistencePortFixture.save(
-            articleLikeCount = articleLikeCountFixture(
-                articleId = article.articleId,
-                likeCount = 1L
-            )
-        )
+        articleLikeCountPersistencePortFixture.increase(article.articleId)
 
         val command = ArticleLikeCreateCommand(
             articleId = article.articleId,
@@ -256,12 +250,7 @@ class ArticleLikeCreateProcessorTest {
             )
         )
 
-        articleLikeCountPersistencePortFixture.save(
-            articleLikeCount = articleLikeCountFixture(
-                articleId = article.articleId,
-                likeCount = 1L
-            )
-        )
+        articleLikeCountPersistencePortFixture.increase(article.articleId)
 
         val command = ArticleLikeCreateCommand(
             articleId = article.articleId,

--- a/board-system-article-like/article-like-database-adapter/src/main/kotlin/com/ttasjwi/board/system/articlelike/infra/persistence/ArticleLikeCountPersistenceAdapter.kt
+++ b/board-system-article-like/article-like-database-adapter/src/main/kotlin/com/ttasjwi/board/system/articlelike/infra/persistence/ArticleLikeCountPersistenceAdapter.kt
@@ -2,7 +2,6 @@ package com.ttasjwi.board.system.articlelike.infra.persistence
 
 import com.ttasjwi.board.system.articlelike.domain.model.ArticleLikeCount
 import com.ttasjwi.board.system.articlelike.domain.port.ArticleLikeCountPersistencePort
-import com.ttasjwi.board.system.articlelike.infra.persistence.jpa.JpaArticleLikeCount
 import com.ttasjwi.board.system.articlelike.infra.persistence.jpa.JpaArticleLikeCountRepository
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
@@ -12,14 +11,12 @@ class ArticleLikeCountPersistenceAdapter(
     private val jpaArticleLikeCountRepository: JpaArticleLikeCountRepository
 ) : ArticleLikeCountPersistencePort {
 
-    override fun save(articleLikeCount: ArticleLikeCount): ArticleLikeCount {
-        val jpaEntity = JpaArticleLikeCount.from(articleLikeCount)
-        jpaArticleLikeCountRepository.save(jpaEntity)
-        return articleLikeCount
-    }
-
     override fun increase(articleId: Long) {
         jpaArticleLikeCountRepository.increase(articleId)
+    }
+
+    override fun decrease(articleId: Long) {
+        jpaArticleLikeCountRepository.decrease(articleId)
     }
 
     override fun findByIdOrNull(articleId: Long): ArticleLikeCount? {

--- a/board-system-article-like/article-like-database-adapter/src/main/kotlin/com/ttasjwi/board/system/articlelike/infra/persistence/ArticleLikeCountPersistenceAdapter.kt
+++ b/board-system-article-like/article-like-database-adapter/src/main/kotlin/com/ttasjwi/board/system/articlelike/infra/persistence/ArticleLikeCountPersistenceAdapter.kt
@@ -18,6 +18,10 @@ class ArticleLikeCountPersistenceAdapter(
         return articleLikeCount
     }
 
+    override fun increase(articleId: Long) {
+        jpaArticleLikeCountRepository.increase(articleId)
+    }
+
     override fun findByIdOrNull(articleId: Long): ArticleLikeCount? {
         return jpaArticleLikeCountRepository.findByIdOrNull(articleId)?.restoreDomain()
     }

--- a/board-system-article-like/article-like-database-adapter/src/main/kotlin/com/ttasjwi/board/system/articlelike/infra/persistence/jpa/JpaArticleLikeCountRepository.kt
+++ b/board-system-article-like/article-like-database-adapter/src/main/kotlin/com/ttasjwi/board/system/articlelike/infra/persistence/jpa/JpaArticleLikeCountRepository.kt
@@ -1,7 +1,20 @@
 package com.ttasjwi.board.system.articlelike.infra.persistence.jpa
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 
 @Repository("articleLikeJpaArticleLikeCountRepository")
-interface JpaArticleLikeCountRepository : JpaRepository<JpaArticleLikeCount, Long>
+interface JpaArticleLikeCountRepository : JpaRepository<JpaArticleLikeCount, Long> {
+
+    @Modifying
+    @Query(
+        """
+            INSERT INTO article_like_counts (article_id, like_count)
+            VALUES (:articleId, 1)
+            ON DUPLICATE KEY UPDATE like_count  = like_count + 1
+        """, nativeQuery = true
+    )
+    fun increase(articleId: Long)
+}

--- a/board-system-article-like/article-like-database-adapter/src/main/kotlin/com/ttasjwi/board/system/articlelike/infra/persistence/jpa/JpaArticleLikeCountRepository.kt
+++ b/board-system-article-like/article-like-database-adapter/src/main/kotlin/com/ttasjwi/board/system/articlelike/infra/persistence/jpa/JpaArticleLikeCountRepository.kt
@@ -17,4 +17,14 @@ interface JpaArticleLikeCountRepository : JpaRepository<JpaArticleLikeCount, Lon
         """, nativeQuery = true
     )
     fun increase(articleId: Long)
+
+    @Modifying
+    @Query(
+        """
+            UPDATE article_like_counts
+            SET like_count = like_count - 1
+            WHERE article_id = :articleId
+        """, nativeQuery = true
+    )
+    fun decrease(articleId: Long)
 }

--- a/board-system-article-like/article-like-database-adapter/src/test/kotlin/com/ttasjwi/board/system/articlelike/infra/persistence/ArticleLikeCountPersistenceAdapterTest.kt
+++ b/board-system-article-like/article-like-database-adapter/src/test/kotlin/com/ttasjwi/board/system/articlelike/infra/persistence/ArticleLikeCountPersistenceAdapterTest.kt
@@ -11,6 +11,46 @@ import org.junit.jupiter.api.Test
 class ArticleLikeCountPersistenceAdapterTest : ArticleLikeDataBaseIntegrationTest() {
 
     @Nested
+    @DisplayName("increase: 좋아요 수 증가")
+    inner class IncreaseTest {
+
+        @Test
+        @DisplayName("최초 좋아요 테스트")
+        fun test1() {
+            // given
+            val articleId = 5857L
+
+            // when
+            articleLikeArticleLikeCountPersistenceAdapter.increase(articleId)
+
+
+            // then
+            val articleLikeCount = articleLikeArticleLikeCountPersistenceAdapter.findByIdOrNull(articleId)!!
+
+            assertThat(articleLikeCount.articleId).isEqualTo(articleId)
+            assertThat(articleLikeCount.likeCount).isEqualTo(1)
+        }
+
+        @Test
+        @DisplayName("첫번째 이후 좋아요 테스트")
+        fun test2() {
+            // given
+            val articleId = 5857L
+
+            // when
+            articleLikeArticleLikeCountPersistenceAdapter.increase(articleId)
+            articleLikeArticleLikeCountPersistenceAdapter.increase(articleId)
+
+            // then
+            val articleLikeCount = articleLikeArticleLikeCountPersistenceAdapter.findByIdOrNull(articleId)!!
+
+            assertThat(articleLikeCount.articleId).isEqualTo(articleId)
+            assertThat(articleLikeCount.likeCount).isEqualTo(2)
+        }
+
+    }
+
+    @Nested
     @DisplayName("findByIdOrNull : articleId 값으로 좋아요 수 조회")
     inner class FindByIdOrNullTest {
 

--- a/board-system-article-like/article-like-database-adapter/src/test/kotlin/com/ttasjwi/board/system/articlelike/infra/persistence/ArticleLikeCountPersistenceAdapterTest.kt
+++ b/board-system-article-like/article-like-database-adapter/src/test/kotlin/com/ttasjwi/board/system/articlelike/infra/persistence/ArticleLikeCountPersistenceAdapterTest.kt
@@ -1,6 +1,5 @@
 package com.ttasjwi.board.system.articlelike.infra.persistence
 
-import com.ttasjwi.board.system.articlelike.domain.model.fixture.articleLikeCountFixture
 import com.ttasjwi.board.system.articlelike.infra.test.ArticleLikeDataBaseIntegrationTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
@@ -47,32 +46,37 @@ class ArticleLikeCountPersistenceAdapterTest : ArticleLikeDataBaseIntegrationTes
             assertThat(articleLikeCount.articleId).isEqualTo(articleId)
             assertThat(articleLikeCount.likeCount).isEqualTo(2)
         }
+    }
+
+
+    @Nested
+    @DisplayName("decrease: 좋아요 수 감소")
+    inner class DecreaseTest {
+
+        @Test
+        @DisplayName("두번 좋아요 수 증가 후, 좋아요수 감소 테스트")
+        fun test() {
+            // given
+            val articleId = 5857L
+
+            // when
+            articleLikeArticleLikeCountPersistenceAdapter.increase(articleId)
+            articleLikeArticleLikeCountPersistenceAdapter.increase(articleId)
+            articleLikeArticleLikeCountPersistenceAdapter.decrease(articleId)
+
+            // then
+            val articleLikeCount = articleLikeArticleLikeCountPersistenceAdapter.findByIdOrNull(articleId)!!
+
+            assertThat(articleLikeCount.articleId).isEqualTo(articleId)
+            assertThat(articleLikeCount.likeCount).isEqualTo(1)
+        }
 
     }
+
 
     @Nested
     @DisplayName("findByIdOrNull : articleId 값으로 좋아요 수 조회")
     inner class FindByIdOrNullTest {
-
-        @Test
-        @DisplayName("성공 테스트")
-        fun test1() {
-            // given
-            val articleId = 13L
-            val articleLikeCount = articleLikeCountFixture(
-                articleId = articleId,
-                likeCount = 1345L
-            )
-            articleLikeArticleLikeCountPersistenceAdapter.save(articleLikeCount)
-
-            // when
-            val findArticleLikeCount = articleLikeArticleLikeCountPersistenceAdapter.findByIdOrNull(articleId)!!
-
-            // then
-            assertThat(findArticleLikeCount.articleId).isEqualTo(articleLikeCount.articleId)
-            assertThat(findArticleLikeCount.likeCount).isEqualTo(articleLikeCount.likeCount)
-        }
-
 
         @Test
         @DisplayName("조회 실패시 null 반환 테스트")

--- a/board-system-article-like/article-like-database-adapter/src/test/resources/test-schema.sql
+++ b/board-system-article-like/article-like-database-adapter/src/test/resources/test-schema.sql
@@ -115,9 +115,8 @@ CREATE TABLE IF NOT EXISTS article_likes(
 );
 
 CREATE TABLE IF NOT EXISTS article_like_counts(
-    article_like_count_id BIGINT NOT NULL PRIMARY KEY,
-    article_id            BIGINT NOT NULL UNIQUE,
-    like_count            BIGINT NOT NULL
+    article_id BIGINT NOT NULL PRIMARY KEY,
+    like_count BIGINT NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS article_dislikes(

--- a/board-system-article-like/article-like-domain/src/main/kotlin/com/ttasjwi/board/system/articlelike/domain/model/ArticleLikeCount.kt
+++ b/board-system-article-like/article-like-domain/src/main/kotlin/com/ttasjwi/board/system/articlelike/domain/model/ArticleLikeCount.kt
@@ -2,33 +2,16 @@ package com.ttasjwi.board.system.articlelike.domain.model
 
 class ArticleLikeCount(
     val articleId: Long,
-    likeCount: Long
+    val likeCount: Long
 ) {
-    var likeCount: Long = likeCount
-        private set
 
     companion object {
-        fun init(articleId: Long): ArticleLikeCount {
-            return ArticleLikeCount(
-                articleId = articleId,
-                likeCount = 0L
-            )
-        }
-
         fun restore(articleId: Long, likeCount: Long): ArticleLikeCount {
             return ArticleLikeCount(
                 articleId = articleId,
                 likeCount = likeCount
             )
         }
-    }
-
-    fun increase() {
-        this.likeCount += 1
-    }
-
-    fun decrease() {
-        this.likeCount -= 1
     }
 
     override fun toString(): String {

--- a/board-system-article-like/article-like-domain/src/test/kotlin/com/ttasjwi/board/system/articlelike/domain/model/ArticleLikeCountTest.kt
+++ b/board-system-article-like/article-like-domain/src/test/kotlin/com/ttasjwi/board/system/articlelike/domain/model/ArticleLikeCountTest.kt
@@ -8,22 +8,6 @@ import org.junit.jupiter.api.Test
 @DisplayName("[article-like-domain] ArticleLikeCount 테스트")
 class ArticleLikeCountTest {
 
-
-    @Test
-    @DisplayName("init: 초기화")
-    fun initTest() {
-        // given
-        val articleId = 12243414L
-
-        // when
-        val articleLikeCount = ArticleLikeCount.init(articleId)
-
-        // then
-        assertThat(articleLikeCount.articleId).isEqualTo(articleId)
-        assertThat(articleLikeCount.likeCount).isEqualTo(0L)
-    }
-
-
     @Test
     @DisplayName("restore: 값으로 부터 복원")
     fun restoreTest() {
@@ -41,44 +25,6 @@ class ArticleLikeCountTest {
         assertThat(articleLikeCount.articleId).isEqualTo(articleId)
         assertThat(articleLikeCount.likeCount).isEqualTo(likeCount)
     }
-
-
-    @Test
-    @DisplayName("increase : 좋아요 수 증가")
-    fun increaseTest() {
-        // given
-        val articleId = 12243414L
-        val likeCount = 1314L
-        val articleLikeCount = articleLikeCountFixture(
-            articleId = articleId,
-            likeCount = likeCount,
-        )
-        // when
-        articleLikeCount.increase()
-
-        // then
-        assertThat(articleLikeCount.likeCount).isEqualTo(likeCount + 1)
-    }
-
-
-    @Test
-    @DisplayName("decrease(): 좋아요 수 감소")
-    fun decreaseTest() {
-        // given
-        val articleId = 12243414L
-        val likeCount = 1314L
-        val articleLikeCount = articleLikeCountFixture(
-            articleId = articleId,
-            likeCount = likeCount,
-        )
-
-        // when
-        articleLikeCount.decrease()
-
-        // then
-        assertThat(articleLikeCount.likeCount).isEqualTo(likeCount - 1)
-    }
-
 
     @Test
     @DisplayName("toString(): 디버깅용 문자열 반환")

--- a/board-system-board/board-database-adapter/src/test/resources/test-schema.sql
+++ b/board-system-board/board-database-adapter/src/test/resources/test-schema.sql
@@ -115,9 +115,8 @@ CREATE TABLE IF NOT EXISTS article_likes(
 );
 
 CREATE TABLE IF NOT EXISTS article_like_counts(
-    article_like_count_id BIGINT NOT NULL PRIMARY KEY,
-    article_id            BIGINT NOT NULL UNIQUE,
-    like_count            BIGINT NOT NULL
+    article_id BIGINT NOT NULL PRIMARY KEY,
+    like_count BIGINT NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS article_dislikes(

--- a/board-system-infrastructure/web-support/src/main/kotlin/com/ttasjwi/board/system/common/infra/websupport/auth/security/AuthUserAuthentication.kt
+++ b/board-system-infrastructure/web-support/src/main/kotlin/com/ttasjwi/board/system/common/infra/websupport/auth/security/AuthUserAuthentication.kt
@@ -5,7 +5,7 @@ import org.springframework.security.core.Authentication
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 
-internal class AuthUserAuthentication
+class AuthUserAuthentication
 private constructor(
     private val authUser: AuthUser
 ) : Authentication {


### PR DESCRIPTION
# JIRA 티켓
- [BRD-153]

---

# 개요
- 동시에 여러명의 사용자가 좋아요를 할 경우, 좋아요 수가 데이터베이스에 정상적으로 반영되지 않는다.
- 이런 동시성 문제를 해결하고, 동시 사용자가 좋아요한 만큼 좋아요수가 정상적으로 증가할 수 있도록 한다.

---

# 문제상황
```kotlin

@Disabled // 수동테스트용(테스트 해보고 싶을 경우 주석처리)
@SpringBootTest
@DisplayName("[app] 게시글 좋아요 수 통합테스트")
class ArticleLikeCountIntegrationTest {

    @Autowired
    private lateinit var articlePersistencePort: ArticlePersistencePort

    @Autowired
    private lateinit var articleCategoryPersistencePort: ArticleCategoryPersistencePort

    @Autowired
    private lateinit var articleLikeUseCase: ArticleLikeCreateUseCase

    @Autowired
    private lateinit var articleLikeCountReadUseCase: ArticleLikeCountReadUseCase

    @Test
    @DisplayName("좋아요 수 동시성 테스트 : 동시 사용자가 많을 때, 좋아요 수")
    fun likeCountConcurrencyTest() {
        val executorService = Executors.newFixedThreadPool(100)
        likeCountTest(executorService, 111L, 111L, 111L)
        executorService.shutdown()
    }

    private fun likeCountTest(
        executorService: ExecutorService,
        boardId: Long,
        articleId: Long,
        articleCategoryId: Long
    ) {

        val userCount = 3000
        prepareArticleCategory(boardId, articleCategoryId)
        prepareArticle(boardId, articleCategoryId, articleId)

        val latch = CountDownLatch(userCount)
        println("--------------------------------------------------------------------------")
        println("start")
        val start = System.nanoTime()
        for (i in 1..userCount) {
            val userId = i.toLong()

            executorService.execute {
                try {
                    like(articleId, userId)
                } catch (e: Exception) {
                    println("Error for userId=$userId: ${e.message}")
                } finally {
                    latch.countDown()
                }
            }

        }
        latch.await()
        val end = System.nanoTime()
        println("time = ${(end - start) / 100_0000} ms")

        val response = articleLikeCountReadUseCase.readLikeCount(
            articleId = articleId,
        )

        println("end")
        println("count = ${response.likeCount}")
        println("--------------------------------------------------------------------------")

        assertThat(response.likeCount).isNotEqualTo(userCount)
    }

    private fun like(articleId: Long, userId: Long) {
        setAuthUser(userId)
        articleLikeUseCase.like(articleId)
    }

    private fun setAuthUser(userId: Long) {
        val authentication = AuthUserAuthentication.from(
            authUser = authUserFixture(
                userId = userId,
                role = Role.USER
            )
        )
        val securityContext = SecurityContextHolder.getContextHolderStrategy().createEmptyContext()
        securityContext.authentication = authentication
        SecurityContextHolder.getContextHolderStrategy().context = securityContext
    }

    private fun prepareArticle(boardId: Long, articleCategoryId: Long, articleId: Long) {
        articlePersistencePort.save(
            articleFixture(
                articleId = articleId,
                title = "article-title-$articleId",
                content = "article-content-$articleId",
                boardId = boardId,
                articleCategoryId = articleCategoryId,
                writerId = 1L
            )
        )
    }

    private fun prepareArticleCategory(boardId: Long, articleCategoryId: Long) {
        articleCategoryPersistencePort.save(
            articleCategoryFixture(
                articleCategoryId = articleCategoryId,
                name = "테스트",
                slug = "test",
                boardId = boardId,
                allowLike = true,
                allowDislike = true
            )
        )
    }
}
```
- 이 테스트에서는 3000명의 사용자가 동시에 하나의 게시글에 좋아요를 한번씩 한다고 가정하고 테스트를 합니다.


```text
--------------------------------------------------------------------------
start
2025-05-21T12:00:36.040+09:00  WARN 8424 --- [board-system] [pool-3-thread-3] o.h.engine.jdbc.spi.SqlExceptionHelper   : SQL Error: 1062, SQLState: 23000
2025-05-21T12:00:36.040+09:00  WARN 8424 --- [board-system] [ool-3-thread-33] o.h.engine.jdbc.spi.SqlExceptionHelper   : SQL Error: 1062, SQLState: 23000
2025-05-21T12:00:36.040+09:00  WARN 8424 --- [board-system] [ool-3-thread-16] o.h.engine.jdbc.spi.SqlExceptionHelper   : SQL Error: 1062, SQLState: 23000
2025-05-21T12:00:36.041+09:00 ERROR 8424 --- [board-system] [ool-3-thread-33] o.h.engine.jdbc.spi.SqlExceptionHelper   : Duplicate entry '111' for key 'article_like_counts.PRIMARY'
2025-05-21T12:00:36.040+09:00  WARN 8424 --- [board-system] [ool-3-thread-36] o.h.engine.jdbc.spi.SqlExceptionHelper   : SQL Error: 1062, SQLState: 23000
2025-05-21T12:00:36.040+09:00  WARN 8424 --- [board-system] [ool-3-thread-20] o.h.engine.jdbc.spi.SqlExceptionHelper   : SQL Error: 1062, SQLState: 23000
2025-05-21T12:00:36.041+09:00 ERROR 8424 --- [board-system] [ool-3-thread-20] o.h.engine.jdbc.spi.SqlExceptionHelper   : Duplicate entry '111' for key 'article_like_counts.PRIMARY'
2025-05-21T12:00:36.041+09:00 ERROR 8424 --- [board-system] [ool-3-thread-36] o.h.engine.jdbc.spi.SqlExceptionHelper   : Duplicate entry '111' for key 'article_like_counts.PRIMARY'
2025-05-21T12:00:36.040+09:00  WARN 8424 --- [board-system] [pool-3-thread-6] o.h.engine.jdbc.spi.SqlExceptionHelper   : SQL Error: 1062, SQLState: 23000
2025-05-21T12:00:36.040+09:00  WARN 8424 --- [board-system] [ool-3-thread-37] o.h.engine.jdbc.spi.SqlExceptionHelper   : SQL Error: 1062, SQLState: 23000
2025-05-21T12:00:36.042+09:00 ERROR 8424 --- [board-system] [pool-3-thread-6] o.h.engine.jdbc.spi.SqlExceptionHelper   : Duplicate entry '111' for key 'article_like_counts.PRIMARY'
2025-05-21T12:00:36.041+09:00  WARN 8424 --- [board-system] [ool-3-thread-25] o.h.engine.jdbc.spi.SqlExceptionHelper   : SQL Error: 1062, SQLState: 23000
2025-05-21T12:00:36.042+09:00 ERROR 8424 --- [board-system] [ool-3-thread-37] o.h.engine.jdbc.spi.SqlExceptionHelper   : Duplicate entry '111' for key 'article_like_counts.PRIMARY'
2025-05-21T12:00:36.042+09:00 ERROR 8424 --- [board-system] [ool-3-thread-25] o.h.engine.jdbc.spi.SqlExceptionHelper   : Duplicate entry '111' for key 'article_like_counts.PRIMARY'
2025-05-21T12:00:36.041+09:00  WARN 8424 --- [board-system] [ool-3-thread-34] o.h.engine.jdbc.spi.SqlExceptionHelper   : SQL Error: 1062, SQLState: 23000
2025-05-21T12:00:36.042+09:00 ERROR 8424 --- [board-system] [ool-3-thread-34] o.h.engine.jdbc.spi.SqlExceptionHelper   : Duplicate entry '111' for key 'article_like_counts.PRIMARY'
2025-05-21T12:00:36.041+09:00 ERROR 8424 --- [board-system] [pool-3-thread-3] o.h.engine.jdbc.spi.SqlExceptionHelper   : Duplicate entry '111' for key 'article_like_counts.PRIMARY'
2025-05-21T12:00:36.041+09:00 ERROR 8424 --- [board-system] [ool-3-thread-16] o.h.engine.jdbc.spi.SqlExceptionHelper   : Duplicate entry '111' for key 'article_like_counts.PRIMARY'
Error for userId=34: could not execute statement [Duplicate entry '111' for key 'article_like_counts.PRIMARY'] [insert into article_like_counts (like_count,article_id) values (?,?)]; SQL [insert into article_like_counts (like_count,article_id) values (?,?)]; constraint [article_like_counts.PRIMARY]
Error for userId=6: could not execute statement [Duplicate entry '111' for key 'article_like_counts.PRIMARY'] [insert into article_like_counts (like_count,article_id) values (?,?)]; SQL [insert into article_like_counts (like_count,article_id) values (?,?)]; constraint [article_like_counts.PRIMARY]
Error for userId=33: could not execute statement [Duplicate entry '111' for key 'article_like_counts.PRIMARY'] [insert into article_like_counts (like_count,article_id) values (?,?)]; SQL [insert into article_like_counts (like_count,article_id) values (?,?)]; constraint [article_like_counts.PRIMARY]
Error for userId=20: could not execute statement [Duplicate entry '111' for key 'article_like_counts.PRIMARY'] [insert into article_like_counts (like_count,article_id) values (?,?)]; SQL [insert into article_like_counts (like_count,article_id) values (?,?)]; constraint [article_like_counts.PRIMARY]
Error for userId=3: could not execute statement [Duplicate entry '111' for key 'article_like_counts.PRIMARY'] [insert into article_like_counts (like_count,article_id) values (?,?)]; SQL [insert into article_like_counts (like_count,article_id) values (?,?)]; constraint [article_like_counts.PRIMARY]
Error for userId=16: could not execute statement [Duplicate entry '111' for key 'article_like_counts.PRIMARY'] [insert into article_like_counts (like_count,article_id) values (?,?)]; SQL [insert into article_like_counts (like_count,article_id) values (?,?)]; constraint [article_like_counts.PRIMARY]
Error for userId=36: could not execute statement [Duplicate entry '111' for key 'article_like_counts.PRIMARY'] [insert into article_like_counts (like_count,article_id) values (?,?)]; SQL [insert into article_like_counts (like_count,article_id) values (?,?)]; constraint [article_like_counts.PRIMARY]
Error for userId=25: could not execute statement [Duplicate entry '111' for key 'article_like_counts.PRIMARY'] [insert into article_like_counts (like_count,article_id) values (?,?)]; SQL [insert into article_like_counts (like_count,article_id) values (?,?)]; constraint [article_like_counts.PRIMARY]
Error for userId=37: could not execute statement [Duplicate entry '111' for key 'article_like_counts.PRIMARY'] [insert into article_like_counts (like_count,article_id) values (?,?)]; SQL [insert into article_like_counts (like_count,article_id) values (?,?)]; constraint [article_like_counts.PRIMARY]
time = 30536 ms
end
count = 302
--------------------------------------------------------------------------
```
- 3000개의 사용자가 100개 스레드를 통해 좋아요 동시 요청을 하였는데, 실제 최종 좋아요 수는 302개가 됩니다.
- 그리고, 테스트 초반부에서는 '좋아요 수' 객체를 최초 삽입하는 과정에서도 중복키 예외가 발생하여, 좋아요가 정상적으로 생성되지 않습니다.

# 문제 원인 분석
```kotlin


    private fun upsertArticleLikeCount(articleId: Long) {
        val articleLikeCount = articleLikeCountPersistencePort.findByIdOrNull(articleId = articleId)
            ?: ArticleLikeCount.init(articleId)
        articleLikeCount.increase()

        // 동시성 문제가 발생할 여지가 있음.
        // A 트랜잭션이 좋아요수를 조회
        // B 트랜잭션이 좋아요수를 조회
        // A 트랜잭션이 조회한 좋아요수를 기반으로 좋아요수 증가 커밋
        // B 트랜잭션이 조회한 좋아요수를 기반으로 좋아요수 증가 커밋
        // 이렇게 동시 요청자수가 2명일 경우 좋아요수가  2 증가해야하지만, 실제로는 1 증가할 수 있는 것이다.
        // 동시요청자수가 100명, 1000명 늘어나게 될 경우 좋아요수의 정확도가 실제 좋아요 갯수와 많이 어긋나게 된다.
        articleLikeCountPersistencePort.save(articleLikeCount)
    }
```
- 문제의 원인은 좋아요수를 저장하는 부분에 있습니다.
- 우선 데이터베이스에서 좋아요수를 조회하고
  - 없으면 '좋아요수' 객체를 초기화하고, 있으면 조회된 좋아요수 객체를 사용합니다.
  - 이렇게 구해진 좋아요수 객체의 좋아요수를 1 증가시킨뒤 저장소에 save를 통해 저장합니다.
- 이 방식의 문제점은 조회된(초기화된) 좋아요수 객체의 상태를 기반으로 1 증가시키고 이를 데이터베이스에 변경된 값으로 업데이트하는 데에 있습니다.
  - A 트랜잭션이 좋아요수 조회
  - B 트랜잭션이 좋아요수 조회
  - A 트랜잭션이 조회한 좋아요수를 기반으로 좋아요수 증가 커밋
  - B 트랜잭션이 조회한 좋아요수를 기반으로 좋아요수 증가 커밋
  - 이렇게 동시 요청자수가 2명일 경우 좋아요수가  2 증가해야하지만, 실제로는 1 증가할 수 있음
- 이렇게 될 경우, 좋아요수가 실제 좋아요 갯수와 일치하지 않게 됩니다.

---

# 문제 해결방법 고민
이 동시성 문제를 해결하는 방법은 이미 잘 알려져있고, 그 중 몇 가지를 이야기해보겠습니다
- 방법1: 낙관적 락
  - '좋아요수' 테이블에 'Version` 칼럼을 추가하고, 매 순간 좋아요수 레코드의 버전을 관리합니다.
  - 별도의 락을 사용하지 않고, 매번 로직을 실행하여, 좋아요수 수정시도를 합니다.
  - 저장시점의 Version 이 기존 Version + 1 이 아닐 경우, 예외가 발생하게 됩니다.
  - 이런 예외를 애플리케이션에서 Catch 하고, 성공할 때까지 무한반복을 하는 식으로 문제를 해결할 수 있습니다.
- 방법2: 비관적 락
  - '좋아요수' 조회 시점에, select 쿼리 끝에 `for update` 를 붙입니다. 이렇게 하면 좋아요수 행에 대한 exclusive lock (배타락)을 획득합니다.
  - 배타락(exclusive lock) 을 획득하면, 다른 트랜잭션에서 해당 행 데이터에 대한 수정이 불가능하고 배타락 획득을 할 수 없습니다.
  - 락은 트랜잭션이 종료(commit/rollback)될 때까지 유지됩니다.

---

# 그런데 문제점이 있다.
- 우리 애플리케이션 로직에서는 '좋아요수'가 최초 초기화되는 지점이, 최초 좋아요를 한 사람이 좋아요수 객체를 생성하고, 좋아요수 행을 실제 insert 하게 됩니다.
- 이 좋아요수를 최초에 생성하는 것도 동시사용자가 여럿 있다면 '중복키 예외'가 발생할 수 있고, 락 개념을 통틀어서 생각해도 좋아요수가 항상 올바르다고 할 수 없습니다.
- 조회락 개념이란 것도, 좋아요수 데이터가 실제 있어야 가능한 개념인데 실제 대상이 되는 좋아요수가 없을 수도 있기 때문에 위 방식에도 한계가 있을 수 있습니다.
- '좋아요수'를 게시글이 생성된 시점에 초기화하는 방법도 고려해볼 수 있습니다.
  - 이렇게 하면 게시글이 생성된 시점에 '좋아요수'객체가 존재하는 것을 보장할 수 있습니다.
  - 하지만 이렇게 하면 게시글 컨텍스트에서, '좋아요수' 개념을 알게되는 문제가 생깁니다.
- 또는 별도의 락 저장소를 통해, 게시글수 락을 관리하는 방법도 있습니다. 게시글이 실제 있든 없든, 좋아요를 하려는 사용자가 '좋아요 수 락'을 명시적으로 획득해서 관리하는 방법이죠.
  - 이렇게 하면, 좋아요를 할 때마다 별도의 저장소(예: 레디스) 에서 좋아요수 락 획득을 시도합니다.
  - 좋아요수를 초기화하고, 저장하는 작업을 하기 전에 락 획득을 시도하며 락을 획득하지 않으면 좋아요 로직을 실행할 수 없습니다.
  - 최초에 좋아요수가 객체가 없더라도, 좋아요수락 저장소에서 락을 획득할 수 있기 때문에 모든 경우를 통틀어 동시성 문제를 해결 할 수 있습니다.
  - 다만 별도의 저장소를 사용해야하는 비용이 발생합니다.

---

# 최초 생성 중복문제와 통틀어 저렴하게 동시성 문제를 해결하는 방법
- 별도의 저장소를 사용하지 않고, MySQL 만을 이용해 좋아요수 동시성 문제를 해결할 방법은 없을까?
- 답은 생각보다 간단했습니다. 좋아요수를 조회해서 증가시켜서 데이터베이스에 반영시키지 않고, 그냥 바로 데이터베이스에서 현재 데이터베이스 상태에 기반하여 생성/증가를 하도록 하는 것입니다.

```kotlin
    @Modifying
    @Query(
        """
            INSERT INTO article_like_counts (article_id, like_count)
            VALUES (:articleId, 1)
            ON DUPLICATE KEY UPDATE like_count  = like_count + 1
        """, nativeQuery = true
    )
    fun increase(articleId: Long)
```
- mysql native query의 'on duplicate key' 구문을 활용하면, insert 쿼리 실행시 중복키 문제가 발생할 경우 어떻게 갱신시킬지를 설정할 수 있습니다.
- 최초에 좋아요수를 초기화하는 시점에 중복키 문제가 발생하면 update 구문이 실행됨으서 최초 초기화 시의 동시성 문제를 해결할 수 있습니다.
- 매번 실행될 때마다 현재 데이터베이스의 상태를 기반으로 값을 업데이트하므로 동시성 문제를 해결할 수 있습니다. 

```kotlin
    private fun upsertArticleLikeCount(articleId: Long) {
        articleLikeCountPersistencePort.increase(articleId)
    }
```
- 이제, 좋아요수 증가하는 부분을 수정해봅니다.
  - 기존 : '조회' -> 객체 가져오기 -> '객체 상태 변경' -> '데이터베이스에 반영'
  - 변경후 : 바로 데이터베이스에 반영

---

# 테스트 다시 실행
```shell
--------------------------------------------------------------------------
start
time = 35604 ms
end
count = 3000
--------------------------------------------------------------------------
```
- 다시 테스트를 실행해보면, 좋아요수가 3000만큼 딱 증가된 것을 볼 수 있어요.
- 실제 데이터베이스에서도 잘 되어있는지 확인해봅시다.

```mysql
mysql> select Count(*) from article_likes where article_id = 12345;
+----------+
| Count(*) |
+----------+
|     3000 |
+----------+
1 row in set (0.00 sec)
```
```mysql
mysql> select * from article_like_counts where article_id = 12345;
+------------+------------+
| article_id | like_count |
+------------+------------+
|      12345 |       3000 |
+------------+------------+
1 row in set (0.00 sec)
```
- 실제 좋아요 갯수도 3000개 생성됐고, 좋아요수 테이블의 좋아요수 상태도 3000으로 잘 저장된 것을 볼 수 있습니다.

---

# 좋아요수 취소 로직 수정
```kotlin
    @Modifying
    @Query(
        """
            UPDATE article_like_counts
            SET like_count = like_count - 1
            WHERE article_id = :articleId
        """, nativeQuery = true
    )
    fun decrease(articleId: Long)
```
```kotlin
    /**
     * 게시글 좋아요 수 감소
     */
    private fun decreaseArticleLikeCount(articleId: Long) {
        articleLikeCountPersistencePort.decrease(articleId)
    }
```
- 마찬가지로, 좋아요 취소시 좋아요수 감소가 되어야하는데 이 역시 동시성 이슈가 있습니다.
- 위와 같은 방식으로 문제를 해결합니다.

```text
--------------------------------------------------------------------------
start create Likes : articleId = 13413413413
time = 36193 ms
end create Likes : articleId = 13413413413
count = 3000
--------------------------------------------------------------------------
--------------------------------------------------------------------------
start cancel Likes : articleId = 13413413413
time = 27069 ms
end cancel Likes : articleId = 13413413413
count = 0
--------------------------------------------------------------------------
```
- 좋아요, 좋아요 취소 기능을 각각 3000번(사용자 3000명) 호출시, 좋아요 수가 3000으로 증가했다가 0이 되는 것을 확인할 수 있습니다.


[BRD-153]: https://ttasjwi.atlassian.net/browse/BRD-153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ