### PR TITLE
Fix: (BRD-157) 게시글 싫어요수 동시성 문제 해결

### DIFF
--- a/board-system-app/src/test/kotlin/com/ttasjwi/board/system/app/articlelike/api/ArticleDislikeCountIntegrationTest.kt
+++ b/board-system-app/src/test/kotlin/com/ttasjwi/board/system/app/articlelike/api/ArticleDislikeCountIntegrationTest.kt
@@ -1,0 +1,195 @@
+package com.ttasjwi.board.system.app.articlelike.api
+
+import com.ttasjwi.board.system.article.domain.model.fixture.articleFixture
+import com.ttasjwi.board.system.article.domain.port.ArticlePersistencePort
+import com.ttasjwi.board.system.articlelike.domain.*
+import com.ttasjwi.board.system.board.domain.model.fixture.articleCategoryFixture
+import com.ttasjwi.board.system.board.domain.port.ArticleCategoryPersistencePort
+import com.ttasjwi.board.system.common.auth.Role
+import com.ttasjwi.board.system.common.auth.fixture.authUserFixture
+import com.ttasjwi.board.system.common.infra.websupport.auth.security.AuthUserAuthentication
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.security.core.context.SecurityContextHolder
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+
+@Disabled // 수동테스트용(테스트 해보고 싶을 경우 주석처리)
+@SpringBootTest
+@DisplayName("[app] 게시글 싫어요 수 통합테스트")
+class ArticleDislikeCountIntegrationTest {
+
+    @Autowired
+    private lateinit var articlePersistencePort: ArticlePersistencePort
+
+    @Autowired
+    private lateinit var articleCategoryPersistencePort: ArticleCategoryPersistencePort
+
+    @Autowired
+    private lateinit var articleDislikeCreateUseCase: ArticleDislikeCreateUseCase
+
+    @Autowired
+    private lateinit var articleDislikeCancelUseCase: ArticleDislikeCancelUseCase
+
+    @Autowired
+    private lateinit var articleDislikeCountReadUseCase: ArticleDislikeCountReadUseCase
+
+    @Test
+    @DisplayName("싫어요 수 동시성 테스트 : 동시 사용자가 많을 때, 싫어요 수")
+    fun dislikeCountConcurrencyTest() {
+        val threadCount = 100
+        val userCount = 3000
+        val boardArticleArticleCategoryId = 13413413413L
+
+        val executorService = Executors.newFixedThreadPool(threadCount)
+
+        createDislikes(
+            executorService = executorService,
+            userCount = userCount,
+            boardId = boardArticleArticleCategoryId,
+            articleId = boardArticleArticleCategoryId,
+            articleCategoryId = boardArticleArticleCategoryId
+        )
+        cancelDislikes(
+            executorService = executorService,
+            userCount = userCount,
+            articleId = boardArticleArticleCategoryId,
+        )
+        executorService.shutdown()
+    }
+
+    private fun createDislikes(
+        executorService: ExecutorService,
+        userCount: Int,
+        boardId: Long,
+        articleId: Long,
+        articleCategoryId: Long
+    ) {
+        prepareArticleCategory(boardId, articleCategoryId)
+        prepareArticle(boardId, articleCategoryId, articleId)
+
+        val latch = CountDownLatch(userCount)
+        println("--------------------------------------------------------------------------")
+        println("start create Dislikes : articleId = $articleId")
+        val start = System.nanoTime()
+        for (i in 1..userCount) {
+            val userId = i.toLong()
+
+            executorService.execute {
+                try {
+                    dislike(articleId, userId)
+                } catch (e: Exception) {
+                    println("Error for userId=$userId: ${e.message}")
+                } finally {
+                    latch.countDown()
+                }
+            }
+
+        }
+        latch.await()
+        val end = System.nanoTime()
+        println("time = ${(end - start) / 100_0000} ms")
+
+        val response = articleDislikeCountReadUseCase.readDislikeCount(
+            articleId = articleId,
+        )
+
+        println("end create Dislikes : articleId = $articleId")
+        println("count = ${response.dislikeCount}")
+        println("--------------------------------------------------------------------------")
+
+        assertThat(response.dislikeCount).isNotEqualTo(userCount.toLong())
+    }
+
+    private fun cancelDislikes(
+        executorService: ExecutorService,
+        userCount: Int,
+        articleId: Long,
+    ) {
+        val latch = CountDownLatch(userCount)
+        println("--------------------------------------------------------------------------")
+        println("start cancel Dislikes : articleId = $articleId")
+        val start = System.nanoTime()
+        for (i in 1..userCount) {
+            val userId = i.toLong()
+
+            executorService.execute {
+                try {
+                    cancelDislike(articleId, userId)
+                } catch (e: Exception) {
+                    println("Error for userId=$userId: ${e.message}")
+                } finally {
+                    latch.countDown()
+                }
+            }
+
+        }
+        latch.await()
+        val end = System.nanoTime()
+        println("time = ${(end - start) / 100_0000} ms")
+
+        val response = articleDislikeCountReadUseCase.readDislikeCount(
+            articleId = articleId,
+        )
+
+        println("end cancel Dislikes : articleId = $articleId")
+        println("count = ${response.dislikeCount}")
+        println("--------------------------------------------------------------------------")
+
+        assertThat(response.dislikeCount).isNotEqualTo(0)
+    }
+
+
+    private fun dislike(articleId: Long, userId: Long) {
+        setAuthUser(userId)
+        articleDislikeCreateUseCase.dislike(articleId)
+    }
+
+    private fun cancelDislike(articleId: Long, userId: Long) {
+        setAuthUser(userId)
+        articleDislikeCancelUseCase.cancelDislike(articleId)
+    }
+
+    private fun setAuthUser(userId: Long) {
+        val authentication = AuthUserAuthentication.from(
+            authUser = authUserFixture(
+                userId = userId,
+                role = Role.USER
+            )
+        )
+        val securityContext = SecurityContextHolder.getContextHolderStrategy().createEmptyContext()
+        securityContext.authentication = authentication
+        SecurityContextHolder.getContextHolderStrategy().context = securityContext
+    }
+
+    private fun prepareArticle(boardId: Long, articleCategoryId: Long, articleId: Long) {
+        articlePersistencePort.save(
+            articleFixture(
+                articleId = articleId,
+                title = "article-title-$articleId",
+                content = "article-content-$articleId",
+                boardId = boardId,
+                articleCategoryId = articleCategoryId,
+                writerId = 1L
+            )
+        )
+    }
+
+    private fun prepareArticleCategory(boardId: Long, articleCategoryId: Long) {
+        articleCategoryPersistencePort.save(
+            articleCategoryFixture(
+                articleCategoryId = articleCategoryId,
+                name = "테스트",
+                slug = "test",
+                boardId = boardId,
+                allowLike = true,
+                allowDislike = true
+            )
+        )
+    }
+}

--- a/board-system-app/src/test/kotlin/com/ttasjwi/board/system/app/articlelike/api/ArticleDislikeCountIntegrationTest.kt
+++ b/board-system-app/src/test/kotlin/com/ttasjwi/board/system/app/articlelike/api/ArticleDislikeCountIntegrationTest.kt
@@ -44,7 +44,7 @@ class ArticleDislikeCountIntegrationTest {
     fun dislikeCountConcurrencyTest() {
         val threadCount = 100
         val userCount = 3000
-        val boardArticleArticleCategoryId = 13413413413L
+        val boardArticleArticleCategoryId = 171531L
 
         val executorService = Executors.newFixedThreadPool(threadCount)
 
@@ -103,7 +103,7 @@ class ArticleDislikeCountIntegrationTest {
         println("count = ${response.dislikeCount}")
         println("--------------------------------------------------------------------------")
 
-        assertThat(response.dislikeCount).isNotEqualTo(userCount.toLong())
+        assertThat(response.dislikeCount).isEqualTo(userCount.toLong())
     }
 
     private fun cancelDislikes(
@@ -141,7 +141,7 @@ class ArticleDislikeCountIntegrationTest {
         println("count = ${response.dislikeCount}")
         println("--------------------------------------------------------------------------")
 
-        assertThat(response.dislikeCount).isNotEqualTo(0)
+        assertThat(response.dislikeCount).isEqualTo(0)
     }
 
 

--- a/board-system-article-like/article-like-application-output-port/src/main/kotlin/com/ttasjwi/board/system/articlelike/domain/port/ArticleDislikeCountPersistencePort.kt
+++ b/board-system-article-like/article-like-application-output-port/src/main/kotlin/com/ttasjwi/board/system/articlelike/domain/port/ArticleDislikeCountPersistencePort.kt
@@ -3,6 +3,8 @@ package com.ttasjwi.board.system.articlelike.domain.port
 import com.ttasjwi.board.system.articlelike.domain.model.ArticleDislikeCount
 
 interface ArticleDislikeCountPersistencePort {
-    fun save(articleDislikeCount: ArticleDislikeCount): ArticleDislikeCount
+
+    fun increase(articleId: Long)
+    fun decrease(articleId: Long)
     fun findByIdOrNull(articleId: Long): ArticleDislikeCount?
 }

--- a/board-system-article-like/article-like-application-output-port/src/test/kotlin/com/ttasjwi/board/system/articlelike/domain/port/fixture/ArticleDislikeCountPersistencePortFixtureTest.kt
+++ b/board-system-article-like/article-like-application-output-port/src/test/kotlin/com/ttasjwi/board/system/articlelike/domain/port/fixture/ArticleDislikeCountPersistencePortFixtureTest.kt
@@ -1,6 +1,5 @@
 package com.ttasjwi.board.system.articlelike.domain.port.fixture
 
-import com.ttasjwi.board.system.articlelike.domain.model.fixture.articleDislikeCountFixture
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -18,28 +17,72 @@ class ArticleDislikeCountPersistencePortFixtureTest {
     }
 
     @Nested
-    @DisplayName("findByIdOrNull : articleId 값으로 좋아요 수 조회")
-    inner class FindByIdOrNullTest {
+    @DisplayName("increase: 싫어요 수 증가")
+    inner class IncreaseTest {
 
         @Test
-        @DisplayName("성공 테스트")
+        @DisplayName("최초 싫어요 테스트")
         fun test1() {
             // given
-            val articleId = 13L
-            val articleDislikeCount = articleDislikeCountFixture(
-                articleId = articleId,
-                dislikeCount = 1345L
-            )
-            articleDislikeCountPersistencePortFixture.save(articleDislikeCount)
+            val articleId = 5857L
 
             // when
-            val findArticleDislikeCount = articleDislikeCountPersistencePortFixture.findByIdOrNull(articleId)!!
+            articleDislikeCountPersistencePortFixture.increase(articleId)
+
 
             // then
-            assertThat(findArticleDislikeCount.articleId).isEqualTo(articleDislikeCount.articleId)
-            assertThat(findArticleDislikeCount.dislikeCount).isEqualTo(articleDislikeCount.dislikeCount)
+            val articleDislikeCount = articleDislikeCountPersistencePortFixture.findByIdOrNull(articleId)!!
+
+            assertThat(articleDislikeCount.articleId).isEqualTo(articleId)
+            assertThat(articleDislikeCount.dislikeCount).isEqualTo(1)
         }
 
+        @Test
+        @DisplayName("첫번째 이후 싫어요 테스트")
+        fun test2() {
+            // given
+            val articleId = 5857L
+
+            // when
+            articleDislikeCountPersistencePortFixture.increase(articleId)
+            articleDislikeCountPersistencePortFixture.increase(articleId)
+
+            // then
+            val articleDislikeCount = articleDislikeCountPersistencePortFixture.findByIdOrNull(articleId)!!
+
+            assertThat(articleDislikeCount.articleId).isEqualTo(articleId)
+            assertThat(articleDislikeCount.dislikeCount).isEqualTo(2)
+        }
+    }
+
+
+    @Nested
+    @DisplayName("decrease: 싫어요 수 감소")
+    inner class DecreaseTest {
+
+        @Test
+        @DisplayName("두번 싫어요 수 증가 후, 싫어요수 감소 테스트")
+        fun test() {
+            // given
+            val articleId = 5857L
+
+            // when
+            articleDislikeCountPersistencePortFixture.increase(articleId)
+            articleDislikeCountPersistencePortFixture.increase(articleId)
+            articleDislikeCountPersistencePortFixture.decrease(articleId)
+
+            // then
+            val articleDislikeCount = articleDislikeCountPersistencePortFixture.findByIdOrNull(articleId)!!
+
+            assertThat(articleDislikeCount.articleId).isEqualTo(articleId)
+            assertThat(articleDislikeCount.dislikeCount).isEqualTo(1)
+        }
+
+    }
+
+    @Nested
+    @DisplayName("findByIdOrNull : articleId 값으로 싫어요 수 조회")
+    inner class FindByIdOrNullTest {
 
         @Test
         @DisplayName("조회 실패시 null 반환 테스트")

--- a/board-system-article-like/article-like-application-output-port/src/testFixtures/kotlin/com/ttasjwi/board/system/articlelike/domain/port/fixture/ArticleDislikeCountPersistencePortFixture.kt
+++ b/board-system-article-like/article-like-application-output-port/src/testFixtures/kotlin/com/ttasjwi/board/system/articlelike/domain/port/fixture/ArticleDislikeCountPersistencePortFixture.kt
@@ -1,15 +1,26 @@
 package com.ttasjwi.board.system.articlelike.domain.port.fixture
 
 import com.ttasjwi.board.system.articlelike.domain.model.ArticleDislikeCount
+import com.ttasjwi.board.system.articlelike.domain.model.fixture.articleDislikeCountFixture
 import com.ttasjwi.board.system.articlelike.domain.port.ArticleDislikeCountPersistencePort
 
 class ArticleDislikeCountPersistencePortFixture : ArticleDislikeCountPersistencePort {
 
     private val storage = mutableMapOf<Long, ArticleDislikeCount>()
 
-    override fun save(articleDislikeCount: ArticleDislikeCount): ArticleDislikeCount {
-        storage[articleDislikeCount.articleId] = articleDislikeCount
-        return articleDislikeCount
+    override fun increase(articleId: Long) {
+        if (!storage.containsKey(articleId)) {
+            storage[articleId] = articleDislikeCountFixture(articleId, 1)
+        } else {
+            val articleDislikeCount = storage[articleId]!!
+            storage[articleId] = articleDislikeCountFixture(articleId, articleDislikeCount.dislikeCount + 1)
+        }
+    }
+
+    override fun decrease(articleId: Long) {
+        // 전제 : articleId 의 articleDislikeCount 가 있어야함 (애플리케이션 로직에서 보장)
+        val articleDislikeCount = storage[articleId]!!
+        storage[articleDislikeCount.articleId] = articleDislikeCountFixture(articleId, articleDislikeCount.dislikeCount - 1)
     }
 
     override fun findByIdOrNull(articleId: Long): ArticleDislikeCount? {

--- a/board-system-article-like/article-like-application-service/src/main/kotlin/com/ttasjwi/board/system/articlelike/domain/processor/ArticleDislikeCancelProcessor.kt
+++ b/board-system-article-like/article-like-application-service/src/main/kotlin/com/ttasjwi/board/system/articlelike/domain/processor/ArticleDislikeCancelProcessor.kt
@@ -61,9 +61,6 @@ internal class ArticleDislikeCancelProcessor(
      * 게시글 싫어요 수 감소
      */
     private fun decreaseArticleDislikeCount(articleId: Long) {
-        val articleDislikeCount = articleDislikeCountPersistencePort.findByIdOrNull(articleId = articleId)
-            ?: throw IllegalStateException("게시글 싫어요 수가 저장되어 있지 않음(articleId = $articleId)") // 서버 에러
-        articleDislikeCount.decrease()
-        articleDislikeCountPersistencePort.save(articleDislikeCount)
+        articleDislikeCountPersistencePort.decrease(articleId)
     }
 }

--- a/board-system-article-like/article-like-application-service/src/main/kotlin/com/ttasjwi/board/system/articlelike/domain/processor/ArticleDislikeCreateProcessor.kt
+++ b/board-system-article-like/article-like-application-service/src/main/kotlin/com/ttasjwi/board/system/articlelike/domain/processor/ArticleDislikeCreateProcessor.kt
@@ -76,17 +76,6 @@ internal class ArticleDislikeCreateProcessor(
 
 
     private fun upsertArticleDislikeCount(articleId: Long) {
-        val articleDislikeCount = articleDislikeCountPersistencePort.findByIdOrNull(articleId = articleId)
-            ?: ArticleDislikeCount.init(articleId)
-        articleDislikeCount.increase()
-
-        // 동시성 문제가 발생할 여지가 있음.
-        // A 트랜잭션이 싫어요수를 조회
-        // B 트랜잭션이 싫어요수를 조회
-        // A 트랜잭션이 조회한 싫어요수를 기반으로 싫어요수 증가 커밋
-        // B 트랜잭션이 조회한 싫어요수를 기반으로 싫어요수 증가 커밋
-        // 이렇게 동시 요청자수가 2명일 경우 싫어요수가  2 증가해야하지만, 실제로는 1 증가할 수 있는 것이다.
-        // 동시요청자수가 100명, 1000명 늘어나게 될 경우 싫어요수의 정확도가 실제 싫어요 갯수와 많이 어긋나게 된다.
-        articleDislikeCountPersistencePort.save(articleDislikeCount)
+        articleDislikeCountPersistencePort.increase(articleId)
     }
 }

--- a/board-system-article-like/article-like-application-service/src/test/kotlin/com/ttasjwi/board/system/articlelike/domain/ArticleDislikeCancelUseCaseImplTest.kt
+++ b/board-system-article-like/article-like-application-service/src/test/kotlin/com/ttasjwi/board/system/articlelike/domain/ArticleDislikeCancelUseCaseImplTest.kt
@@ -1,6 +1,5 @@
 package com.ttasjwi.board.system.articlelike.domain
 
-import com.ttasjwi.board.system.articlelike.domain.model.fixture.articleDislikeCountFixture
 import com.ttasjwi.board.system.articlelike.domain.model.fixture.articleDislikeFixture
 import com.ttasjwi.board.system.articlelike.domain.model.fixture.articleFixture
 import com.ttasjwi.board.system.articlelike.domain.port.fixture.ArticleDislikeCountPersistencePortFixture
@@ -63,12 +62,7 @@ class ArticleDislikeCancelUseCaseImplTest {
             )
         )
 
-        articleDislikeCountPersistencePortFixture.save(
-            articleDislikeCountFixture(
-                articleId = article.articleId,
-                dislikeCount = 13L
-            )
-        )
+        articleDislikeCountPersistencePortFixture.increase(article.articleId)
 
         // when
         val response = articleDislikeCancelUseCase.cancelDislike(article.articleId)

--- a/board-system-article-like/article-like-application-service/src/test/kotlin/com/ttasjwi/board/system/articlelike/domain/ArticleDislikeCountReadUseCaseImplTest.kt
+++ b/board-system-article-like/article-like-application-service/src/test/kotlin/com/ttasjwi/board/system/articlelike/domain/ArticleDislikeCountReadUseCaseImplTest.kt
@@ -1,7 +1,6 @@
 package com.ttasjwi.board.system.articlelike.domain
 
 import com.ttasjwi.board.system.articlelike.domain.exception.ArticleNotFoundException
-import com.ttasjwi.board.system.articlelike.domain.model.fixture.articleDislikeCountFixture
 import com.ttasjwi.board.system.articlelike.domain.model.fixture.articleFixture
 import com.ttasjwi.board.system.articlelike.domain.port.fixture.ArticleDislikeCountPersistencePortFixture
 import com.ttasjwi.board.system.articlelike.domain.port.fixture.ArticlePersistencePortFixture
@@ -36,19 +35,14 @@ class ArticleDislikeCountReadUseCaseImplTest {
                 articleId = 134151235L,
             )
         )
-        val articleDislikeCount = articleDislikeCountPersistencePortFixture.save(
-            articleDislikeCountFixture(
-                articleId = article.articleId,
-                dislikeCount = 31412L,
-            )
-        )
+        articleDislikeCountPersistencePortFixture.increase(article.articleId)
 
         // when
         val response = articleDislikeCountReadUseCase.readDislikeCount(article.articleId)
 
         // then
         assertThat(response.articleId).isEqualTo(article.articleId.toString())
-        assertThat(response.dislikeCount).isEqualTo(articleDislikeCount.dislikeCount)
+        assertThat(response.dislikeCount).isEqualTo(1L)
     }
 
     @Test

--- a/board-system-article-like/article-like-application-service/src/test/kotlin/com/ttasjwi/board/system/articlelike/domain/ArticleLikeCancelUseCaseImplTest.kt
+++ b/board-system-article-like/article-like-application-service/src/test/kotlin/com/ttasjwi/board/system/articlelike/domain/ArticleLikeCancelUseCaseImplTest.kt
@@ -1,7 +1,6 @@
 package com.ttasjwi.board.system.articlelike.domain
 
 import com.ttasjwi.board.system.articlelike.domain.model.fixture.articleFixture
-import com.ttasjwi.board.system.articlelike.domain.model.fixture.articleLikeCountFixture
 import com.ttasjwi.board.system.articlelike.domain.model.fixture.articleLikeFixture
 import com.ttasjwi.board.system.articlelike.domain.port.fixture.ArticleLikeCountPersistencePortFixture
 import com.ttasjwi.board.system.articlelike.domain.port.fixture.ArticleLikePersistencePortFixture

--- a/board-system-article-like/article-like-application-service/src/test/kotlin/com/ttasjwi/board/system/articlelike/domain/ArticleLikeCountReadUseCaseImplTest.kt
+++ b/board-system-article-like/article-like-application-service/src/test/kotlin/com/ttasjwi/board/system/articlelike/domain/ArticleLikeCountReadUseCaseImplTest.kt
@@ -2,7 +2,6 @@ package com.ttasjwi.board.system.articlelike.domain
 
 import com.ttasjwi.board.system.articlelike.domain.exception.ArticleNotFoundException
 import com.ttasjwi.board.system.articlelike.domain.model.fixture.articleFixture
-import com.ttasjwi.board.system.articlelike.domain.model.fixture.articleLikeCountFixture
 import com.ttasjwi.board.system.articlelike.domain.port.fixture.ArticleLikeCountPersistencePortFixture
 import com.ttasjwi.board.system.articlelike.domain.port.fixture.ArticlePersistencePortFixture
 import com.ttasjwi.board.system.articlelike.domain.test.support.TestContainer

--- a/board-system-article-like/article-like-application-service/src/test/kotlin/com/ttasjwi/board/system/articlelike/domain/processor/ArticleDislikeCreateProcessorTest.kt
+++ b/board-system-article-like/article-like-application-service/src/test/kotlin/com/ttasjwi/board/system/articlelike/domain/processor/ArticleDislikeCreateProcessorTest.kt
@@ -5,7 +5,6 @@ import com.ttasjwi.board.system.articlelike.domain.exception.ArticleAlreadyDisli
 import com.ttasjwi.board.system.articlelike.domain.exception.ArticleDislikeNotAllowedException
 import com.ttasjwi.board.system.articlelike.domain.exception.ArticleNotFoundException
 import com.ttasjwi.board.system.articlelike.domain.model.fixture.articleCategoryFixture
-import com.ttasjwi.board.system.articlelike.domain.model.fixture.articleDislikeCountFixture
 import com.ttasjwi.board.system.articlelike.domain.model.fixture.articleDislikeFixture
 import com.ttasjwi.board.system.articlelike.domain.model.fixture.articleFixture
 import com.ttasjwi.board.system.articlelike.domain.port.fixture.ArticleCategoryPersistencePortFixture
@@ -115,12 +114,7 @@ class ArticleDislikeCreateProcessorTest {
             )
         )
 
-        articleDislikeCountPersistencePortFixture.save(
-            articleDislikeCount = articleDislikeCountFixture(
-                articleId = article.articleId,
-                dislikeCount = 1L
-            )
-        )
+        articleDislikeCountPersistencePortFixture.increase(article.articleId)
 
         val command = ArticleDislikeCreateCommand(
             articleId = article.articleId,
@@ -258,12 +252,7 @@ class ArticleDislikeCreateProcessorTest {
             )
         )
 
-        articleDislikeCountPersistencePortFixture.save(
-            articleDislikeCount = articleDislikeCountFixture(
-                articleId = article.articleId,
-                dislikeCount = 1L
-            )
-        )
+        articleDislikeCountPersistencePortFixture.increase(article.articleId)
 
         val command = ArticleDislikeCreateCommand(
             articleId = article.articleId,

--- a/board-system-article-like/article-like-database-adapter/src/main/kotlin/com/ttasjwi/board/system/articlelike/infra/persistence/ArticleDislikeCountPersistenceAdapter.kt
+++ b/board-system-article-like/article-like-database-adapter/src/main/kotlin/com/ttasjwi/board/system/articlelike/infra/persistence/ArticleDislikeCountPersistenceAdapter.kt
@@ -2,7 +2,6 @@ package com.ttasjwi.board.system.articlelike.infra.persistence
 
 import com.ttasjwi.board.system.articlelike.domain.model.ArticleDislikeCount
 import com.ttasjwi.board.system.articlelike.domain.port.ArticleDislikeCountPersistencePort
-import com.ttasjwi.board.system.articlelike.infra.persistence.jpa.JpaArticleDislikeCount
 import com.ttasjwi.board.system.articlelike.infra.persistence.jpa.JpaArticleDislikeCountRepository
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
@@ -12,10 +11,12 @@ class ArticleDislikeCountPersistenceAdapter(
     private val jpaArticleDislikeCountRepository: JpaArticleDislikeCountRepository
 ) : ArticleDislikeCountPersistencePort {
 
-    override fun save(articleDislikeCount: ArticleDislikeCount): ArticleDislikeCount {
-        val jpaEntity = JpaArticleDislikeCount.from(articleDislikeCount)
-        jpaArticleDislikeCountRepository.save(jpaEntity)
-        return articleDislikeCount
+    override fun increase(articleId: Long) {
+        jpaArticleDislikeCountRepository.increase(articleId)
+    }
+
+    override fun decrease(articleId: Long) {
+        jpaArticleDislikeCountRepository.decrease(articleId)
     }
 
     override fun findByIdOrNull(articleId: Long): ArticleDislikeCount? {

--- a/board-system-article-like/article-like-database-adapter/src/main/kotlin/com/ttasjwi/board/system/articlelike/infra/persistence/jpa/JpaArticleDislikeCountRepository.kt
+++ b/board-system-article-like/article-like-database-adapter/src/main/kotlin/com/ttasjwi/board/system/articlelike/infra/persistence/jpa/JpaArticleDislikeCountRepository.kt
@@ -1,7 +1,30 @@
 package com.ttasjwi.board.system.articlelike.infra.persistence.jpa
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 
 @Repository("articleLikeJpaArticleDislikeCountRepository")
-interface JpaArticleDislikeCountRepository : JpaRepository<JpaArticleDislikeCount, Long>
+interface JpaArticleDislikeCountRepository : JpaRepository<JpaArticleDislikeCount, Long> {
+
+    @Modifying
+    @Query(
+        """
+            INSERT INTO article_dislike_counts (article_id, dislike_count)
+            VALUES (:articleId, 1)
+            ON DUPLICATE KEY UPDATE dislike_count  = dislike_count + 1
+        """, nativeQuery = true
+    )
+    fun increase(articleId: Long)
+
+    @Modifying
+    @Query(
+        """
+            UPDATE article_dislike_counts
+            SET dislike_count = dislike_count - 1
+            WHERE article_id = :articleId
+        """, nativeQuery = true
+    )
+    fun decrease(articleId: Long)
+}

--- a/board-system-article-like/article-like-database-adapter/src/test/kotlin/com/ttasjwi/board/system/articlelike/infra/persistence/ArticleDislikeCountPersistenceAdapterTest.kt
+++ b/board-system-article-like/article-like-database-adapter/src/test/kotlin/com/ttasjwi/board/system/articlelike/infra/persistence/ArticleDislikeCountPersistenceAdapterTest.kt
@@ -1,6 +1,5 @@
 package com.ttasjwi.board.system.articlelike.infra.persistence
 
-import com.ttasjwi.board.system.articlelike.domain.model.fixture.articleDislikeCountFixture
 import com.ttasjwi.board.system.articlelike.infra.test.ArticleLikeDataBaseIntegrationTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
@@ -11,28 +10,72 @@ import org.junit.jupiter.api.Test
 class ArticleDislikeCountPersistenceAdapterTest : ArticleLikeDataBaseIntegrationTest() {
 
     @Nested
-    @DisplayName("findByIdOrNull : articleId 값으로 좋아요 수 조회")
-    inner class FindByIdOrNullTest {
+    @DisplayName("increase: 싫어요 수 증가")
+    inner class IncreaseTest {
 
         @Test
-        @DisplayName("성공 테스트")
+        @DisplayName("최초 싫어요 테스트")
         fun test1() {
             // given
-            val articleId = 13L
-            val articleDislikeCount = articleDislikeCountFixture(
-                articleId = articleId,
-                dislikeCount = 1345L
-            )
-            articleLikeArticleDislikeCountPersistenceAdapter.save(articleDislikeCount)
+            val articleId = 5857L
 
             // when
-            val findArticleDislikeCount = articleLikeArticleDislikeCountPersistenceAdapter.findByIdOrNull(articleId)!!
+            articleLikeArticleDislikeCountPersistenceAdapter.increase(articleId)
+
 
             // then
-            assertThat(findArticleDislikeCount.articleId).isEqualTo(articleDislikeCount.articleId)
-            assertThat(findArticleDislikeCount.dislikeCount).isEqualTo(articleDislikeCount.dislikeCount)
+            val articleDislikeCount = articleLikeArticleDislikeCountPersistenceAdapter.findByIdOrNull(articleId)!!
+
+            assertThat(articleDislikeCount.articleId).isEqualTo(articleId)
+            assertThat(articleDislikeCount.dislikeCount).isEqualTo(1)
         }
 
+        @Test
+        @DisplayName("첫번째 이후 싫어요 테스트")
+        fun test2() {
+            // given
+            val articleId = 5857L
+
+            // when
+            articleLikeArticleDislikeCountPersistenceAdapter.increase(articleId)
+            articleLikeArticleDislikeCountPersistenceAdapter.increase(articleId)
+
+            // then
+            val articleDislikeCount = articleLikeArticleDislikeCountPersistenceAdapter.findByIdOrNull(articleId)!!
+
+            assertThat(articleDislikeCount.articleId).isEqualTo(articleId)
+            assertThat(articleDislikeCount.dislikeCount).isEqualTo(2)
+        }
+    }
+
+
+    @Nested
+    @DisplayName("decrease: 싫어요 수 감소")
+    inner class DecreaseTest {
+
+        @Test
+        @DisplayName("두번 싫어요 수 증가 후, 싫어요수 감소 테스트")
+        fun test() {
+            // given
+            val articleId = 5857L
+
+            // when
+            articleLikeArticleDislikeCountPersistenceAdapter.increase(articleId)
+            articleLikeArticleDislikeCountPersistenceAdapter.increase(articleId)
+            articleLikeArticleDislikeCountPersistenceAdapter.decrease(articleId)
+
+            // then
+            val articleDislikeCount = articleLikeArticleDislikeCountPersistenceAdapter.findByIdOrNull(articleId)!!
+
+            assertThat(articleDislikeCount.articleId).isEqualTo(articleId)
+            assertThat(articleDislikeCount.dislikeCount).isEqualTo(1)
+        }
+
+    }
+
+    @Nested
+    @DisplayName("findByIdOrNull : articleId 값으로 싫어요 수 조회")
+    inner class FindByIdOrNullTest {
 
         @Test
         @DisplayName("조회 실패시 null 반환 테스트")

--- a/board-system-article-like/article-like-domain/src/main/kotlin/com/ttasjwi/board/system/articlelike/domain/model/ArticleDislikeCount.kt
+++ b/board-system-article-like/article-like-domain/src/main/kotlin/com/ttasjwi/board/system/articlelike/domain/model/ArticleDislikeCount.kt
@@ -2,18 +2,10 @@ package com.ttasjwi.board.system.articlelike.domain.model
 
 class ArticleDislikeCount(
     val articleId: Long,
-    dislikeCount: Long
+    val dislikeCount: Long
 ) {
-    var dislikeCount: Long = dislikeCount
-        private set
 
     companion object {
-        fun init(articleId: Long): ArticleDislikeCount {
-            return ArticleDislikeCount(
-                articleId = articleId,
-                dislikeCount = 0L
-            )
-        }
 
         fun restore(articleId: Long, dislikeCount: Long): ArticleDislikeCount {
             return ArticleDislikeCount(
@@ -21,14 +13,6 @@ class ArticleDislikeCount(
                 dislikeCount = dislikeCount
             )
         }
-    }
-
-    fun increase() {
-        this.dislikeCount += 1
-    }
-
-    fun decrease() {
-        this.dislikeCount -= 1
     }
 
     override fun toString(): String {

--- a/board-system-article-like/article-like-domain/src/test/kotlin/com/ttasjwi/board/system/articlelike/domain/model/ArticleDislikeCountTest.kt
+++ b/board-system-article-like/article-like-domain/src/test/kotlin/com/ttasjwi/board/system/articlelike/domain/model/ArticleDislikeCountTest.kt
@@ -9,21 +9,6 @@ import org.junit.jupiter.api.Test
 class ArticleDislikeCountTest {
 
     @Test
-    @DisplayName("init: 초기화")
-    fun initTest() {
-        // given
-        val articleId = 12243414L
-
-        // when
-        val articleDislikeCount = ArticleDislikeCount.init(articleId)
-
-        // then
-        assertThat(articleDislikeCount.articleId).isEqualTo(articleId)
-        assertThat(articleDislikeCount.dislikeCount).isEqualTo(0L)
-    }
-
-
-    @Test
     @DisplayName("restore: 값으로 부터 복원")
     fun restoreTest() {
         // given
@@ -40,44 +25,6 @@ class ArticleDislikeCountTest {
         assertThat(articleDislikeCount.articleId).isEqualTo(articleId)
         assertThat(articleDislikeCount.dislikeCount).isEqualTo(dislikeCount)
     }
-
-
-    @Test
-    @DisplayName("increase : 좋아요 수 증가")
-    fun increaseTest() {
-        // given
-        val articleId = 12243414L
-        val dislikeCount = 1314L
-        val articleDislikeCount = articleDislikeCountFixture(
-            articleId = articleId,
-            dislikeCount = dislikeCount,
-        )
-        // when
-        articleDislikeCount.increase()
-
-        // then
-        assertThat(articleDislikeCount.dislikeCount).isEqualTo(dislikeCount + 1)
-    }
-
-
-    @Test
-    @DisplayName("decrease(): 좋아요 수 감소")
-    fun decreaseTest() {
-        // given
-        val articleId = 12243414L
-        val dislikeCount = 1314L
-        val articleDislikeCount = articleDislikeCountFixture(
-            articleId = articleId,
-            dislikeCount = dislikeCount,
-        )
-
-        // when
-        articleDislikeCount.decrease()
-
-        // then
-        assertThat(articleDislikeCount.dislikeCount).isEqualTo(dislikeCount - 1)
-    }
-
 
     @Test
     @DisplayName("toString(): 디버깅용 문자열 반환")


### PR DESCRIPTION
# JIRA 티켓
- [BRD-157]

---

# 개요
- 게시글 싫어요수 역시 좋아요수와 마찬가지의 이유로 동시성 문제가 발생한다.
- 동일한 방식으로 동시성 문제를 해결한다.


[BRD-157]: https://ttasjwi.atlassian.net/browse/BRD-157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ