### PR TITLE
Feature: (BRD-146) 게시글 조회수 증가 API 구현

### DIFF
--- a/board-system-app/build.gradle.kts
+++ b/board-system-app/build.gradle.kts
@@ -88,12 +88,14 @@ tasks.register("copySnippets", Copy::class) {
     dependsOn(":board-system-article:article-web-adapter:test")
     dependsOn(":board-system-article-comment:article-comment-web-adapter:test")
     dependsOn(":board-system-article-like:article-like-web-adapter:test")
+    dependsOn(":board-system-article-view:article-view-web-adapter:test")
 
     from(file("$rootDir/board-system-user/user-web-adapter/build/generated-snippets"))
     from(file("$rootDir/board-system-board/board-web-adapter/build/generated-snippets"))
     from(file("$rootDir/board-system-article/article-web-adapter/build/generated-snippets"))
     from(file("$rootDir/board-system-article-comment/article-comment-web-adapter/build/generated-snippets"))
     from(file("$rootDir/board-system-article-like/article-like-web-adapter/build/generated-snippets"))
+    from(file("$rootDir/board-system-article-view/article-view-web-adapter/build/generated-snippets"))
     into(file("build/generated-snippets"))
 }
 

--- a/board-system-app/build.gradle.kts
+++ b/board-system-app/build.gradle.kts
@@ -48,6 +48,9 @@ dependencies {
     // article-view
     implementation(project(":board-system-article-view:article-view-web-adapter"))
     implementation(project(":board-system-article-view:article-view-application-service"))
+    testImplementation(project(":board-system-article-view:article-view-domain"))
+    testImplementation(project(":board-system-article-view:article-view-application-input-port"))
+    testImplementation(project(":board-system-article-view:article-view-application-output-port"))
 
     // aop
     implementation("org.springframework.boot:spring-boot-starter-aop")

--- a/board-system-app/build.gradle.kts
+++ b/board-system-app/build.gradle.kts
@@ -45,6 +45,10 @@ dependencies {
     implementation(project(":board-system-article-like:article-like-application-service"))
     testImplementation(project(":board-system-article-like:article-like-application-input-port"))
 
+    // article-view
+    implementation(project(":board-system-article-view:article-view-web-adapter"))
+    implementation(project(":board-system-article-view:article-view-application-service"))
+
     // aop
     implementation("org.springframework.boot:spring-boot-starter-aop")
 

--- a/board-system-app/src/docs/asciidoc/article-view-api.adoc
+++ b/board-system-app/src/docs/asciidoc/article-view-api.adoc
@@ -1,0 +1,23 @@
+== 게시글 조회수 API 명세
+
+=== 게시글 조회수 증가
+==== 기본정보
+- 메서드 : POST
+- URL : `/api/v1/articles/{articleId}/views`
+- 권한 : 인증된 사용자 누구든지
+- 인증방식 : 액세스 토큰
+
+게시글의 조회수를 증가시킵니다.
+한 사용자가 이 API를 호출하여 조회수를 증가시키고, 10분 이내에 다시 이 API 를 호출하더라도 조회수가 증가하지 않습니다.
+즉, 한 사용자는 10분당 1의 조회수를 증카시킬 수 있습니다.
+
+==== 요청
+include::{snippets}/article-view-count-increase-success/request-headers.adoc[]
+include::{snippets}/article-view-count-increase-success/path-parameters.adoc[]
+
+==== 응답
+응답으로 200 상태코드가 전달되고, 본문에 내용이 포함되지 않습니다.
+
+==== 예시
+include::{snippets}/article-view-count-increase-success/http-request.adoc[]
+include::{snippets}/article-view-count-increase-success/http-response.adoc[]

--- a/board-system-app/src/docs/asciidoc/index.adoc
+++ b/board-system-app/src/docs/asciidoc/index.adoc
@@ -21,4 +21,4 @@ include::board-api.adoc[]
 include::article-api.adoc[]
 include::article-comment-api.adoc[]
 include::article-like-api.adoc[]
-
+include::article-view-api.adoc[]

--- a/board-system-app/src/main/kotlin/com/ttasjwi/board/system/app/config/ComponentScanConfig.kt
+++ b/board-system-app/src/main/kotlin/com/ttasjwi/board/system/app/config/ComponentScanConfig.kt
@@ -11,6 +11,7 @@ import org.springframework.context.annotation.FilterType
         "com.ttasjwi.board.system.article",
         "com.ttasjwi.board.system.articlecomment",
         "com.ttasjwi.board.system.articlelike",
+        "com.ttasjwi.board.system.articleview",
         "com.ttasjwi.board.system.board",
         "com.ttasjwi.board.system.user",
         "com.ttasjwi.board.system.emailsender",

--- a/board-system-app/src/test/kotlin/com/ttasjwi/board/system/app/articleview/ArticleViewCountIntegrationTest.kt
+++ b/board-system-app/src/test/kotlin/com/ttasjwi/board/system/app/articleview/ArticleViewCountIntegrationTest.kt
@@ -1,0 +1,144 @@
+package com.ttasjwi.board.system.app.articleview
+
+import com.ttasjwi.board.system.article.domain.model.fixture.articleFixture
+import com.ttasjwi.board.system.article.domain.port.ArticlePersistencePort
+import com.ttasjwi.board.system.articleview.domain.ArticleViewCountIncreaseUseCase
+import com.ttasjwi.board.system.articleview.domain.port.ArticleViewCountPersistencePort
+import com.ttasjwi.board.system.board.domain.model.fixture.articleCategoryFixture
+import com.ttasjwi.board.system.board.domain.port.ArticleCategoryPersistencePort
+import com.ttasjwi.board.system.common.auth.Role
+import com.ttasjwi.board.system.common.auth.fixture.authUserFixture
+import com.ttasjwi.board.system.common.infra.websupport.auth.security.AuthUserAuthentication
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.security.core.context.SecurityContextHolder
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+
+@Disabled // 수동테스트용(테스트 해보고 싶을 경우 주석처리)
+@SpringBootTest
+@DisplayName("[app] 게시글 조회 수 통합테스트")
+class ArticleViewCountIntegrationTest {
+
+    @Autowired
+    private lateinit var articleViewCountIncreaseUseCase: ArticleViewCountIncreaseUseCase
+
+    @Autowired
+    private lateinit var articlePersistencePort: ArticlePersistencePort
+
+    @Autowired
+    private lateinit var articleCategoryPersistencePort: ArticleCategoryPersistencePort
+
+    @Autowired
+    private lateinit var articleViewCountPersistencePort: ArticleViewCountPersistencePort
+
+    @Test
+    @DisplayName("댓글 수 동시성 테스트 : 같은 사용자가 동시 조회수 어뷰징 요청하더라도, 조회수는 1 증가한다")
+    fun viewCountConcurrencyTest() {
+        val threadCount = 100
+        val tryCount = 10000
+        val boardArticleArticleCategoryUserId = 38314133141345L
+
+        val executorService = Executors.newFixedThreadPool(threadCount)
+
+        increaseViewCounts(
+            executorService = executorService,
+            tryCount = tryCount,
+            boardId = boardArticleArticleCategoryUserId,
+            articleId = boardArticleArticleCategoryUserId,
+            articleCategoryId = boardArticleArticleCategoryUserId,
+            userId = boardArticleArticleCategoryUserId
+        )
+        executorService.shutdown()
+    }
+
+
+    private fun increaseViewCounts(
+        executorService: ExecutorService,
+        tryCount: Int,
+        boardId: Long,
+        articleId: Long,
+        articleCategoryId: Long,
+        userId: Long,
+    ) {
+        prepareArticleCategory(boardId, articleCategoryId)
+        prepareArticle(boardId, articleCategoryId, articleId)
+
+        val latch = CountDownLatch(tryCount)
+        println("--------------------------------------------------------------------------")
+        println("start increase viewCounts : articleId = $articleId")
+        val start = System.nanoTime()
+        for (i in 1..tryCount) {
+            executorService.execute {
+                try {
+                    increaseViewCount(articleId, userId)
+                } catch (e: Exception) {
+                    e.printStackTrace()
+                } finally {
+                    latch.countDown()
+                }
+            }
+
+        }
+        latch.await()
+        val end = System.nanoTime()
+        println("time = ${(end - start) / 100_0000} ms")
+
+        val viewCount = articleViewCountPersistencePort.findByIdOrNull(articleId)!!.viewCount
+
+        println("start increase viewCounts : articleId = $articleId")
+        println("viewCount = $viewCount")
+        println("--------------------------------------------------------------------------")
+
+        assertThat(viewCount).isEqualTo(1L)
+    }
+
+    private fun prepareArticle(boardId: Long, articleCategoryId: Long, articleId: Long) {
+        articlePersistencePort.save(
+            articleFixture(
+                articleId = articleId,
+                title = "article-title-$articleId",
+                content = "article-content-$articleId",
+                boardId = boardId,
+                articleCategoryId = articleCategoryId,
+                writerId = 1L
+            )
+        )
+    }
+
+    private fun prepareArticleCategory(boardId: Long, articleCategoryId: Long) {
+        articleCategoryPersistencePort.save(
+            articleCategoryFixture(
+                articleCategoryId = articleCategoryId,
+                name = "테스트",
+                slug = "test",
+                boardId = boardId,
+                allowLike = true,
+                allowDislike = true
+            )
+        )
+    }
+
+    private fun increaseViewCount(articleId: Long, userId: Long) {
+        setAuthUser(userId)
+        articleViewCountIncreaseUseCase.increase(articleId)
+    }
+
+    private fun setAuthUser(userId: Long) {
+        val authentication = AuthUserAuthentication.from(
+            authUser = authUserFixture(
+                userId = userId,
+                role = Role.USER
+            )
+        )
+        val securityContext = SecurityContextHolder.getContextHolderStrategy().createEmptyContext()
+        securityContext.authentication = authentication
+        SecurityContextHolder.getContextHolderStrategy().context = securityContext
+    }
+
+}

--- a/board-system-article-view/article-view-application-input-port/src/main/kotlin/com/ttasjwi/board/system/articleview/domain/ArticleViewCountIncreaseUseCase.kt
+++ b/board-system-article-view/article-view-application-input-port/src/main/kotlin/com/ttasjwi/board/system/articleview/domain/ArticleViewCountIncreaseUseCase.kt
@@ -1,0 +1,5 @@
+package com.ttasjwi.board.system.articleview.domain
+
+interface ArticleViewCountIncreaseUseCase {
+    fun increase(articleId: Long)
+}

--- a/board-system-article-view/article-view-application-output-port/build.gradle.kts
+++ b/board-system-article-view/article-view-application-output-port/build.gradle.kts
@@ -1,0 +1,7 @@
+dependencies {
+    implementation(project(":board-system-common:core"))
+    testFixturesImplementation(testFixtures(project(":board-system-common:core")))
+
+    implementation(project(":board-system-article-view:article-view-domain"))
+    testFixturesImplementation(testFixtures(project(":board-system-article-view:article-view-domain")))
+}

--- a/board-system-article-view/article-view-application-output-port/src/main/kotlin/com/ttasjwi/board/system/articleview/domain/port/ArticlePersistencePort.kt
+++ b/board-system-article-view/article-view-application-output-port/src/main/kotlin/com/ttasjwi/board/system/articleview/domain/port/ArticlePersistencePort.kt
@@ -1,0 +1,5 @@
+package com.ttasjwi.board.system.articleview.domain.port
+
+interface ArticlePersistencePort {
+    fun existsById(articleId: Long): Boolean
+}

--- a/board-system-article-view/article-view-application-output-port/src/main/kotlin/com/ttasjwi/board/system/articleview/domain/port/ArticleViewCountLockPersistencePort.kt
+++ b/board-system-article-view/article-view-application-output-port/src/main/kotlin/com/ttasjwi/board/system/articleview/domain/port/ArticleViewCountLockPersistencePort.kt
@@ -1,0 +1,7 @@
+package com.ttasjwi.board.system.articleview.domain.port
+
+import java.time.Duration
+
+interface ArticleViewCountLockPersistencePort {
+    fun lock(articleId: Long, userId: Long, ttl: Duration): Boolean
+}

--- a/board-system-article-view/article-view-application-output-port/src/main/kotlin/com/ttasjwi/board/system/articleview/domain/port/ArticleViewCountPersistencePort.kt
+++ b/board-system-article-view/article-view-application-output-port/src/main/kotlin/com/ttasjwi/board/system/articleview/domain/port/ArticleViewCountPersistencePort.kt
@@ -1,0 +1,9 @@
+package com.ttasjwi.board.system.articleview.domain.port
+
+import com.ttasjwi.board.system.articleview.domain.model.ArticleViewCount
+
+interface ArticleViewCountPersistencePort {
+
+    fun increase(articleId: Long)
+    fun findByIdOrNull(articleId: Long): ArticleViewCount?
+}

--- a/board-system-article-view/article-view-application-output-port/src/test/kotlin/com/ttasjwi/board/system/articleview/domain/port/fixture/ArticlePersistencePortFixtureTest.kt
+++ b/board-system-article-view/article-view-application-output-port/src/test/kotlin/com/ttasjwi/board/system/articleview/domain/port/fixture/ArticlePersistencePortFixtureTest.kt
@@ -1,0 +1,51 @@
+package com.ttasjwi.board.system.articleview.domain.port.fixture
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("[article-view-application-output-port] ArticlePersistencePortFixture 테스트")
+class ArticlePersistencePortFixtureTest {
+
+    private lateinit var articlePersistencePortFixture: ArticlePersistencePortFixture
+
+    @BeforeEach
+    fun setup() {
+        articlePersistencePortFixture = ArticlePersistencePortFixture()
+    }
+
+    @Nested
+    @DisplayName("existsById : 게시글 존재여부 확인")
+    inner class ExistsByIdTest {
+
+
+        @Test
+        @DisplayName("저장된 게시글이 있을 경우 true 반환")
+        fun test1() {
+            // given
+            val articleId = 2345L
+            articlePersistencePortFixture.save(articleId)
+
+            // when
+            val exists = articlePersistencePortFixture.existsById(articleId)
+
+            // then
+            assertThat(exists).isTrue
+        }
+
+        @Test
+        @DisplayName("저장된 게시글이 없을 경우 false 반환")
+        fun test2() {
+            // given
+            val articleId = 5553155L
+
+            // when
+            val exists = articlePersistencePortFixture.existsById(articleId)
+
+            // then
+            assertThat(exists).isFalse
+        }
+    }
+}

--- a/board-system-article-view/article-view-application-output-port/src/test/kotlin/com/ttasjwi/board/system/articleview/domain/port/fixture/ArticleViewCountLockPersistencePortFixtureTest.kt
+++ b/board-system-article-view/article-view-application-output-port/src/test/kotlin/com/ttasjwi/board/system/articleview/domain/port/fixture/ArticleViewCountLockPersistencePortFixtureTest.kt
@@ -1,0 +1,48 @@
+package com.ttasjwi.board.system.articleview.domain.port.fixture
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.time.Duration
+
+@DisplayName("[article-view-application-output-port] ArticleViewCountLockPersistencePortFixture 테스트")
+class ArticleViewCountLockPersistencePortFixtureTest {
+
+    private lateinit var articleViewCountLockPersistencePortFixture: ArticleViewCountLockPersistencePortFixture
+
+    @BeforeEach
+    fun setup() {
+        articleViewCountLockPersistencePortFixture = ArticleViewCountLockPersistencePortFixture()
+    }
+
+
+    @Test
+    @DisplayName("LOCK_USER_ID 에 대해서는 락 획득에 실패")
+    fun test1() {
+        // given
+        val articleId = 1234L
+        val lockUserId = ArticleViewCountLockPersistencePortFixture.LOCK_USER_ID
+
+        // when
+        val getLockSuccess =
+            articleViewCountLockPersistencePortFixture.lock(articleId, lockUserId, Duration.ofMinutes(10))
+
+        // then
+        assertThat(getLockSuccess).isFalse()
+    }
+
+    @Test
+    @DisplayName("LOCK_USER_ID 가 아닐 경우 락 획득에 성공")
+    fun test2() {
+        // given
+        val articleId = 1234L
+        val userId = 21324134L
+
+        // when
+        val getLockSuccess = articleViewCountLockPersistencePortFixture.lock(articleId, userId, Duration.ofMinutes(10))
+
+        // then
+        assertThat(getLockSuccess).isTrue()
+    }
+}

--- a/board-system-article-view/article-view-application-output-port/src/test/kotlin/com/ttasjwi/board/system/articleview/domain/port/fixture/ArticleViewCountPersistencePortFixtureTest.kt
+++ b/board-system-article-view/article-view-application-output-port/src/test/kotlin/com/ttasjwi/board/system/articleview/domain/port/fixture/ArticleViewCountPersistencePortFixtureTest.kt
@@ -1,0 +1,67 @@
+package com.ttasjwi.board.system.articleview.domain.port.fixture
+
+import com.ttasjwi.board.system.articleview.domain.model.fixture.articleViewCountFixture
+import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("[article-view-application-output-port] ArticleViewCountPersistencePortFixture 테스트")
+class ArticleViewCountPersistencePortFixtureTest {
+
+    private lateinit var articleViewCountPersistencePortFixture: ArticleViewCountPersistencePortFixture
+
+    @BeforeEach
+    fun setup() {
+        articleViewCountPersistencePortFixture = ArticleViewCountPersistencePortFixture()
+    }
+
+
+    @Test
+    @DisplayName("조회수 증가 후 게시글 Id로 조회 테스트")
+    fun increaseAndFindByIdOrNullTest() {
+        // given
+        val articleId = 123153L
+        articleViewCountPersistencePortFixture.increase(articleId)
+
+        // when
+        val articleViewCount = articleViewCountPersistencePortFixture.findByIdOrNull(articleId)!!
+
+        // then
+        assertThat(articleViewCount.articleId).isEqualTo(articleId)
+        assertThat(articleViewCount.viewCount).isEqualTo(1)
+    }
+
+
+    @Test
+    @DisplayName("조회수 2회 증가 후 게시글 Id로 조회 테스트")
+    fun doubleIncreaseAndFindByIdOrNullTest() {
+        // given
+        val articleId = 123153L
+        articleViewCountPersistencePortFixture.increase(articleId)
+        articleViewCountPersistencePortFixture.increase(articleId)
+
+        // when
+        val articleViewCount = articleViewCountPersistencePortFixture.findByIdOrNull(articleId)!!
+
+        // then
+        assertThat(articleViewCount.articleId).isEqualTo(articleId)
+        assertThat(articleViewCount.viewCount).isEqualTo(2)
+    }
+
+
+    @Test
+    @DisplayName("조회수가 저장되어 있지않은 게시글 Id로 조회 시 null 반환")
+    fun notFoundTest() {
+        // given
+        val articleId = 12143125L
+
+        // when
+        val articleViewCount = articleViewCountPersistencePortFixture.findByIdOrNull(articleId)
+
+        // then
+        assertThat(articleViewCount).isNull()
+    }
+}

--- a/board-system-article-view/article-view-application-output-port/src/testFixtures/kotlin/com/ttasjwi/board/system/articleview/domain/port/fixture/ArticlePersistencePortFixture.kt
+++ b/board-system-article-view/article-view-application-output-port/src/testFixtures/kotlin/com/ttasjwi/board/system/articleview/domain/port/fixture/ArticlePersistencePortFixture.kt
@@ -1,0 +1,16 @@
+package com.ttasjwi.board.system.articleview.domain.port.fixture
+
+import com.ttasjwi.board.system.articleview.domain.port.ArticlePersistencePort
+
+class ArticlePersistencePortFixture : ArticlePersistencePort {
+
+    private val storage = mutableSetOf<Long>()
+
+    fun save(articleId: Long) {
+        storage.add(articleId)
+    }
+
+    override fun existsById(articleId: Long): Boolean {
+        return storage.contains(articleId)
+    }
+}

--- a/board-system-article-view/article-view-application-output-port/src/testFixtures/kotlin/com/ttasjwi/board/system/articleview/domain/port/fixture/ArticleViewCountLockPersistencePortFixture.kt
+++ b/board-system-article-view/article-view-application-output-port/src/testFixtures/kotlin/com/ttasjwi/board/system/articleview/domain/port/fixture/ArticleViewCountLockPersistencePortFixture.kt
@@ -1,0 +1,15 @@
+package com.ttasjwi.board.system.articleview.domain.port.fixture
+
+import com.ttasjwi.board.system.articleview.domain.port.ArticleViewCountLockPersistencePort
+import java.time.Duration
+
+class ArticleViewCountLockPersistencePortFixture : ArticleViewCountLockPersistencePort {
+
+    companion object {
+        const val LOCK_USER_ID = 134513513251531L
+    }
+
+    override fun lock(articleId: Long, userId: Long, ttl: Duration): Boolean {
+        return userId != LOCK_USER_ID
+    }
+}

--- a/board-system-article-view/article-view-application-output-port/src/testFixtures/kotlin/com/ttasjwi/board/system/articleview/domain/port/fixture/ArticleViewCountPersistencePortFixture.kt
+++ b/board-system-article-view/article-view-application-output-port/src/testFixtures/kotlin/com/ttasjwi/board/system/articleview/domain/port/fixture/ArticleViewCountPersistencePortFixture.kt
@@ -1,0 +1,26 @@
+package com.ttasjwi.board.system.articleview.domain.port.fixture
+
+import com.ttasjwi.board.system.articleview.domain.model.ArticleViewCount
+import com.ttasjwi.board.system.articleview.domain.model.fixture.articleViewCountFixture
+import com.ttasjwi.board.system.articleview.domain.port.ArticleViewCountPersistencePort
+
+class ArticleViewCountPersistencePortFixture : ArticleViewCountPersistencePort {
+
+    private val storage = mutableMapOf<Long, Long>()
+
+    override fun increase(articleId: Long) {
+        if (!storage.containsKey(articleId)) {
+            storage[articleId] = 1
+        } else {
+            storage[articleId] = storage[articleId]!! + 1
+        }
+    }
+
+    override fun findByIdOrNull(articleId: Long): ArticleViewCount? {
+        val viewCount = storage[articleId] ?: return null
+        return articleViewCountFixture(
+            articleId = articleId,
+            viewCount = viewCount
+        )
+    }
+}

--- a/board-system-article-view/article-view-application-service/build.gradle.kts
+++ b/board-system-article-view/article-view-application-service/build.gradle.kts
@@ -1,0 +1,20 @@
+allOpen {
+    annotation(
+        "com.ttasjwi.board.system.common.annotation.component.ApplicationProcessor"
+    )
+}
+
+dependencies {
+    implementation("org.springframework:spring-tx")
+    implementation(project(":board-system-common:core"))
+    testImplementation(testFixtures(project(":board-system-common:core")))
+
+    implementation(project(":board-system-article-view:article-view-domain"))
+    testImplementation(testFixtures(project(":board-system-article-view:article-view-domain")))
+
+    implementation(project(":board-system-article-view:article-view-application-input-port"))
+    implementation(project(":board-system-article-view:article-view-application-output-port"))
+    testImplementation(testFixtures(project(":board-system-article-view:article-view-application-output-port")))
+
+    implementation(project(":board-system-common:logger"))
+}

--- a/board-system-article-view/article-view-application-service/src/main/kotlin/com/ttasjwi/board/system/articleview/domain/ArticleViewCountIncreaseUseCaseImpl.kt
+++ b/board-system-article-view/article-view-application-service/src/main/kotlin/com/ttasjwi/board/system/articleview/domain/ArticleViewCountIncreaseUseCaseImpl.kt
@@ -1,0 +1,17 @@
+package com.ttasjwi.board.system.articleview.domain
+
+import com.ttasjwi.board.system.articleview.domain.mapper.ArticleViewCountIncreaseCommandMapper
+import com.ttasjwi.board.system.articleview.domain.processor.ArticleViewCountIncreaseProcessor
+import com.ttasjwi.board.system.common.annotation.component.UseCase
+
+@UseCase
+internal class ArticleViewCountIncreaseUseCaseImpl(
+    private val commandMapper: ArticleViewCountIncreaseCommandMapper,
+    private val processor: ArticleViewCountIncreaseProcessor,
+) : ArticleViewCountIncreaseUseCase {
+
+    override fun increase(articleId: Long) {
+        val command = commandMapper.mapToCommand(articleId)
+        processor.increase(command)
+    }
+}

--- a/board-system-article-view/article-view-application-service/src/main/kotlin/com/ttasjwi/board/system/articleview/domain/command/ArticleViewCountIncreaseCommand.kt
+++ b/board-system-article-view/article-view-application-service/src/main/kotlin/com/ttasjwi/board/system/articleview/domain/command/ArticleViewCountIncreaseCommand.kt
@@ -1,0 +1,8 @@
+package com.ttasjwi.board.system.articleview.domain.command
+
+import com.ttasjwi.board.system.common.auth.AuthUser
+
+internal data class ArticleViewCountIncreaseCommand(
+    val articleId: Long,
+    val user: AuthUser,
+)

--- a/board-system-article-view/article-view-application-service/src/main/kotlin/com/ttasjwi/board/system/articleview/domain/mapper/ArticleViewCountIncreaseCommandMapper.kt
+++ b/board-system-article-view/article-view-application-service/src/main/kotlin/com/ttasjwi/board/system/articleview/domain/mapper/ArticleViewCountIncreaseCommandMapper.kt
@@ -1,0 +1,18 @@
+package com.ttasjwi.board.system.articleview.domain.mapper
+
+import com.ttasjwi.board.system.articleview.domain.command.ArticleViewCountIncreaseCommand
+import com.ttasjwi.board.system.common.annotation.component.ApplicationCommandMapper
+import com.ttasjwi.board.system.common.auth.AuthUserLoader
+
+@ApplicationCommandMapper
+internal class ArticleViewCountIncreaseCommandMapper(
+    private val authUserLoader: AuthUserLoader,
+) {
+
+    fun mapToCommand(articleId: Long): ArticleViewCountIncreaseCommand {
+        return ArticleViewCountIncreaseCommand(
+            articleId = articleId,
+            user = authUserLoader.loadCurrentAuthUser()!!,
+        )
+    }
+}

--- a/board-system-article-view/article-view-application-service/src/main/kotlin/com/ttasjwi/board/system/articleview/domain/processor/ArticleViewCountIncreaseProcessor.kt
+++ b/board-system-article-view/article-view-application-service/src/main/kotlin/com/ttasjwi/board/system/articleview/domain/processor/ArticleViewCountIncreaseProcessor.kt
@@ -1,0 +1,40 @@
+package com.ttasjwi.board.system.articleview.domain.processor
+
+import com.ttasjwi.board.system.articleview.domain.command.ArticleViewCountIncreaseCommand
+import com.ttasjwi.board.system.articleview.domain.exception.ArticleNotFoundException
+import com.ttasjwi.board.system.articleview.domain.port.ArticlePersistencePort
+import com.ttasjwi.board.system.articleview.domain.port.ArticleViewCountLockPersistencePort
+import com.ttasjwi.board.system.articleview.domain.port.ArticleViewCountPersistencePort
+import com.ttasjwi.board.system.common.annotation.component.ApplicationProcessor
+import java.time.Duration
+
+@ApplicationProcessor
+internal class ArticleViewCountIncreaseProcessor(
+    private val articlePersistencePort: ArticlePersistencePort,
+    private val articleViewCountLockPersistencePort: ArticleViewCountLockPersistencePort,
+    private val articleViewCountPersistencePort: ArticleViewCountPersistencePort,
+) {
+
+    companion object {
+        private val TTL = Duration.ofMinutes(10)
+    }
+
+    fun increase(command: ArticleViewCountIncreaseCommand) {
+        // 게시글 존재 여부 확인
+        checkArticleExistence(command.articleId)
+
+        // 게시글 조회수 락 획득, 획득 실패시 그냥 반환
+        if (!articleViewCountLockPersistencePort.lock(command.articleId, command.user.userId, TTL)) {
+            return
+        }
+
+        // 게시글 조회수 증가
+        articleViewCountPersistencePort.increase(command.articleId)
+    }
+
+    private fun checkArticleExistence(articleId: Long) {
+        if (!articlePersistencePort.existsById(articleId)) {
+            throw ArticleNotFoundException(articleId = articleId)
+        }
+    }
+}

--- a/board-system-article-view/article-view-application-service/src/test/kotlin/com/ttasjwi/board/system/articleview/domain/ArticleViewCountIncreaseUseCaseImplTest.kt
+++ b/board-system-article-view/article-view-application-service/src/test/kotlin/com/ttasjwi/board/system/articleview/domain/ArticleViewCountIncreaseUseCaseImplTest.kt
@@ -1,0 +1,54 @@
+package com.ttasjwi.board.system.articleview.domain
+
+import com.ttasjwi.board.system.articleview.domain.command.ArticleViewCountIncreaseCommand
+import com.ttasjwi.board.system.articleview.domain.port.fixture.ArticlePersistencePortFixture
+import com.ttasjwi.board.system.articleview.domain.port.fixture.ArticleViewCountPersistencePortFixture
+import com.ttasjwi.board.system.articleview.domain.processor.ArticleViewCountIncreaseProcessor
+import com.ttasjwi.board.system.articleview.domain.test.support.TestContainer
+import com.ttasjwi.board.system.common.auth.AuthUser
+import com.ttasjwi.board.system.common.auth.Role
+import com.ttasjwi.board.system.common.auth.fixture.authUserFixture
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("[article-view-application-service] ArticleViewCountIncreaseUseCaseImpl 테스트")
+class ArticleViewCountIncreaseUseCaseImplTest {
+
+    private lateinit var articleViewCountIncreaseUseCase: ArticleViewCountIncreaseUseCase
+    private lateinit var authUser: AuthUser
+    private lateinit var articlePersistencePortFixture: ArticlePersistencePortFixture
+    private lateinit var articleViewCountPersistencePortFixture: ArticleViewCountPersistencePortFixture
+
+
+    @BeforeEach
+    fun setup() {
+        val container = TestContainer.create()
+        articleViewCountIncreaseUseCase = container.articleViewCountIncreaseUseCase
+
+        authUser = authUserFixture(userId = 3336L, role = Role.USER)
+        container.authUserLoaderFixture.changeAuthUser(authUser)
+
+        articlePersistencePortFixture = container.articlePersistencePortFixture
+        articleViewCountPersistencePortFixture = container.articleViewCountPersistencePortFixture
+    }
+
+    @Test
+    @DisplayName("성공테스트 - 락 획득에 성공한 경우")
+    fun testSuccess() {
+        // given
+        val articleId = 13L
+        articlePersistencePortFixture.save(articleId)
+        articleViewCountPersistencePortFixture.increase(articleId)
+
+        // when
+        articleViewCountIncreaseUseCase.increase(articleId)
+
+        // then
+        val articleViewCount = articleViewCountPersistencePortFixture.findByIdOrNull(articleId)!!
+        assertThat(articleViewCount.articleId).isEqualTo(articleId)
+        assertThat(articleViewCount.viewCount).isEqualTo(2L)
+    }
+
+}

--- a/board-system-article-view/article-view-application-service/src/test/kotlin/com/ttasjwi/board/system/articleview/domain/mapper/ArticleViewCountIncreaseCommandMapperTest.kt
+++ b/board-system-article-view/article-view-application-service/src/test/kotlin/com/ttasjwi/board/system/articleview/domain/mapper/ArticleViewCountIncreaseCommandMapperTest.kt
@@ -1,0 +1,40 @@
+package com.ttasjwi.board.system.articleview.domain.mapper
+
+import com.ttasjwi.board.system.articleview.domain.test.support.TestContainer
+import com.ttasjwi.board.system.common.auth.AuthUser
+import com.ttasjwi.board.system.common.auth.Role
+import com.ttasjwi.board.system.common.auth.fixture.authUserFixture
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("[article-view-application-service] ArticleViewCountIncreaseCommandMapper 테스트")
+class ArticleViewCountIncreaseCommandMapperTest {
+
+    private lateinit var articleViewCountIncreaseCommandMapper: ArticleViewCountIncreaseCommandMapper
+    private lateinit var authUser: AuthUser
+
+    @BeforeEach
+    fun setup() {
+        val container = TestContainer.create()
+        articleViewCountIncreaseCommandMapper = container.articleViewCountIncreaseCommandMapper
+
+        authUser = authUserFixture(userId = 3336L, role = Role.USER)
+        container.authUserLoaderFixture.changeAuthUser(authUser)
+    }
+
+    @Test
+    @DisplayName("성공 테스트")
+    fun testSuccess() {
+        // given
+        val articleId = 5552L
+
+        // when
+        val command = articleViewCountIncreaseCommandMapper.mapToCommand(articleId)
+
+        // then
+        assertThat(command.articleId).isEqualTo(articleId)
+        assertThat(command.user).isEqualTo(authUser)
+    }
+}

--- a/board-system-article-view/article-view-application-service/src/test/kotlin/com/ttasjwi/board/system/articleview/domain/processor/ArticleViewCountIncreaseProcessorTest.kt
+++ b/board-system-article-view/article-view-application-service/src/test/kotlin/com/ttasjwi/board/system/articleview/domain/processor/ArticleViewCountIncreaseProcessorTest.kt
@@ -1,0 +1,100 @@
+package com.ttasjwi.board.system.articleview.domain.processor
+
+import com.ttasjwi.board.system.articleview.domain.command.ArticleViewCountIncreaseCommand
+import com.ttasjwi.board.system.articleview.domain.exception.ArticleNotFoundException
+import com.ttasjwi.board.system.articleview.domain.port.fixture.ArticlePersistencePortFixture
+import com.ttasjwi.board.system.articleview.domain.port.fixture.ArticleViewCountLockPersistencePortFixture
+import com.ttasjwi.board.system.articleview.domain.port.fixture.ArticleViewCountPersistencePortFixture
+import com.ttasjwi.board.system.articleview.domain.test.support.TestContainer
+import com.ttasjwi.board.system.common.auth.Role
+import com.ttasjwi.board.system.common.auth.fixture.authUserFixture
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+@DisplayName("[article-view-application-service] ArticleViewCountIncreaseProcessor 테스트")
+class ArticleViewCountIncreaseProcessorTest {
+
+    private lateinit var articleViewCountIncreaseProcessor: ArticleViewCountIncreaseProcessor
+
+    private lateinit var articlePersistencePortFixture: ArticlePersistencePortFixture
+
+    private lateinit var articleViewCountPersistencePortFixture: ArticleViewCountPersistencePortFixture
+
+    @BeforeEach
+    fun setup() {
+        val container = TestContainer.create()
+        articleViewCountIncreaseProcessor = container.articleViewCountIncreaseProcessor
+        articlePersistencePortFixture = container.articlePersistencePortFixture
+        articleViewCountPersistencePortFixture = container.articleViewCountPersistencePortFixture
+    }
+
+
+    @Test
+    @DisplayName("성공 - 락 획득 성공한 경우")
+    fun testSuccess1() {
+        // given
+        val articleId = 13L
+        val user = authUserFixture(userId= 12345L, role = Role.USER)
+
+        articlePersistencePortFixture.save(articleId)
+        articleViewCountPersistencePortFixture.increase(articleId)
+
+        val command = ArticleViewCountIncreaseCommand(
+            articleId = articleId,
+            user = user,
+        )
+
+        // when
+        articleViewCountIncreaseProcessor.increase(command)
+
+        // then
+        val articleViewCount = articleViewCountPersistencePortFixture.findByIdOrNull(articleId)!!
+        assertThat(articleViewCount.articleId).isEqualTo(articleId)
+        assertThat(articleViewCount.viewCount).isEqualTo(2L)
+    }
+
+    @Test
+    @DisplayName("성공 - 락 획득 실패한 경우")
+    fun testSuccess2() {
+        // given
+        val articleId = 13L
+        val user = authUserFixture(userId= ArticleViewCountLockPersistencePortFixture.LOCK_USER_ID, role = Role.USER)
+        articlePersistencePortFixture.save(articleId)
+        articleViewCountPersistencePortFixture.increase(articleId)
+
+        val command = ArticleViewCountIncreaseCommand(
+            articleId = articleId,
+            user = user,
+        )
+
+        // when
+        articleViewCountIncreaseProcessor.increase(command)
+
+        // then
+        val articleViewCount = articleViewCountPersistencePortFixture.findByIdOrNull(articleId)!!
+        assertThat(articleViewCount.viewCount).isEqualTo(1L)
+    }
+
+
+    @Test
+    @DisplayName("게시글이 존재하지 않는다면 예외 발생")
+    fun testArticleNotFound() {
+        // given
+        val articleId = 13L
+        val user = authUserFixture(userId= 12345L, role = Role.USER)
+
+        val command = ArticleViewCountIncreaseCommand(
+            articleId = articleId,
+            user = user,
+        )
+
+        val exception = assertThrows<ArticleNotFoundException> {
+            articleViewCountIncreaseProcessor.increase(command)
+        }
+
+        assertThat(exception.args).containsExactly("articleId", articleId)
+    }
+}

--- a/board-system-article-view/article-view-application-service/src/test/kotlin/com/ttasjwi/board/system/articleview/domain/test/support/TestContainer.kt
+++ b/board-system-article-view/article-view-application-service/src/test/kotlin/com/ttasjwi/board/system/articleview/domain/test/support/TestContainer.kt
@@ -1,0 +1,66 @@
+package com.ttasjwi.board.system.articleview.domain.test.support
+
+import com.ttasjwi.board.system.articleview.domain.ArticleViewCountIncreaseUseCase
+import com.ttasjwi.board.system.articleview.domain.ArticleViewCountIncreaseUseCaseImpl
+import com.ttasjwi.board.system.articleview.domain.mapper.ArticleViewCountIncreaseCommandMapper
+import com.ttasjwi.board.system.articleview.domain.port.fixture.ArticlePersistencePortFixture
+import com.ttasjwi.board.system.articleview.domain.port.fixture.ArticleViewCountLockPersistencePortFixture
+import com.ttasjwi.board.system.articleview.domain.port.fixture.ArticleViewCountPersistencePortFixture
+import com.ttasjwi.board.system.articleview.domain.processor.ArticleViewCountIncreaseProcessor
+import com.ttasjwi.board.system.common.auth.fixture.AuthUserLoaderFixture
+import com.ttasjwi.board.system.common.time.fixture.TimeManagerFixture
+
+internal class TestContainer private constructor() {
+
+    companion object {
+
+        fun create(): TestContainer {
+            return TestContainer()
+        }
+    }
+
+    val timeManagerFixture: TimeManagerFixture by lazy {
+        TimeManagerFixture()
+    }
+
+    val authUserLoaderFixture: AuthUserLoaderFixture by lazy {
+        AuthUserLoaderFixture()
+    }
+
+    // port
+    val articlePersistencePortFixture: ArticlePersistencePortFixture by lazy {
+        ArticlePersistencePortFixture()
+    }
+
+    val articleViewCountPersistencePortFixture: ArticleViewCountPersistencePortFixture by lazy {
+        ArticleViewCountPersistencePortFixture()
+    }
+
+    val articleViewCountLockPersistencePortFixture: ArticleViewCountLockPersistencePortFixture by lazy {
+        ArticleViewCountLockPersistencePortFixture()
+    }
+
+    // mapper
+    val articleViewCountIncreaseCommandMapper: ArticleViewCountIncreaseCommandMapper by lazy {
+        ArticleViewCountIncreaseCommandMapper(
+            authUserLoader = authUserLoaderFixture
+        )
+    }
+
+    // processor
+    val articleViewCountIncreaseProcessor : ArticleViewCountIncreaseProcessor by lazy {
+        ArticleViewCountIncreaseProcessor(
+            articlePersistencePort = articlePersistencePortFixture,
+            articleViewCountPersistencePort = articleViewCountPersistencePortFixture,
+            articleViewCountLockPersistencePort = articleViewCountLockPersistencePortFixture,
+        )
+    }
+
+    // useCase
+    val articleViewCountIncreaseUseCase: ArticleViewCountIncreaseUseCase by lazy {
+        ArticleViewCountIncreaseUseCaseImpl(
+            commandMapper = articleViewCountIncreaseCommandMapper,
+            processor = articleViewCountIncreaseProcessor
+        )
+    }
+}

--- a/board-system-article-view/article-view-domain/build.gradle.kts
+++ b/board-system-article-view/article-view-domain/build.gradle.kts
@@ -1,0 +1,4 @@
+dependencies {
+    implementation(project(":board-system-common:core"))
+    testFixturesImplementation(testFixtures(project(":board-system-common:core")))
+}

--- a/board-system-article-view/article-view-domain/src/main/kotlin/com/ttasjwi/board/system/articleview/domain/exception/ArticleNotFoundException.kt
+++ b/board-system-article-view/article-view-domain/src/main/kotlin/com/ttasjwi/board/system/articleview/domain/exception/ArticleNotFoundException.kt
@@ -1,0 +1,14 @@
+package com.ttasjwi.board.system.articleview.domain.exception
+
+import com.ttasjwi.board.system.common.exception.CustomException
+import com.ttasjwi.board.system.common.exception.ErrorStatus
+
+class ArticleNotFoundException(
+    articleId: Long,
+) : CustomException(
+    status = ErrorStatus.NOT_FOUND,
+    code = "Error.ArticleNotFound",
+    source = "articleId",
+    args = listOf("articleId", articleId),
+    debugMessage = "조건에 부합하는 게시글을 찾지 못 했습니다. (articleId = $articleId)",
+)

--- a/board-system-article-view/article-view-domain/src/main/kotlin/com/ttasjwi/board/system/articleview/domain/model/ArticleViewCount.kt
+++ b/board-system-article-view/article-view-domain/src/main/kotlin/com/ttasjwi/board/system/articleview/domain/model/ArticleViewCount.kt
@@ -1,0 +1,23 @@
+package com.ttasjwi.board.system.articleview.domain.model
+
+class ArticleViewCount
+internal constructor(
+    val articleId: Long,
+    val viewCount: Long,
+) {
+
+
+    companion object {
+
+        fun restore(articleId: Long, viewCount: Long): ArticleViewCount {
+            return ArticleViewCount(
+                articleId = articleId,
+                viewCount = viewCount
+            )
+        }
+    }
+
+    override fun toString(): String {
+        return "ArticleViewCount(articleId=$articleId, viewCount=$viewCount)"
+    }
+}

--- a/board-system-article-view/article-view-domain/src/test/kotlin/com/ttasjwi/board/system/articleview/domain/exception/ArticleNotFoundExceptionTest.kt
+++ b/board-system-article-view/article-view-domain/src/test/kotlin/com/ttasjwi/board/system/articleview/domain/exception/ArticleNotFoundExceptionTest.kt
@@ -1,0 +1,25 @@
+package com.ttasjwi.board.system.articleview.domain.exception
+
+import com.ttasjwi.board.system.common.exception.ErrorStatus
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("[article-view-domain] ArticleNotFoundException 테스트")
+class ArticleNotFoundExceptionTest {
+
+    @Test
+    @DisplayName("예외 기본값 테스트")
+    fun test() {
+        val articleId = 12455674599L
+        val exception = ArticleNotFoundException(articleId = articleId)
+
+        assertThat(exception.status).isEqualTo(ErrorStatus.NOT_FOUND)
+        assertThat(exception.code).isEqualTo("Error.ArticleNotFound")
+        assertThat(exception.source).isEqualTo("articleId")
+        assertThat(exception.args).containsExactly("articleId", articleId)
+        assertThat(exception.message).isEqualTo(exception.debugMessage)
+        assertThat(exception.cause).isNull()
+        assertThat(exception.debugMessage).isEqualTo("조건에 부합하는 게시글을 찾지 못 했습니다. (articleId = $articleId)")
+    }
+}

--- a/board-system-article-view/article-view-domain/src/test/kotlin/com/ttasjwi/board/system/articleview/domain/model/ArticleViewCountTest.kt
+++ b/board-system-article-view/article-view-domain/src/test/kotlin/com/ttasjwi/board/system/articleview/domain/model/ArticleViewCountTest.kt
@@ -1,0 +1,44 @@
+package com.ttasjwi.board.system.articleview.domain.model
+
+import com.ttasjwi.board.system.articleview.domain.model.fixture.articleViewCountFixture
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("[article-view-domain] ArticleViewCount 테스트")
+class ArticleViewCountTest {
+
+    @Test
+    @DisplayName("restore: 값으로 부터 복원")
+    fun restoreTest() {
+        // given
+        val articleId = 12243414L
+        val viewCount = 1314L
+
+        // when
+        val articleViewCount = ArticleViewCount.restore(
+            articleId = articleId,
+            viewCount = viewCount,
+        )
+
+        // then
+        assertThat(articleViewCount.articleId).isEqualTo(articleId)
+        assertThat(articleViewCount.viewCount).isEqualTo(viewCount)
+    }
+
+    @Test
+    @DisplayName("toString(): 디버깅용 문자열 반환")
+    fun toStringTest() {
+        // given
+        val articleId = 12243414L
+        val viewCount = 1314L
+
+        // when
+        val articleViewCount = articleViewCountFixture(
+            articleId = articleId,
+            viewCount = viewCount,
+        )
+
+        assertThat(articleViewCount.toString()).isEqualTo("ArticleViewCount(articleId=$articleId, viewCount=$viewCount)")
+    }
+}

--- a/board-system-article-view/article-view-domain/src/test/kotlin/com/ttasjwi/board/system/articleview/domain/model/fixture/ArticleViewCountFixtureTest.kt
+++ b/board-system-article-view/article-view-domain/src/test/kotlin/com/ttasjwi/board/system/articleview/domain/model/fixture/ArticleViewCountFixtureTest.kt
@@ -1,0 +1,33 @@
+package com.ttasjwi.board.system.articleview.domain.model.fixture
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("[article-view-domain] ArticleViewCountFixture 테스트")
+class ArticleViewCountFixtureTest {
+
+    @Test
+    @DisplayName("인자 없이 생성해도 기본값을 가진다.")
+    fun test1() {
+        val articleViewCount = articleViewCountFixture()
+
+        assertThat(articleViewCount.articleId).isNotNull()
+        assertThat(articleViewCount.viewCount).isNotNull()
+    }
+
+    @Test
+    @DisplayName("커스텀하게 인자를 지정할 수 있다.")
+    fun test2() {
+        val articleId = 14578L
+        val viewCount = 2314558888L
+
+        val articleViewCount = articleViewCountFixture(
+            articleId = articleId,
+            viewCount = viewCount,
+        )
+
+        assertThat(articleViewCount.articleId).isEqualTo(articleId)
+        assertThat(articleViewCount.viewCount).isEqualTo(viewCount)
+    }
+}

--- a/board-system-article-view/article-view-domain/src/testFixtures/kotlin/com/ttasjwi/board/system/articleview/domain/model/fixture/ArticleViewCountFixture.kt
+++ b/board-system-article-view/article-view-domain/src/testFixtures/kotlin/com/ttasjwi/board/system/articleview/domain/model/fixture/ArticleViewCountFixture.kt
@@ -1,0 +1,13 @@
+package com.ttasjwi.board.system.articleview.domain.model.fixture
+
+import com.ttasjwi.board.system.articleview.domain.model.ArticleViewCount
+
+fun articleViewCountFixture(
+    articleId: Long = 1L,
+    viewCount: Long = 0L
+): ArticleViewCount {
+   return ArticleViewCount(
+       articleId = articleId,
+       viewCount = viewCount
+   )
+}

--- a/board-system-article-view/article-view-web-adapter/build.gradle.kts
+++ b/board-system-article-view/article-view-web-adapter/build.gradle.kts
@@ -1,0 +1,10 @@
+dependencies {
+    implementation(Dependencies.SPRING_BOOT_WEB.fullName)
+    implementation(project(":board-system-common:core"))
+    implementation(project(":board-system-article-view:article-view-application-input-port"))
+
+    testImplementation(Dependencies.SPRING_BOOT_SECURITY.fullName)
+    testImplementation(project(":board-system-test:restdocs-support"))
+    testImplementation("com.ninja-squad:springmockk:4.0.2")
+    testImplementation("org.springframework.boot:spring-boot-starter-aop")
+}

--- a/board-system-article-view/article-view-web-adapter/src/main/kotlin/com/ttasjwi/board/system/articleview/api/ArticleViewCountIncreaseController.kt
+++ b/board-system-article-view/article-view-web-adapter/src/main/kotlin/com/ttasjwi/board/system/articleview/api/ArticleViewCountIncreaseController.kt
@@ -1,0 +1,19 @@
+package com.ttasjwi.board.system.articleview.api
+
+import com.ttasjwi.board.system.articleview.domain.ArticleViewCountIncreaseUseCase
+import com.ttasjwi.board.system.common.annotation.auth.RequireAuthenticated
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class ArticleViewCountIncreaseController(
+    private val articleViewCountIncreaseUseCase: ArticleViewCountIncreaseUseCase
+) {
+
+    @RequireAuthenticated
+    @PostMapping("/api/v1/articles/{articleId}/views")
+    fun increaseViewCount(@PathVariable articleId: Long) {
+        articleViewCountIncreaseUseCase.increase(articleId)
+    }
+}

--- a/board-system-article-view/article-view-web-adapter/src/test/kotlin/com/ttasjwi/board/system/articleview/ArticleViewWebAdapterTestApplication.kt
+++ b/board-system-article-view/article-view-web-adapter/src/test/kotlin/com/ttasjwi/board/system/articleview/ArticleViewWebAdapterTestApplication.kt
@@ -1,0 +1,12 @@
+package com.ttasjwi.board.system.articleview
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+@SpringBootApplication
+class ArticleViewWebAdapterTestApplication
+
+fun main(args: Array<String>) {
+    runApplication<ArticleViewWebAdapterTestApplication>(*args)
+}
+

--- a/board-system-article-view/article-view-web-adapter/src/test/kotlin/com/ttasjwi/board/system/articleview/api/ArticleViewCountIncreaseControllerTest.kt
+++ b/board-system-article-view/article-view-web-adapter/src/test/kotlin/com/ttasjwi/board/system/articleview/api/ArticleViewCountIncreaseControllerTest.kt
@@ -1,0 +1,84 @@
+package com.ttasjwi.board.system.articleview.api
+
+import com.ninjasquad.springmockk.MockkBean
+import com.ttasjwi.board.system.articleview.domain.ArticleViewCountIncreaseUseCase
+import com.ttasjwi.board.system.articleview.test.base.ArticleViewRestDocsTest
+import com.ttasjwi.board.system.common.auth.Role
+import com.ttasjwi.board.system.common.time.fixture.appDateTimeFixture
+import com.ttasjwi.board.system.test.util.*
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.verify
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.request
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@WebMvcTest(ArticleViewCountIncreaseController::class)
+@DisplayName("[article-view-web-adapter] ArticleViewCountIncreaseController 테스트")
+class ArticleViewCountIncreaseControllerTest : ArticleViewRestDocsTest() {
+
+    @MockkBean
+    private lateinit var articleViewCountIncreaseUseCase: ArticleViewCountIncreaseUseCase
+
+    @Test
+    @DisplayName("성공 테스트")
+    fun testSuccess() {
+        // given
+        val urlPattern = "/api/v1/articles/{articleId}/views"
+        val articleId = 134L
+        val accessToken = generateAccessToken(
+            userId = 1557,
+            role = Role.USER,
+            issuedAt = appDateTimeFixture(),
+            expiresAt = appDateTimeFixture(minute = 30)
+        )
+        val currentTime = appDateTimeFixture(minute = 18)
+        changeCurrentTime(currentTime)
+
+        every { articleViewCountIncreaseUseCase.increase(articleId) } just Runs
+
+        mockMvc
+            .perform(
+                request(HttpMethod.POST, urlPattern, articleId)
+                    .header("Authorization", "Bearer ${accessToken.tokenValue}")
+            )
+            .andExpectAll(
+                status().isOk,
+            )
+            .andDocument(
+                identifier = "article-view-count-increase-success",
+                requestHeaders(
+                    HttpHeaders.AUTHORIZATION
+                            headerMeans "인증에 필요한 토큰('Bearer [액세스토큰]' 형태)"
+                            example "Bearer 액세스토큰",
+                ),
+                pathParameters(
+                    "articleId"
+                            paramMeans "게시글 식별자"
+                            constraint "실제 게시글이 존재해야함."
+                ),
+            )
+        verify(exactly = 1) { articleViewCountIncreaseUseCase.increase(articleId) }
+    }
+
+    @Test
+    @DisplayName("미인증 사용자는 좋아요할 수 없다.")
+    fun testUnauthenticated() {
+        // given
+        val urlPattern = "/api/v1/articles/{articleId}/views"
+        val articleId = 134L
+
+        mockMvc
+            .perform(
+                request(HttpMethod.POST, urlPattern, articleId)
+            )
+            .andExpectAll(
+                status().isUnauthorized,
+            )
+    }
+}

--- a/board-system-article-view/article-view-web-adapter/src/test/kotlin/com/ttasjwi/board/system/articleview/test/base/ArticleViewRestDocsTest.kt
+++ b/board-system-article-view/article-view-web-adapter/src/test/kotlin/com/ttasjwi/board/system/articleview/test/base/ArticleViewRestDocsTest.kt
@@ -1,0 +1,8 @@
+package com.ttasjwi.board.system.articleview.test.base
+
+import com.ttasjwi.board.system.articleview.test.config.ArticleViewRestDocsTestConfig
+import com.ttasjwi.board.system.test.base.RestDocsTest
+import org.springframework.context.annotation.Import
+
+@Import(ArticleViewRestDocsTestConfig::class)
+abstract class ArticleViewRestDocsTest : RestDocsTest()

--- a/board-system-article-view/article-view-web-adapter/src/test/kotlin/com/ttasjwi/board/system/articleview/test/config/ArticleViewRestDocsTestConfig.kt
+++ b/board-system-article-view/article-view-web-adapter/src/test/kotlin/com/ttasjwi/board/system/articleview/test/config/ArticleViewRestDocsTestConfig.kt
@@ -1,0 +1,25 @@
+package com.ttasjwi.board.system.articleview.test.config
+
+import com.ttasjwi.board.system.common.infra.websupport.auth.config.CoreSecurityDsl
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.invoke
+import org.springframework.security.web.SecurityFilterChain
+
+@TestConfiguration
+class ArticleViewRestDocsTestConfig(
+    private val coreSecurityDsl: CoreSecurityDsl,
+) {
+
+    @Bean
+    fun testSecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
+        coreSecurityDsl.apply(http)
+        http {
+            authorizeHttpRequests {
+                authorize(anyRequest, permitAll)
+            }
+        }
+        return http.build()
+    }
+}

--- a/board-system-infrastructure/database-adapter/build.gradle.kts
+++ b/board-system-infrastructure/database-adapter/build.gradle.kts
@@ -34,4 +34,9 @@ dependencies {
     implementation(project(":board-system-article-like:article-like-domain"))
     testImplementation(testFixtures(project(":board-system-article-like:article-like-domain")))
     implementation(project(":board-system-article-like:article-like-application-output-port"))
+
+    // article-view
+    implementation(project(":board-system-article-view:article-view-domain"))
+    testImplementation(testFixtures(project(":board-system-article-view:article-view-domain")))
+    implementation(project(":board-system-article-view:article-view-application-output-port"))
 }

--- a/board-system-infrastructure/database-adapter/src/main/kotlin/com/ttasjwi/board/system/articleview/infra/persistence/ArticlePersistenceAdapter.kt
+++ b/board-system-infrastructure/database-adapter/src/main/kotlin/com/ttasjwi/board/system/articleview/infra/persistence/ArticlePersistenceAdapter.kt
@@ -1,0 +1,15 @@
+package com.ttasjwi.board.system.articleview.infra.persistence
+
+import com.ttasjwi.board.system.articleview.domain.port.ArticlePersistencePort
+import com.ttasjwi.board.system.articleview.infra.persistence.jpa.JpaArticleRepository
+import org.springframework.stereotype.Component
+
+@Component("articleViewArticlePersistenceAdapter")
+class ArticlePersistenceAdapter(
+    private val jpaArticleRepository: JpaArticleRepository
+): ArticlePersistencePort {
+
+    override fun existsById(articleId: Long): Boolean {
+        return jpaArticleRepository.existsById(articleId)
+    }
+}

--- a/board-system-infrastructure/database-adapter/src/main/kotlin/com/ttasjwi/board/system/articleview/infra/persistence/jpa/JpaArticle.kt
+++ b/board-system-infrastructure/database-adapter/src/main/kotlin/com/ttasjwi/board/system/articleview/infra/persistence/jpa/JpaArticle.kt
@@ -1,0 +1,39 @@
+package com.ttasjwi.board.system.articleview.infra.persistence.jpa
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity(name = "ArticleViewJpaArticle")
+@Table(name = "articles")
+class JpaArticle(
+    @Id
+    @Column(name = "article_id")
+    val articleId: Long,
+
+    @Column(name = "title")
+    val title: String,
+
+    @Column(name = "content")
+    val content: String,
+
+    @Column(name = "board_id")
+    val boardId: Long,
+
+    @Column(name = "article_category_id")
+    var articleCategoryId: Long,
+
+    @Column(name = "writer_id")
+    val writerId: Long,
+
+    @Column(name = "writer_nickname")
+    val writerNickname: String,
+
+    @Column(name = "created_at")
+    val createdAt: LocalDateTime,
+
+    @Column(name = "modified_at")
+    val modifiedAt: LocalDateTime
+)

--- a/board-system-infrastructure/database-adapter/src/main/kotlin/com/ttasjwi/board/system/articleview/infra/persistence/jpa/JpaArticleRepository.kt
+++ b/board-system-infrastructure/database-adapter/src/main/kotlin/com/ttasjwi/board/system/articleview/infra/persistence/jpa/JpaArticleRepository.kt
@@ -1,0 +1,7 @@
+package com.ttasjwi.board.system.articleview.infra.persistence.jpa
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository("articleViewJpaArticleRepository")
+interface JpaArticleRepository : JpaRepository<JpaArticle, Long>

--- a/board-system-infrastructure/database-adapter/src/test/kotlin/com/ttasjwi/board/system/articleview/infra/persistence/ArticlePersistenceAdapterTest.kt
+++ b/board-system-infrastructure/database-adapter/src/test/kotlin/com/ttasjwi/board/system/articleview/infra/persistence/ArticlePersistenceAdapterTest.kt
@@ -1,0 +1,57 @@
+package com.ttasjwi.board.system.articleview.infra.persistence
+
+import com.ttasjwi.board.system.articleview.infra.persistence.jpa.JpaArticle
+import com.ttasjwi.board.system.common.time.fixture.appDateTimeFixture
+import com.ttasjwi.board.system.test.DataBaseIntegrationTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("[article-view-database-adapter] ArticlePersistenceAdapter 테스트")
+class ArticlePersistenceAdapterTest : DataBaseIntegrationTest() {
+
+    @Nested
+    @DisplayName("existsById : articleId 값으로 게시글 존재여부 확인")
+    inner class ExistsByIdTest {
+
+        @Test
+        @DisplayName("존재하면 true 반환")
+        fun test1() {
+            // given
+            val article = JpaArticle(
+                articleId = 123L,
+                articleCategoryId = 13445L,
+                title = "제목",
+                content = "본문",
+                boardId = 1234L,
+                writerId = 122L,
+                writerNickname = "땃쥐",
+                createdAt = appDateTimeFixture().toLocalDateTime(),
+                modifiedAt = appDateTimeFixture().toLocalDateTime(),
+            )
+            entityManager.persist(article)
+            flushAndClearEntityManager()
+
+            // when
+            val exists = articleViewArticlePersistenceAdapter.existsById(article.articleId)
+
+            // then
+            assertThat(exists).isTrue()
+        }
+
+
+        @Test
+        @DisplayName("존재하지 않으면 false 반환")
+        fun test2() {
+            // given
+            val articleId = 15555L
+
+            // when
+            // then
+            val exists = articleViewArticlePersistenceAdapter.existsById(articleId)
+
+            assertThat(exists).isFalse()
+        }
+    }
+}

--- a/board-system-infrastructure/database-adapter/src/test/kotlin/com/ttasjwi/board/system/test/DataBaseIntegrationTest.kt
+++ b/board-system-infrastructure/database-adapter/src/test/kotlin/com/ttasjwi/board/system/test/DataBaseIntegrationTest.kt
@@ -61,6 +61,9 @@ abstract class DataBaseIntegrationTest {
     protected lateinit var articleLikeArticlePersistenceAdapter: com.ttasjwi.board.system.articlelike.infra.persistence.ArticlePersistenceAdapter
 
     @Autowired
+    protected lateinit var articleViewArticlePersistenceAdapter: com.ttasjwi.board.system.articleview.infra.persistence.ArticlePersistenceAdapter
+
+    @Autowired
     protected lateinit var entityManager: EntityManager
 
     protected fun flushAndClearEntityManager() {

--- a/board-system-infrastructure/redis-adapter/build.gradle.kts
+++ b/board-system-infrastructure/redis-adapter/build.gradle.kts
@@ -17,4 +17,9 @@ dependencies {
     // user-oauth2
     implementation("org.springframework.security:spring-security-oauth2-client")
     implementation("jakarta.servlet:jakarta.servlet-api")
+
+    // article-view
+    implementation(project(":board-system-article-view:article-view-domain"))
+    implementation(project(":board-system-article-view:article-view-application-output-port"))
+    testImplementation(testFixtures(project(":board-system-article-view:article-view-domain")))
 }

--- a/board-system-infrastructure/redis-adapter/src/main/kotlin/com/ttasjwi/board/system/articleview/infra/persistence/ArticleViewCountLockPersistenceAdapter.kt
+++ b/board-system-infrastructure/redis-adapter/src/main/kotlin/com/ttasjwi/board/system/articleview/infra/persistence/ArticleViewCountLockPersistenceAdapter.kt
@@ -1,0 +1,26 @@
+package com.ttasjwi.board.system.articleview.infra.persistence
+
+import com.ttasjwi.board.system.articleview.domain.port.ArticleViewCountLockPersistencePort
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Component
+import java.time.Duration
+
+@Component
+class ArticleViewCountLockPersistenceAdapter(
+    private val redisTemplate: StringRedisTemplate
+) : ArticleViewCountLockPersistencePort {
+
+    companion object {
+        private const val KEY_PATTERN = "board-system::article-view::article::%s::user::%s::lock"
+        private const val LOCK_VALUE = ""
+    }
+
+    override fun lock(articleId: Long, userId: Long, ttl: Duration): Boolean {
+        val key = generateKey(articleId, userId)
+        return redisTemplate.opsForValue().setIfAbsent(key, LOCK_VALUE, ttl)!!
+    }
+
+    private fun generateKey(articleId: Long, userId: Long): String {
+        return KEY_PATTERN.format(articleId, userId)
+    }
+}

--- a/board-system-infrastructure/redis-adapter/src/main/kotlin/com/ttasjwi/board/system/articleview/infra/persistence/ArticleViewCountPersistenceAdapter.kt
+++ b/board-system-infrastructure/redis-adapter/src/main/kotlin/com/ttasjwi/board/system/articleview/infra/persistence/ArticleViewCountPersistenceAdapter.kt
@@ -1,0 +1,35 @@
+package com.ttasjwi.board.system.articleview.infra.persistence
+
+import com.ttasjwi.board.system.articleview.domain.model.ArticleViewCount
+import com.ttasjwi.board.system.articleview.domain.port.ArticleViewCountPersistencePort
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Component
+
+@Component
+class ArticleViewCountPersistenceAdapter(
+    private val redisTemplate: StringRedisTemplate
+) : ArticleViewCountPersistencePort {
+
+    companion object {
+        private const val KEY_PATTERN = "board-system::article-view::article::%s::view-count"
+    }
+
+    override fun increase(articleId: Long) {
+        val key = generateKey(articleId)
+        redisTemplate.opsForValue().increment(key)
+    }
+
+    override fun findByIdOrNull(articleId: Long): ArticleViewCount? {
+        val key = generateKey(articleId)
+        val viewCount = redisTemplate.opsForValue().get(key)?.toLong() ?: return null
+
+        return ArticleViewCount.restore(
+            articleId = articleId,
+            viewCount = viewCount
+        )
+    }
+
+    private fun generateKey(articleId: Long): String {
+        return KEY_PATTERN.format(articleId)
+    }
+}

--- a/board-system-infrastructure/redis-adapter/src/test/kotlin/com/ttasjwi/board/system/articleview/infra/persistence/ArticleViewCountLockPersistenceAdapterTest.kt
+++ b/board-system-infrastructure/redis-adapter/src/test/kotlin/com/ttasjwi/board/system/articleview/infra/persistence/ArticleViewCountLockPersistenceAdapterTest.kt
@@ -1,0 +1,51 @@
+package com.ttasjwi.board.system.articleview.infra.persistence
+
+import com.ttasjwi.board.system.test.RedisAdapterTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.time.Duration
+
+@DisplayName("[article-view-redis-adapter] ArticleViewCountLockPersistenceAdapter 테스트")
+class ArticleViewCountLockPersistenceAdapterTest : RedisAdapterTest() {
+
+    @AfterEach
+    fun tearDown() {
+        val keys = redisTemplate.keys("board-system::article-view::article::*::user::*::lock")
+        if (keys.isNotEmpty()) {
+            redisTemplate.delete(keys)
+        }
+    }
+
+    @Test
+    @DisplayName("이미 동일 사용자가 락을 획득해서, 락 획득에 실패할 경우, False 반환")
+    fun test1() {
+        // given
+        val articleId = 1234L
+        val userId = 123456L
+        val ttl = Duration.ofMinutes(10)
+
+        val firstLockSuccess = articleViewCountLockPersistenceAdapter.lock(articleId, userId, ttl)
+        val secondLockSuccess = articleViewCountLockPersistenceAdapter.lock(articleId, userId, ttl)
+
+        // when
+        assertThat(firstLockSuccess).isTrue
+        assertThat(secondLockSuccess).isFalse
+    }
+
+    @Test
+    @DisplayName("사용자가 락을 획득하지 않았다면 true 반환")
+    fun test2() {
+        // given
+        val articleId = 1234L
+        val userId = 21324134L
+        val ttl = Duration.ofMinutes(10)
+
+        // when
+        val getLockSuccess = articleViewCountLockPersistenceAdapter.lock(articleId, userId, ttl)
+
+        // then
+        assertThat(getLockSuccess).isTrue()
+    }
+}

--- a/board-system-infrastructure/redis-adapter/src/test/kotlin/com/ttasjwi/board/system/articleview/infra/persistence/ArticleViewCountPersistencePortFixtureTest.kt
+++ b/board-system-infrastructure/redis-adapter/src/test/kotlin/com/ttasjwi/board/system/articleview/infra/persistence/ArticleViewCountPersistencePortFixtureTest.kt
@@ -1,0 +1,65 @@
+package com.ttasjwi.board.system.articleview.infra.persistence
+
+import com.ttasjwi.board.system.test.RedisAdapterTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("[article-view-redis-adapter] ArticleViewCountPersistenceAdapter 테스트")
+class ArticleViewCountPersistencePortFixtureTest : RedisAdapterTest() {
+
+    @BeforeEach
+    fun tearDown() {
+        val keys = redisTemplate.keys("board-system::article-view::article::*::view-count")
+        if (keys.isNotEmpty()) {
+            redisTemplate.delete(keys)
+        }
+    }
+
+    @Test
+    @DisplayName("조회수 증가 후 게시글 Id로 조회 테스트")
+    fun increaseAndFindByIdOrNullTest() {
+        // given
+        val articleId = 123153L
+        articleViewCountPersistenceAdapter.increase(articleId)
+
+        // when
+        val articleViewCount = articleViewCountPersistenceAdapter.findByIdOrNull(articleId)!!
+
+        // then
+        assertThat(articleViewCount.articleId).isEqualTo(articleId)
+        assertThat(articleViewCount.viewCount).isEqualTo(1)
+    }
+
+
+    @Test
+    @DisplayName("조회수 2회 증가 후 게시글 Id로 조회 테스트")
+    fun doubleIncreaseAndFindByIdOrNullTest() {
+        // given
+        val articleId = 123153L
+        articleViewCountPersistenceAdapter.increase(articleId)
+        articleViewCountPersistenceAdapter.increase(articleId)
+
+        // when
+        val articleViewCount = articleViewCountPersistenceAdapter.findByIdOrNull(articleId)!!
+
+        // then
+        assertThat(articleViewCount.articleId).isEqualTo(articleId)
+        assertThat(articleViewCount.viewCount).isEqualTo(2)
+    }
+
+
+    @Test
+    @DisplayName("조회수가 저장되어 있지않은 게시글 Id로 조회 시 null 반환")
+    fun notFoundTest() {
+        // given
+        val articleId = 12143125L
+
+        // when
+        val articleViewCount = articleViewCountPersistenceAdapter.findByIdOrNull(articleId)
+
+        // then
+        assertThat(articleViewCount).isNull()
+    }
+}

--- a/board-system-infrastructure/redis-adapter/src/test/kotlin/com/ttasjwi/board/system/test/RedisAdapterTest.kt
+++ b/board-system-infrastructure/redis-adapter/src/test/kotlin/com/ttasjwi/board/system/test/RedisAdapterTest.kt
@@ -1,5 +1,7 @@
 package com.ttasjwi.board.system.test
 
+import com.ttasjwi.board.system.articleview.infra.persistence.ArticleViewCountLockPersistenceAdapter
+import com.ttasjwi.board.system.articleview.infra.persistence.ArticleViewCountPersistenceAdapter
 import com.ttasjwi.board.system.user.infra.persistence.EmailVerificationPersistenceAdapter
 import com.ttasjwi.board.system.user.infra.persistence.OAuth2AuthorizationRequestPersistenceAdapter
 import com.ttasjwi.board.system.user.infra.persistence.RefreshTokenIdPersistenceAdapter
@@ -22,6 +24,12 @@ abstract class RedisAdapterTest {
 
     @Autowired
     protected lateinit var oAuth2AuthorizationRequestPersistenceAdapter: OAuth2AuthorizationRequestPersistenceAdapter
+
+    @Autowired
+    protected lateinit var articleViewCountPersistenceAdapter: ArticleViewCountPersistenceAdapter
+
+    @Autowired
+    protected lateinit var articleViewCountLockPersistenceAdapter: ArticleViewCountLockPersistenceAdapter
 
     @Autowired
     protected lateinit var redisTemplate: StringRedisTemplate

--- a/board-system-infrastructure/redis-adapter/src/test/kotlin/com/ttasjwi/board/system/user/infra/persistence/EmailVerificationPersistenceAdapterTest.kt
+++ b/board-system-infrastructure/redis-adapter/src/test/kotlin/com/ttasjwi/board/system/user/infra/persistence/EmailVerificationPersistenceAdapterTest.kt
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 
-@DisplayName("EmailVerificationPersistenceAdapter 테스트")
+@DisplayName("[user-redis-adapter] EmailVerificationPersistenceAdapter 테스트")
 class EmailVerificationPersistenceAdapterTest : RedisAdapterTest() {
 
     companion object {

--- a/board-system-infrastructure/redis-adapter/src/test/kotlin/com/ttasjwi/board/system/user/infra/persistence/RefreshTokenIdListPersistenceAdapterTest.kt
+++ b/board-system-infrastructure/redis-adapter/src/test/kotlin/com/ttasjwi/board/system/user/infra/persistence/RefreshTokenIdListPersistenceAdapterTest.kt
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 
-@DisplayName("UserRefreshTokenIdListPersistenceAdapter 테스트")
+@DisplayName("[user-redis-adapter] UserRefreshTokenIdListPersistenceAdapter 테스트")
 class RefreshTokenIdListPersistenceAdapterTest : RedisAdapterTest() {
 
     @AfterEach

--- a/board-system-infrastructure/redis-adapter/src/test/kotlin/com/ttasjwi/board/system/user/infra/persistence/RefreshTokenIdPersistenceAdapterTest.kt
+++ b/board-system-infrastructure/redis-adapter/src/test/kotlin/com/ttasjwi/board/system/user/infra/persistence/RefreshTokenIdPersistenceAdapterTest.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 
-@DisplayName("RefreshTokenIdPersistenceAdapterTest")
+@DisplayName("[user-redis-adapter] RefreshTokenIdPersistenceAdapter 테스트")
 class RefreshTokenIdPersistenceAdapterTest : RedisAdapterTest() {
 
     @AfterEach

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -56,6 +56,15 @@ include(
     "board-system-article-like:article-like-application-output-port",
     "board-system-article-like:article-like-domain",
 
+    // article-view ===================================================================================
+    "board-system-article-view",
+    "board-system-article-view:article-view-web-adapter",
+    "board-system-article-view:article-view-batch-adapter",
+    "board-system-article-view:article-view-application-input-port",
+    "board-system-article-view:article-view-application-service",
+    "board-system-article-view:article-view-application-output-port",
+    "board-system-article-view:article-view-domain",
+
     // email-sender ==============================================================================
     "board-system-email-sender",
 


### PR DESCRIPTION
# JIRA 티켓
- [BRD-146]

---

# 개요
- 게시글페이지, 화면에서 특정 트리거에 의해 게시글 조회수 증가 API를 호출하는 식으로 게시글 조회수 증가가 동작한다.
- 다만 어뷰징으로 인해 게시글 조회수가 무한정 늘어나게하는 것은 올바르지 못 하므로
  - 인증된 사용자에 한 해, 10분당 1회 조회수가 1 증가하게 하도록 한다.

# 수동테스트
```text
--------------------------------------------------------------------------
start increase viewCounts : articleId = 38314133141345
time = 21549 ms
start increase viewCounts : articleId = 38314133141345
viewCount = 1
--------------------------------------------------------------------------
```
- 동시에 한 사용자가 1만번 조회수 증가 요청을 하게 해봤고(100개 스레드), 조회수는 1 정도만 증가하는 것을 확인했다.



[BRD-146]: https://ttasjwi.atlassian.net/browse/BRD-146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ