### PR TITLE
Feature: (BRD-154) 게시글 댓글수 비정규화

### DIFF
--- a/board-system-app/build.gradle.kts
+++ b/board-system-app/build.gradle.kts
@@ -18,6 +18,8 @@ dependencies {
     implementation(project(":board-system-user:user-password-adapter"))
     implementation(project(":board-system-user:user-email-format-validate-adapter"))
     implementation(project(":board-system-user:user-oauth2-client-adapter"))
+    testImplementation(testFixtures(project(":board-system-user:user-domain")))
+    testImplementation(project(":board-system-user:user-application-output-port"))
 
     // board
     implementation(project(":board-system-board:board-web-adapter"))
@@ -34,6 +36,9 @@ dependencies {
     // article-comment
     implementation(project(":board-system-article-comment:article-comment-web-adapter"))
     implementation(project(":board-system-article-comment:article-comment-application-service"))
+    testImplementation(project(":board-system-article-comment:article-comment-domain"))
+    testImplementation(project(":board-system-article-comment:article-comment-application-input-port"))
+    testImplementation(project(":board-system-article-comment:article-comment-application-output-port"))
 
     // article-like
     implementation(project(":board-system-article-like:article-like-web-adapter"))

--- a/board-system-app/src/test/kotlin/com/ttasjwi/board/system/app/articlecomment/ArticleCommentCountIntegrationTest.kt
+++ b/board-system-app/src/test/kotlin/com/ttasjwi/board/system/app/articlecomment/ArticleCommentCountIntegrationTest.kt
@@ -1,0 +1,172 @@
+package com.ttasjwi.board.system.app.articlecomment
+
+import com.ttasjwi.board.system.article.domain.model.fixture.articleFixture
+import com.ttasjwi.board.system.article.domain.port.ArticlePersistencePort
+import com.ttasjwi.board.system.articlecomment.domain.ArticleCommentCreateRequest
+import com.ttasjwi.board.system.articlecomment.domain.ArticleCommentCreateUseCase
+import com.ttasjwi.board.system.articlecomment.domain.port.ArticleCommentCountPersistencePort
+import com.ttasjwi.board.system.board.domain.model.fixture.articleCategoryFixture
+import com.ttasjwi.board.system.board.domain.port.ArticleCategoryPersistencePort
+import com.ttasjwi.board.system.common.auth.Role
+import com.ttasjwi.board.system.common.auth.fixture.authUserFixture
+import com.ttasjwi.board.system.common.infra.websupport.auth.security.AuthUserAuthentication
+import com.ttasjwi.board.system.common.time.fixture.appDateTimeFixture
+import com.ttasjwi.board.system.user.domain.model.fixture.userFixture
+import com.ttasjwi.board.system.user.domain.port.UserPersistencePort
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.security.core.context.SecurityContextHolder
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+
+@Disabled // 수동테스트용(테스트 해보고 싶을 경우 주석처리)
+@SpringBootTest
+@DisplayName("[app] 게시글 댓글 수 통합테스트")
+class ArticleCommentCountIntegrationTest {
+
+
+    @Autowired
+    private lateinit var articlePersistencePort: ArticlePersistencePort
+
+    @Autowired
+    private lateinit var articleCategoryPersistencePort: ArticleCategoryPersistencePort
+
+    @Autowired
+    private lateinit var articleCommentCreateUseCase: ArticleCommentCreateUseCase
+
+    @Autowired
+    private lateinit var articleCommentCountPersistencePort: ArticleCommentCountPersistencePort
+
+    @Autowired
+    private lateinit var userPersistencePort: UserPersistencePort
+
+    @Test
+    @DisplayName("댓글 수 동시성 테스트 : 동시 사용자가 많을 때, 댓글 수")
+    fun commentCountConcurrencyTest() {
+        val threadCount = 100
+        val userCount = 3000
+        val boardArticleArticleCategoryId = 4314135L
+
+        val executorService = Executors.newFixedThreadPool(threadCount)
+
+        createComments(
+            executorService = executorService,
+            userCount = userCount,
+            boardId = boardArticleArticleCategoryId,
+            articleId = boardArticleArticleCategoryId,
+            articleCategoryId = boardArticleArticleCategoryId
+        )
+        executorService.shutdown()
+    }
+
+
+    private fun createComments(
+        executorService: ExecutorService,
+        userCount: Int,
+        boardId: Long,
+        articleId: Long,
+        articleCategoryId: Long
+    ) {
+        prepareArticleCategory(boardId, articleCategoryId)
+        prepareArticle(boardId, articleCategoryId, articleId)
+        val latch = CountDownLatch(userCount)
+        println("--------------------------------------------------------------------------")
+        println("start create Comments : articleId = $articleId")
+        val start = System.nanoTime()
+        for (i in 1..userCount) {
+            val userId = i.toLong()
+
+            executorService.execute {
+                try {
+                    createComment(articleId, userId)
+                } catch (e: Exception) {
+                    println("Error for userId=$userId: ${e.message}")
+                } finally {
+                    latch.countDown()
+                }
+            }
+
+        }
+        latch.await()
+        val end = System.nanoTime()
+        println("time = ${(end - start) / 100_0000} ms")
+
+        val commentCount = articleCommentCountPersistencePort.findByIdOrNull(articleId)!!.commentCount
+
+        println("end create Comments : articleId = $articleId")
+        println("count = $commentCount")
+        println("--------------------------------------------------------------------------")
+
+        assertThat(commentCount).isEqualTo(userCount.toLong())
+    }
+
+    private fun prepareArticle(boardId: Long, articleCategoryId: Long, articleId: Long) {
+        articlePersistencePort.save(
+            articleFixture(
+                articleId = articleId,
+                title = "article-title-$articleId",
+                content = "article-content-$articleId",
+                boardId = boardId,
+                articleCategoryId = articleCategoryId,
+                writerId = 1L
+            )
+        )
+    }
+
+    private fun prepareArticleCategory(boardId: Long, articleCategoryId: Long) {
+        articleCategoryPersistencePort.save(
+            articleCategoryFixture(
+                articleCategoryId = articleCategoryId,
+                name = "테스트",
+                slug = "test",
+                boardId = boardId,
+                allowLike = true,
+                allowDislike = true
+            )
+        )
+    }
+
+    private fun createComment(articleId: Long, userId: Long) {
+        setAuthUser(userId)
+        prepareCommentWriter(userId)
+        articleCommentCreateUseCase.create(
+            ArticleCommentCreateRequest(
+                content = "comment-by-$userId",
+                articleId = articleId,
+                parentCommentId = null,
+            )
+        )
+    }
+
+    private fun prepareCommentWriter(userId: Long) {
+        userPersistencePort.save(
+            userFixture(
+                userId = userId,
+                email = "user$userId@gmail.com",
+                password = "1234567890",
+                username = "user_$userId",
+                nickname = "USER$userId",
+                role = Role.USER,
+                registeredAt = appDateTimeFixture(minute = 13),
+            )
+        )
+    }
+
+    private fun setAuthUser(userId: Long) {
+        val authentication = AuthUserAuthentication.from(
+            authUser = authUserFixture(
+                userId = userId,
+                role = Role.USER
+            )
+        )
+        val securityContext = SecurityContextHolder.getContextHolderStrategy().createEmptyContext()
+        securityContext.authentication = authentication
+        SecurityContextHolder.getContextHolderStrategy().context = securityContext
+    }
+
+}

--- a/board-system-app/src/test/kotlin/com/ttasjwi/board/system/app/articlelike/ArticleLikeCountIntegrationTest.kt
+++ b/board-system-app/src/test/kotlin/com/ttasjwi/board/system/app/articlelike/ArticleLikeCountIntegrationTest.kt
@@ -1,8 +1,10 @@
-package com.ttasjwi.board.system.app.articlelike.api
+package com.ttasjwi.board.system.app.articlelike
 
 import com.ttasjwi.board.system.article.domain.model.fixture.articleFixture
 import com.ttasjwi.board.system.article.domain.port.ArticlePersistencePort
-import com.ttasjwi.board.system.articlelike.domain.*
+import com.ttasjwi.board.system.articlelike.domain.ArticleLikeCancelUseCase
+import com.ttasjwi.board.system.articlelike.domain.ArticleLikeCountReadUseCase
+import com.ttasjwi.board.system.articlelike.domain.ArticleLikeCreateUseCase
 import com.ttasjwi.board.system.board.domain.model.fixture.articleCategoryFixture
 import com.ttasjwi.board.system.board.domain.port.ArticleCategoryPersistencePort
 import com.ttasjwi.board.system.common.auth.Role
@@ -21,8 +23,8 @@ import java.util.concurrent.Executors
 
 @Disabled // 수동테스트용(테스트 해보고 싶을 경우 주석처리)
 @SpringBootTest
-@DisplayName("[app] 게시글 싫어요 수 통합테스트")
-class ArticleDislikeCountIntegrationTest {
+@DisplayName("[app] 게시글 좋아요 수 통합테스트")
+class ArticleLikeCountIntegrationTest {
 
     @Autowired
     private lateinit var articlePersistencePort: ArticlePersistencePort
@@ -31,31 +33,31 @@ class ArticleDislikeCountIntegrationTest {
     private lateinit var articleCategoryPersistencePort: ArticleCategoryPersistencePort
 
     @Autowired
-    private lateinit var articleDislikeCreateUseCase: ArticleDislikeCreateUseCase
+    private lateinit var articleLikeCreateUseCase: ArticleLikeCreateUseCase
 
     @Autowired
-    private lateinit var articleDislikeCancelUseCase: ArticleDislikeCancelUseCase
+    private lateinit var articleLikeCancelUseCase: ArticleLikeCancelUseCase
 
     @Autowired
-    private lateinit var articleDislikeCountReadUseCase: ArticleDislikeCountReadUseCase
+    private lateinit var articleLikeCountReadUseCase: ArticleLikeCountReadUseCase
 
     @Test
-    @DisplayName("싫어요 수 동시성 테스트 : 동시 사용자가 많을 때, 싫어요 수")
-    fun dislikeCountConcurrencyTest() {
+    @DisplayName("좋아요 수 동시성 테스트 : 동시 사용자가 많을 때, 좋아요 수")
+    fun likeCountConcurrencyTest() {
         val threadCount = 100
         val userCount = 3000
-        val boardArticleArticleCategoryId = 171531L
+        val boardArticleArticleCategoryId = 13413413413L
 
         val executorService = Executors.newFixedThreadPool(threadCount)
 
-        createDislikes(
+        createLikes(
             executorService = executorService,
             userCount = userCount,
             boardId = boardArticleArticleCategoryId,
             articleId = boardArticleArticleCategoryId,
             articleCategoryId = boardArticleArticleCategoryId
         )
-        cancelDislikes(
+        cancelLikes(
             executorService = executorService,
             userCount = userCount,
             articleId = boardArticleArticleCategoryId,
@@ -63,7 +65,7 @@ class ArticleDislikeCountIntegrationTest {
         executorService.shutdown()
     }
 
-    private fun createDislikes(
+    private fun createLikes(
         executorService: ExecutorService,
         userCount: Int,
         boardId: Long,
@@ -75,14 +77,14 @@ class ArticleDislikeCountIntegrationTest {
 
         val latch = CountDownLatch(userCount)
         println("--------------------------------------------------------------------------")
-        println("start create Dislikes : articleId = $articleId")
+        println("start create Likes : articleId = $articleId")
         val start = System.nanoTime()
         for (i in 1..userCount) {
             val userId = i.toLong()
 
             executorService.execute {
                 try {
-                    dislike(articleId, userId)
+                    like(articleId, userId)
                 } catch (e: Exception) {
                     println("Error for userId=$userId: ${e.message}")
                 } finally {
@@ -95,32 +97,32 @@ class ArticleDislikeCountIntegrationTest {
         val end = System.nanoTime()
         println("time = ${(end - start) / 100_0000} ms")
 
-        val response = articleDislikeCountReadUseCase.readDislikeCount(
+        val response = articleLikeCountReadUseCase.readLikeCount(
             articleId = articleId,
         )
 
-        println("end create Dislikes : articleId = $articleId")
-        println("count = ${response.dislikeCount}")
+        println("end create Likes : articleId = $articleId")
+        println("count = ${response.likeCount}")
         println("--------------------------------------------------------------------------")
 
-        assertThat(response.dislikeCount).isEqualTo(userCount.toLong())
+        assertThat(response.likeCount).isEqualTo(userCount.toLong())
     }
 
-    private fun cancelDislikes(
+    private fun cancelLikes(
         executorService: ExecutorService,
         userCount: Int,
         articleId: Long,
     ) {
         val latch = CountDownLatch(userCount)
         println("--------------------------------------------------------------------------")
-        println("start cancel Dislikes : articleId = $articleId")
+        println("start cancel Likes : articleId = $articleId")
         val start = System.nanoTime()
         for (i in 1..userCount) {
             val userId = i.toLong()
 
             executorService.execute {
                 try {
-                    cancelDislike(articleId, userId)
+                    cancelLike(articleId, userId)
                 } catch (e: Exception) {
                     println("Error for userId=$userId: ${e.message}")
                 } finally {
@@ -133,26 +135,26 @@ class ArticleDislikeCountIntegrationTest {
         val end = System.nanoTime()
         println("time = ${(end - start) / 100_0000} ms")
 
-        val response = articleDislikeCountReadUseCase.readDislikeCount(
+        val response = articleLikeCountReadUseCase.readLikeCount(
             articleId = articleId,
         )
 
-        println("end cancel Dislikes : articleId = $articleId")
-        println("count = ${response.dislikeCount}")
+        println("end cancel Likes : articleId = $articleId")
+        println("count = ${response.likeCount}")
         println("--------------------------------------------------------------------------")
 
-        assertThat(response.dislikeCount).isEqualTo(0)
+        assertThat(response.likeCount).isEqualTo(0)
     }
 
 
-    private fun dislike(articleId: Long, userId: Long) {
+    private fun like(articleId: Long, userId: Long) {
         setAuthUser(userId)
-        articleDislikeCreateUseCase.dislike(articleId)
+        articleLikeCreateUseCase.like(articleId)
     }
 
-    private fun cancelDislike(articleId: Long, userId: Long) {
+    private fun cancelLike(articleId: Long, userId: Long) {
         setAuthUser(userId)
-        articleDislikeCancelUseCase.cancelDislike(articleId)
+        articleLikeCancelUseCase.cancelLike(articleId)
     }
 
     private fun setAuthUser(userId: Long) {

--- a/board-system-article-comment/article-comment-application-output-port/src/main/kotlin/com/ttasjwi/board/system/articlecomment/domain/port/ArticleCommentCountPersistencePort.kt
+++ b/board-system-article-comment/article-comment-application-output-port/src/main/kotlin/com/ttasjwi/board/system/articlecomment/domain/port/ArticleCommentCountPersistencePort.kt
@@ -1,0 +1,10 @@
+package com.ttasjwi.board.system.articlecomment.domain.port
+
+import com.ttasjwi.board.system.articlecomment.domain.model.ArticleCommentCount
+
+interface ArticleCommentCountPersistencePort {
+
+    fun increase(articleId: Long)
+    fun decrease(articleId: Long)
+    fun findByIdOrNull(articleId: Long): ArticleCommentCount?
+}

--- a/board-system-article-comment/article-comment-application-output-port/src/test/kotlin/com/ttasjwi/board/system/articlecomment/domain/port/fixture/ArticleCommentCountPersistencePortFixtureTest.kt
+++ b/board-system-article-comment/article-comment-application-output-port/src/test/kotlin/com/ttasjwi/board/system/articlecomment/domain/port/fixture/ArticleCommentCountPersistencePortFixtureTest.kt
@@ -1,0 +1,102 @@
+package com.ttasjwi.board.system.articlecomment.domain.port.fixture
+
+import com.ttasjwi.board.system.articlecomment.domain.port.ArticleCommentCountPersistencePort
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("[article-comment-application-output-port] ArticleCommentCountPersistencePortFixture 테스트")
+class ArticleCommentCountPersistencePortFixtureTest {
+
+    private lateinit var articleCommentCountPersistencePortFixture: ArticleCommentCountPersistencePort
+
+    @BeforeEach
+    fun setup() {
+        articleCommentCountPersistencePortFixture = ArticleCommentCountPersistencePortFixture()
+    }
+
+    @Nested
+    @DisplayName("increase: 댓글 수 증가")
+    inner class IncreaseTest {
+
+        @Test
+        @DisplayName("최초 댓글수 증가 테스트")
+        fun test1() {
+            // given
+            val articleId = 5857L
+
+            // when
+            articleCommentCountPersistencePortFixture.increase(articleId)
+
+
+            // then
+            val articleCommentCount = articleCommentCountPersistencePortFixture.findByIdOrNull(articleId)!!
+
+            assertThat(articleCommentCount.articleId).isEqualTo(articleId)
+            assertThat(articleCommentCount.commentCount).isEqualTo(1)
+        }
+
+        @Test
+        @DisplayName("첫번째 이후 댓글수 증가 테스트")
+        fun test2() {
+            // given
+            val articleId = 5857L
+
+            // when
+            articleCommentCountPersistencePortFixture.increase(articleId)
+            articleCommentCountPersistencePortFixture.increase(articleId)
+
+            // then
+            val articleCommentCount = articleCommentCountPersistencePortFixture.findByIdOrNull(articleId)!!
+
+            assertThat(articleCommentCount.articleId).isEqualTo(articleId)
+            assertThat(articleCommentCount.commentCount).isEqualTo(2)
+        }
+    }
+
+
+    @Nested
+    @DisplayName("decrease: 댓글 수 감소")
+    inner class DecreaseTest {
+
+        @Test
+        @DisplayName("두번 댓글 수 증가 후, 댓글수 감소 테스트")
+        fun test() {
+            // given
+            val articleId = 5857L
+
+            // when
+            articleCommentCountPersistencePortFixture.increase(articleId)
+            articleCommentCountPersistencePortFixture.increase(articleId)
+            articleCommentCountPersistencePortFixture.decrease(articleId)
+
+            // then
+            val articleCommentCount = articleCommentCountPersistencePortFixture.findByIdOrNull(articleId)!!
+
+            assertThat(articleCommentCount.articleId).isEqualTo(articleId)
+            assertThat(articleCommentCount.commentCount).isEqualTo(1)
+        }
+
+    }
+
+
+    @Nested
+    @DisplayName("findByIdOrNull : articleId 값으로 댓글 수 조회")
+    inner class FindByIdOrNullTest {
+
+        @Test
+        @DisplayName("조회 실패시 null 반환 테스트")
+        fun test2() {
+            // given
+            val articleId = 15555L
+
+            // when
+            // then
+            val findArticleCommentCount = articleCommentCountPersistencePortFixture.findByIdOrNull(articleId)
+
+            assertThat(findArticleCommentCount).isNull()
+        }
+    }
+}

--- a/board-system-article-comment/article-comment-application-output-port/src/testFixtures/kotlin/com/ttasjwi/board/system/articlecomment/domain/port/fixture/ArticleCommentCountPersistencePortFixture.kt
+++ b/board-system-article-comment/article-comment-application-output-port/src/testFixtures/kotlin/com/ttasjwi/board/system/articlecomment/domain/port/fixture/ArticleCommentCountPersistencePortFixture.kt
@@ -1,0 +1,29 @@
+package com.ttasjwi.board.system.articlecomment.domain.port.fixture
+
+import com.ttasjwi.board.system.articlecomment.domain.model.ArticleCommentCount
+import com.ttasjwi.board.system.articlecomment.domain.model.fixture.articleCommentCountFixture
+import com.ttasjwi.board.system.articlecomment.domain.port.ArticleCommentCountPersistencePort
+
+class ArticleCommentCountPersistencePortFixture : ArticleCommentCountPersistencePort {
+
+    private val storage = mutableMapOf<Long, ArticleCommentCount>()
+
+    override fun increase(articleId: Long) {
+        if (!storage.containsKey(articleId)) {
+            storage[articleId] = articleCommentCountFixture(articleId = articleId, commentCount = 1)
+        } else{
+            val articleCommentCount = storage[articleId]!!
+            storage[articleId] = articleCommentCountFixture(articleId = articleId, commentCount = articleCommentCount.commentCount + 1)
+        }
+    }
+
+    override fun decrease(articleId: Long) {
+        // 전제 : articleId 의 articleCommentCount 가 있어야함 (애플리케이션 로직에서 보장)
+        val articleCommentCount = storage[articleId]!!
+        storage[articleId] = articleCommentCountFixture(articleId = articleId, commentCount = articleCommentCount.commentCount - 1)
+    }
+
+    override fun findByIdOrNull(articleId: Long): ArticleCommentCount? {
+        return storage[articleId]
+    }
+}

--- a/board-system-article-comment/article-comment-application-service/src/main/kotlin/com/ttasjwi/board/system/articlecomment/domain/processor/ArticleCommentCreateProcessor.kt
+++ b/board-system-article-comment/article-comment-application-service/src/main/kotlin/com/ttasjwi/board/system/articlecomment/domain/processor/ArticleCommentCreateProcessor.kt
@@ -3,6 +3,7 @@ package com.ttasjwi.board.system.articlecomment.domain.processor
 import com.ttasjwi.board.system.articlecomment.domain.dto.ArticleCommentCreateCommand
 import com.ttasjwi.board.system.articlecomment.domain.exception.*
 import com.ttasjwi.board.system.articlecomment.domain.model.ArticleComment
+import com.ttasjwi.board.system.articlecomment.domain.port.ArticleCommentCountPersistencePort
 import com.ttasjwi.board.system.articlecomment.domain.port.ArticleCommentPersistencePort
 import com.ttasjwi.board.system.articlecomment.domain.port.ArticleCommentWriterNicknamePersistencePort
 import com.ttasjwi.board.system.articlecomment.domain.port.ArticlePersistencePort
@@ -13,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional
 @ApplicationProcessor
 internal class ArticleCommentCreateProcessor(
     private val articleCommentPersistencePort: ArticleCommentPersistencePort,
+    private val articleCommentCountPersistencePort: ArticleCommentCountPersistencePort,
     private val articlePersistencePort: ArticlePersistencePort,
     private val articleCommentWriterNicknamePersistencePort: ArticleCommentWriterNicknamePersistencePort,
 ) {
@@ -37,6 +39,9 @@ internal class ArticleCommentCreateProcessor(
         // 댓글 생성 및 저장
         val articleComment = createArticleComment(command, parentComment, commentWriterNickname)
         articleCommentPersistencePort.save(articleComment)
+
+        // 댓글 수 증가
+        articleCommentCountPersistencePort.increase(command.articleId)
 
         return articleComment
     }

--- a/board-system-article-comment/article-comment-application-service/src/test/kotlin/com/ttasjwi/board/system/articlecomment/domain/ArticleCommentCreateUseCaseImplTest.kt
+++ b/board-system-article-comment/article-comment-application-service/src/test/kotlin/com/ttasjwi/board/system/articlecomment/domain/ArticleCommentCreateUseCaseImplTest.kt
@@ -2,6 +2,7 @@ package com.ttasjwi.board.system.articlecomment.domain
 
 import com.ttasjwi.board.system.articlecomment.domain.model.ArticleCommentDeleteStatus
 import com.ttasjwi.board.system.articlecomment.domain.model.fixture.articleFixture
+import com.ttasjwi.board.system.articlecomment.domain.port.fixture.ArticleCommentCountPersistencePortFixture
 import com.ttasjwi.board.system.articlecomment.domain.port.fixture.ArticleCommentPersistencePortFixture
 import com.ttasjwi.board.system.articlecomment.domain.port.fixture.ArticleCommentWriterNicknamePersistencePortFixture
 import com.ttasjwi.board.system.articlecomment.domain.port.fixture.ArticlePersistencePortFixture
@@ -22,6 +23,7 @@ class ArticleCommentCreateUseCaseImplTest {
     private lateinit var currentTime: AppDateTime
     private lateinit var articleCommentWriter: AuthUser
     private lateinit var articleCommentPersistencePortFixture: ArticleCommentPersistencePortFixture
+    private lateinit var articleCommentCountPersistencePortfixture: ArticleCommentCountPersistencePortFixture
     private lateinit var articlePersistencePortFixture: ArticlePersistencePortFixture
     private lateinit var articleCommentWriterNicknamePersistencePortFixture: ArticleCommentWriterNicknamePersistencePortFixture
 
@@ -37,6 +39,7 @@ class ArticleCommentCreateUseCaseImplTest {
         container.authUserLoaderFixture.changeAuthUser(articleCommentWriter)
 
         articleCommentPersistencePortFixture = container.articleCommentPersistencePortFixture
+        articleCommentCountPersistencePortfixture = container.articleCommentCountPersistencePortFixture
         articlePersistencePortFixture = container.articlePersistencePortFixture
         articleCommentWriterNicknamePersistencePortFixture =
             container.articleCommentWriterNicknamePersistencePortFixture
@@ -64,6 +67,7 @@ class ArticleCommentCreateUseCaseImplTest {
 
         // then
         val findArticleComment = articleCommentPersistencePortFixture.findById(response.articleCommentId.toLong())!!
+        val findArticleCommentCount = articleCommentCountPersistencePortfixture.findByIdOrNull(request.articleId!!)!!
 
         assertThat(response.articleCommentId).isNotNull()
         assertThat(response.content).isEqualTo(request.content)
@@ -78,5 +82,7 @@ class ArticleCommentCreateUseCaseImplTest {
         assertThat(response.modifiedAt).isEqualTo(currentTime.toZonedDateTime())
 
         assertThat(findArticleComment.articleCommentId).isEqualTo(response.articleCommentId.toLong())
+        assertThat(findArticleCommentCount.articleId).isEqualTo(request.articleId)
+        assertThat(findArticleCommentCount.commentCount).isEqualTo(1)
     }
 }

--- a/board-system-article-comment/article-comment-application-service/src/test/kotlin/com/ttasjwi/board/system/articlecomment/domain/processor/ArticleCommentCreateProcessorTest.kt
+++ b/board-system-article-comment/article-comment-application-service/src/test/kotlin/com/ttasjwi/board/system/articlecomment/domain/processor/ArticleCommentCreateProcessorTest.kt
@@ -5,6 +5,7 @@ import com.ttasjwi.board.system.articlecomment.domain.exception.*
 import com.ttasjwi.board.system.articlecomment.domain.model.ArticleCommentDeleteStatus
 import com.ttasjwi.board.system.articlecomment.domain.model.fixture.articleCommentFixture
 import com.ttasjwi.board.system.articlecomment.domain.model.fixture.articleFixture
+import com.ttasjwi.board.system.articlecomment.domain.port.fixture.ArticleCommentCountPersistencePortFixture
 import com.ttasjwi.board.system.articlecomment.domain.port.fixture.ArticleCommentPersistencePortFixture
 import com.ttasjwi.board.system.articlecomment.domain.port.fixture.ArticleCommentWriterNicknamePersistencePortFixture
 import com.ttasjwi.board.system.articlecomment.domain.port.fixture.ArticlePersistencePortFixture
@@ -22,6 +23,7 @@ class ArticleCommentCreateProcessorTest {
 
     private lateinit var processor: ArticleCommentCreateProcessor
     private lateinit var articleCommentPersistencePortFixture: ArticleCommentPersistencePortFixture
+    private lateinit var articleCommentCountPersistencePortfixture: ArticleCommentCountPersistencePortFixture
     private lateinit var articlePersistencePortFixture: ArticlePersistencePortFixture
     private lateinit var articleCommentWriterNicknamePersistencePortFixture: ArticleCommentWriterNicknamePersistencePortFixture
 
@@ -30,6 +32,7 @@ class ArticleCommentCreateProcessorTest {
         val container = TestContainer.create()
         processor = container.articleCommentCreateProcessor
         articleCommentPersistencePortFixture = container.articleCommentPersistencePortFixture
+        articleCommentCountPersistencePortfixture = container.articleCommentCountPersistencePortFixture
         articlePersistencePortFixture = container.articlePersistencePortFixture
         articleCommentWriterNicknamePersistencePortFixture =
             container.articleCommentWriterNicknamePersistencePortFixture
@@ -62,6 +65,7 @@ class ArticleCommentCreateProcessorTest {
 
         // then
         val findArticleComment = articleCommentPersistencePortFixture.findById(articleComment.articleCommentId)!!
+        val findArticleCommentCount = articleCommentCountPersistencePortfixture.findByIdOrNull(articleComment.articleId)!!
 
         assertThat(articleComment.articleCommentId).isNotNull()
         assertThat(articleComment.content).isEqualTo(command.content)
@@ -76,6 +80,8 @@ class ArticleCommentCreateProcessorTest {
         assertThat(articleComment.modifiedAt).isEqualTo(command.currentTime)
 
         assertThat(findArticleComment.articleCommentId).isEqualTo(articleComment.articleCommentId)
+        assertThat(findArticleCommentCount.articleId).isEqualTo(articleComment.articleId)
+        assertThat(findArticleCommentCount.commentCount).isEqualTo(1)
     }
 
 
@@ -103,6 +109,7 @@ class ArticleCommentCreateProcessorTest {
                 deleteStatus = ArticleCommentDeleteStatus.NOT_DELETED
             )
         )
+        articleCommentCountPersistencePortfixture.increase(article.articleId)
 
         val command = ArticleCommentCreateCommand(
             content = "댓글 본문",
@@ -117,6 +124,7 @@ class ArticleCommentCreateProcessorTest {
 
         // then
         val findArticleComment = articleCommentPersistencePortFixture.findById(articleComment.articleCommentId)!!
+        val findArticleCommentCount = articleCommentCountPersistencePortfixture.findByIdOrNull(articleComment.articleId)!!
 
         assertThat(articleComment.articleCommentId).isNotNull()
         assertThat(articleComment.content).isEqualTo(command.content)
@@ -131,6 +139,8 @@ class ArticleCommentCreateProcessorTest {
         assertThat(articleComment.modifiedAt).isEqualTo(command.currentTime)
 
         assertThat(findArticleComment.articleCommentId).isEqualTo(articleComment.articleCommentId)
+        assertThat(findArticleCommentCount.articleId).isEqualTo(articleComment.articleId)
+        assertThat(findArticleCommentCount.commentCount).isEqualTo(2)
     }
 
 

--- a/board-system-article-comment/article-comment-application-service/src/test/kotlin/com/ttasjwi/board/system/articlecomment/domain/test/support/TestContainer.kt
+++ b/board-system-article-comment/article-comment-application-service/src/test/kotlin/com/ttasjwi/board/system/articlecomment/domain/test/support/TestContainer.kt
@@ -6,6 +6,8 @@ import com.ttasjwi.board.system.articlecomment.domain.mapper.ArticleCommentCreat
 import com.ttasjwi.board.system.articlecomment.domain.mapper.ArticleCommentInfiniteScrollReadQueryMapper
 import com.ttasjwi.board.system.articlecomment.domain.mapper.ArticleCommentPageReadQueryMapper
 import com.ttasjwi.board.system.articlecomment.domain.policy.fixture.ArticleCommentContentPolicyFixture
+import com.ttasjwi.board.system.articlecomment.domain.port.ArticleCommentCountPersistencePort
+import com.ttasjwi.board.system.articlecomment.domain.port.fixture.ArticleCommentCountPersistencePortFixture
 import com.ttasjwi.board.system.articlecomment.domain.port.fixture.ArticleCommentPersistencePortFixture
 import com.ttasjwi.board.system.articlecomment.domain.port.fixture.ArticleCommentWriterNicknamePersistencePortFixture
 import com.ttasjwi.board.system.articlecomment.domain.port.fixture.ArticlePersistencePortFixture
@@ -34,6 +36,10 @@ internal class TestContainer private constructor() {
     // port
     val articleCommentPersistencePortFixture: ArticleCommentPersistencePortFixture by lazy {
         ArticleCommentPersistencePortFixture()
+    }
+
+    val articleCommentCountPersistencePortFixture: ArticleCommentCountPersistencePortFixture by lazy {
+        ArticleCommentCountPersistencePortFixture()
     }
 
     val articlePersistencePortFixture: ArticlePersistencePortFixture by lazy {
@@ -70,6 +76,7 @@ internal class TestContainer private constructor() {
     val articleCommentCreateProcessor: ArticleCommentCreateProcessor by lazy {
         ArticleCommentCreateProcessor(
             articleCommentPersistencePort = articleCommentPersistencePortFixture,
+            articleCommentCountPersistencePort = articleCommentCountPersistencePortFixture,
             articlePersistencePort = articlePersistencePortFixture,
             articleCommentWriterNicknamePersistencePort = articleCommentWriterNicknamePersistencePortFixture,
         )

--- a/board-system-article-comment/article-comment-domain/src/main/kotlin/com/ttasjwi/board/system/articlecomment/domain/model/ArticleCommentCount.kt
+++ b/board-system-article-comment/article-comment-domain/src/main/kotlin/com/ttasjwi/board/system/articlecomment/domain/model/ArticleCommentCount.kt
@@ -1,0 +1,18 @@
+package com.ttasjwi.board.system.articlecomment.domain.model
+
+class ArticleCommentCount(
+    val articleId: Long,
+    val commentCount: Long
+) {
+
+    companion object {
+
+        fun restore(articleId: Long, commentCount: Long): ArticleCommentCount {
+            return ArticleCommentCount(articleId, commentCount)
+        }
+    }
+
+    override fun toString(): String {
+        return "ArticleCommentCount(articleId=$articleId, commentCount=$commentCount)"
+    }
+}

--- a/board-system-article-comment/article-comment-domain/src/test/kotlin/com/ttasjwi/board/system/articlecomment/domain/model/ArticleCommentCountTest.kt
+++ b/board-system-article-comment/article-comment-domain/src/test/kotlin/com/ttasjwi/board/system/articlecomment/domain/model/ArticleCommentCountTest.kt
@@ -1,0 +1,46 @@
+package com.ttasjwi.board.system.articlecomment.domain.model
+
+import com.ttasjwi.board.system.articlecomment.domain.model.fixture.articleCommentCountFixture
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("[article-comment-domain] ArticleCommentCount 테스트")
+class ArticleCommentCountTest {
+
+    @Test
+    @DisplayName("restore : 값으로 부터 객체 복원")
+    fun restoreTest() {
+        // given
+        val articleId = 134L
+        val commentCount = 55L
+
+        // when
+        val articleCommentCount = ArticleCommentCount.restore(
+            articleId = articleId,
+            commentCount = commentCount
+        )
+
+        // then
+        assertThat(articleCommentCount.articleId).isEqualTo(articleId)
+        assertThat(articleCommentCount.commentCount).isEqualTo(commentCount)
+    }
+
+
+    @Test
+    @DisplayName("toString() : 디버깅문자열 반환")
+    fun toStringTest() {
+        // given
+        val articleId = 134L
+        val commentCount = 55L
+
+        // when
+        val articleComment = articleCommentCountFixture(
+            articleId = articleId,
+            commentCount = commentCount
+        )
+
+        // then
+        assertThat(articleComment.toString()).isEqualTo("ArticleCommentCount(articleId=$articleId, commentCount=$commentCount)")
+    }
+}

--- a/board-system-article-comment/article-comment-domain/src/test/kotlin/com/ttasjwi/board/system/articlecomment/domain/model/fixture/ArticleCommentCountFixtureTest.kt
+++ b/board-system-article-comment/article-comment-domain/src/test/kotlin/com/ttasjwi/board/system/articlecomment/domain/model/fixture/ArticleCommentCountFixtureTest.kt
@@ -1,0 +1,40 @@
+package com.ttasjwi.board.system.articlecomment.domain.model.fixture
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("[article-comment-domain] ArticleCommentCountFixture 테스트")
+class ArticleCommentCountFixtureTest {
+
+    @Test
+    @DisplayName("기본값 생성 테스트")
+    fun test1() {
+        // given
+        // when
+        val articleCommentCount = articleCommentCountFixture()
+
+        // then
+        assertThat(articleCommentCount.articleId).isNotNull
+        assertThat(articleCommentCount.commentCount).isNotNull
+    }
+
+
+    @Test
+    @DisplayName("커스텀 값 지정 테스트")
+    fun test2() {
+        // given
+        val articleId = 134L
+        val commentCount = 55L
+
+        // when
+        val articleCommentCount = articleCommentCountFixture(
+            articleId = articleId,
+            commentCount = commentCount
+        )
+
+        // then
+        assertThat(articleCommentCount.articleId).isEqualTo(articleId)
+        assertThat(articleCommentCount.commentCount).isEqualTo(commentCount)
+    }
+}

--- a/board-system-article-comment/article-comment-domain/src/testFixtures/kotlin/com/ttasjwi/board/system/articlecomment/domain/model/fixture/ArticleCommentCountFixture.kt
+++ b/board-system-article-comment/article-comment-domain/src/testFixtures/kotlin/com/ttasjwi/board/system/articlecomment/domain/model/fixture/ArticleCommentCountFixture.kt
@@ -1,0 +1,13 @@
+package com.ttasjwi.board.system.articlecomment.domain.model.fixture
+
+import com.ttasjwi.board.system.articlecomment.domain.model.ArticleCommentCount
+
+fun articleCommentCountFixture(
+    articleId: Long = 1L,
+    commentCount: Long = 0L,
+): ArticleCommentCount {
+    return ArticleCommentCount(
+        articleId = articleId,
+        commentCount = commentCount
+    )
+}

--- a/board-system-infrastructure/database-adapter/src/main/kotlin/com/ttasjwi/board/system/articlecomment/infra/persistence/ArticleCommentCountPersistenceAdapter.kt
+++ b/board-system-infrastructure/database-adapter/src/main/kotlin/com/ttasjwi/board/system/articlecomment/infra/persistence/ArticleCommentCountPersistenceAdapter.kt
@@ -1,0 +1,25 @@
+package com.ttasjwi.board.system.articlecomment.infra.persistence
+
+import com.ttasjwi.board.system.articlecomment.domain.model.ArticleCommentCount
+import com.ttasjwi.board.system.articlecomment.domain.port.ArticleCommentCountPersistencePort
+import com.ttasjwi.board.system.articlecomment.infra.persistence.jpa.JpaArticleCommentCountRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+
+@Component("articleCommentArticleCommentCountPersistenceAdapter")
+class ArticleCommentCountPersistenceAdapter(
+    private val jpaArticleCommentCountRepository: JpaArticleCommentCountRepository
+) : ArticleCommentCountPersistencePort {
+
+    override fun increase(articleId: Long) {
+        jpaArticleCommentCountRepository.increase(articleId)
+    }
+
+    override fun decrease(articleId: Long) {
+        jpaArticleCommentCountRepository.decrease(articleId)
+    }
+
+    override fun findByIdOrNull(articleId: Long): ArticleCommentCount? {
+        return jpaArticleCommentCountRepository.findByIdOrNull(articleId)?.restoreDomain()
+    }
+}

--- a/board-system-infrastructure/database-adapter/src/main/kotlin/com/ttasjwi/board/system/articlecomment/infra/persistence/jpa/JpaArticleCommentCount.kt
+++ b/board-system-infrastructure/database-adapter/src/main/kotlin/com/ttasjwi/board/system/articlecomment/infra/persistence/jpa/JpaArticleCommentCount.kt
@@ -1,0 +1,27 @@
+package com.ttasjwi.board.system.articlecomment.infra.persistence.jpa
+
+import com.ttasjwi.board.system.articlecomment.domain.model.ArticleCommentCount
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity(name = "ArticleCommentJpaArticleCommentCount")
+@Table(name = "article_comment_counts")
+class JpaArticleCommentCount(
+
+    @Id
+    @Column(name = "article_id")
+    val articleId: Long,
+
+    @Column(name = "comment_count")
+    val commentCount: Long
+) {
+
+    fun restoreDomain(): ArticleCommentCount {
+        return ArticleCommentCount.restore(
+            articleId = articleId,
+            commentCount = commentCount
+        )
+    }
+}

--- a/board-system-infrastructure/database-adapter/src/main/kotlin/com/ttasjwi/board/system/articlecomment/infra/persistence/jpa/JpaArticleCommentCountRepository.kt
+++ b/board-system-infrastructure/database-adapter/src/main/kotlin/com/ttasjwi/board/system/articlecomment/infra/persistence/jpa/JpaArticleCommentCountRepository.kt
@@ -1,0 +1,31 @@
+package com.ttasjwi.board.system.articlecomment.infra.persistence.jpa
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.stereotype.Repository
+
+
+@Repository("articleCommentJpaArticleCommentCountRepository")
+interface JpaArticleCommentCountRepository : JpaRepository<JpaArticleCommentCount, Long> {
+
+    @Modifying
+    @Query(
+        """
+            INSERT INTO article_comment_counts (article_id, comment_count)
+            VALUES (:articleId, 1)
+            ON DUPLICATE KEY UPDATE comment_count  = comment_count + 1
+        """, nativeQuery = true
+    )
+    fun increase(articleId: Long)
+
+    @Modifying
+    @Query(
+        """
+            UPDATE article_comment_counts
+            SET comment_count = comment_count - 1
+            WHERE article_id = :articleId
+        """, nativeQuery = true
+    )
+    fun decrease(articleId: Long)
+}

--- a/board-system-infrastructure/database-adapter/src/main/resources/schema.sql
+++ b/board-system-infrastructure/database-adapter/src/main/resources/schema.sql
@@ -65,6 +65,11 @@ CREATE TABLE IF NOT EXISTS article_comments(
     modified_at                    DATETIME      NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS article_comment_counts(
+    article_id    BIGINT NOT NULL PRIMARY KEY,
+    comment_count BIGINT NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS article_likes(
     article_like_id BIGINT   NOT NULL PRIMARY KEY,
     article_id      BIGINT   NOT NULL,

--- a/board-system-infrastructure/database-adapter/src/test/kotlin/com/ttasjwi/board/system/articlecomment/infra/persistence/ArticleCommentCountPersistenceAdapterTest.kt
+++ b/board-system-infrastructure/database-adapter/src/test/kotlin/com/ttasjwi/board/system/articlecomment/infra/persistence/ArticleCommentCountPersistenceAdapterTest.kt
@@ -1,0 +1,94 @@
+package com.ttasjwi.board.system.articlecomment.infra.persistence
+
+import com.ttasjwi.board.system.test.DataBaseIntegrationTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("[article-comment-database-adapter] ArticleCommentCountPersistenceAdapter 테스트")
+class ArticleCommentCountPersistenceAdapterTest : DataBaseIntegrationTest() {
+
+    @Nested
+    @DisplayName("increase: 댓글 수 증가")
+    inner class IncreaseTest {
+
+        @Test
+        @DisplayName("최초 댓글수 증가 테스트")
+        fun test1() {
+            // given
+            val articleId = 5857L
+
+            // when
+            articleCommentArticleCommentCountPersistenceAdapter.increase(articleId)
+
+
+            // then
+            val articleCommentCount = articleCommentArticleCommentCountPersistenceAdapter.findByIdOrNull(articleId)!!
+
+            assertThat(articleCommentCount.articleId).isEqualTo(articleId)
+            assertThat(articleCommentCount.commentCount).isEqualTo(1)
+        }
+
+        @Test
+        @DisplayName("첫번째 이후 댓글수 증가 테스트")
+        fun test2() {
+            // given
+            val articleId = 5857L
+
+            // when
+            articleCommentArticleCommentCountPersistenceAdapter.increase(articleId)
+            articleCommentArticleCommentCountPersistenceAdapter.increase(articleId)
+
+            // then
+            val articleCommentCount = articleCommentArticleCommentCountPersistenceAdapter.findByIdOrNull(articleId)!!
+
+            assertThat(articleCommentCount.articleId).isEqualTo(articleId)
+            assertThat(articleCommentCount.commentCount).isEqualTo(2)
+        }
+    }
+
+
+    @Nested
+    @DisplayName("decrease: 댓글 수 감소")
+    inner class DecreaseTest {
+
+        @Test
+        @DisplayName("두번 댓글 수 증가 후, 댓글수 감소 테스트")
+        fun test() {
+            // given
+            val articleId = 5857L
+
+            // when
+            articleCommentArticleCommentCountPersistenceAdapter.increase(articleId)
+            articleCommentArticleCommentCountPersistenceAdapter.increase(articleId)
+            articleCommentArticleCommentCountPersistenceAdapter.decrease(articleId)
+
+            // then
+            val articleCommentCount = articleCommentArticleCommentCountPersistenceAdapter.findByIdOrNull(articleId)!!
+
+            assertThat(articleCommentCount.articleId).isEqualTo(articleId)
+            assertThat(articleCommentCount.commentCount).isEqualTo(1)
+        }
+
+    }
+
+
+    @Nested
+    @DisplayName("findByIdOrNull : articleId 값으로 댓글 수 조회")
+    inner class FindByIdOrNullTest {
+
+        @Test
+        @DisplayName("조회 실패시 null 반환 테스트")
+        fun test2() {
+            // given
+            val articleId = 15555L
+
+            // when
+            // then
+            val findArticleCommentCount = articleCommentArticleCommentCountPersistenceAdapter.findByIdOrNull(articleId)
+
+            assertThat(findArticleCommentCount).isNull()
+        }
+    }
+}

--- a/board-system-infrastructure/database-adapter/src/test/kotlin/com/ttasjwi/board/system/test/DataBaseIntegrationTest.kt
+++ b/board-system-infrastructure/database-adapter/src/test/kotlin/com/ttasjwi/board/system/test/DataBaseIntegrationTest.kt
@@ -37,6 +37,9 @@ abstract class DataBaseIntegrationTest {
     protected lateinit var articleCommentArticlePersistenceAdapter: com.ttasjwi.board.system.articlecomment.infra.persistence.ArticlePersistenceAdapter
 
     @Autowired
+    protected lateinit var articleCommentArticleCommentCountPersistenceAdapter: com.ttasjwi.board.system.articlecomment.infra.persistence.ArticleCommentCountPersistenceAdapter
+
+    @Autowired
     protected lateinit var articleCommentArticleCommentWriterNicknamePersistenceAdapter: com.ttasjwi.board.system.articlecomment.infra.persistence.ArticleCommentWriterNicknamePersistenceAdapter
 
     @Autowired


### PR DESCRIPTION

# JIRA 티켓
- [BRD-154]

---

# 개요
- 게시글 댓글 작성 시점에, 게시글별 댓글 수가 증가할 수 있도록 한다.
- 조회를 할 때마다 count 쿼리를 날려도 되겠지만, 이 경우 질의 비용이 증가하여 성능 감소의 원인이 된다.
- 따라서, 게시글별로 댓글 수를 별도의 테이블에 비정규화하여 관리한다.

[BRD-154]: https://ttasjwi.atlassian.net/browse/BRD-154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ