### PR TITLE
Feature: (BRD-148) 게시글 상세 조회 최적화 API 구현

### DIFF
--- a/board-system-app/build.gradle.kts
+++ b/board-system-app/build.gradle.kts
@@ -90,6 +90,7 @@ tasks.register("copySnippets", Copy::class) {
     dependsOn(":board-system-article-comment:article-comment-web-adapter:test")
     dependsOn(":board-system-article-like:article-like-web-adapter:test")
     dependsOn(":board-system-article-view:article-view-web-adapter:test")
+    dependsOn(":board-system-article-read:article-read-web-adapter:test")
 
     from(file("$rootDir/board-system-user/user-web-adapter/build/generated-snippets"))
     from(file("$rootDir/board-system-board/board-web-adapter/build/generated-snippets"))
@@ -97,6 +98,7 @@ tasks.register("copySnippets", Copy::class) {
     from(file("$rootDir/board-system-article-comment/article-comment-web-adapter/build/generated-snippets"))
     from(file("$rootDir/board-system-article-like/article-like-web-adapter/build/generated-snippets"))
     from(file("$rootDir/board-system-article-view/article-view-web-adapter/build/generated-snippets"))
+    from(file("$rootDir/board-system-article-read/article-read-web-adapter/build/generated-snippets"))
     into(file("build/generated-snippets"))
 }
 

--- a/board-system-app/src/docs/asciidoc/article-api.adoc
+++ b/board-system-app/src/docs/asciidoc/article-api.adoc
@@ -20,23 +20,25 @@ include::{snippets}/article-create-success/response-fields.adoc[]
 include::{snippets}/article-create-success/http-request.adoc[]
 include::{snippets}/article-create-success/http-response.adoc[]
 
-=== 게시글 단건 조회
+=== 게시글 단건 상세 조회
 ==== 기본정보
 - 메서드 : GET
-- URL : `/api/v1/articles/{articleId}`
-- 권한 : 누구나
+- URL : `/api/v2/articles/{articleId}`
+- 권한 : 누구나(인증사용자 맞춤정보가 필요한 경우, 액세스토큰 지참)
+- 인증방식 : 액세스 토큰
 
 게시글을 단건 조회합니다.
 
 ==== 요청
-include::{snippets}/article-read-success/path-parameters.adoc[]
+include::{snippets}/article-detail-read-success/request-headers.adoc[]
+include::{snippets}/article-detail-read-success/path-parameters.adoc[]
 
 ==== 응답
-include::{snippets}/article-read-success/response-fields.adoc[]
+include::{snippets}/article-detail-read-success/response-fields.adoc[]
 
 ==== 예시
-include::{snippets}/article-read-success/http-request.adoc[]
-include::{snippets}/article-read-success/http-response.adoc[]
+include::{snippets}/article-detail-read-success/http-request.adoc[]
+include::{snippets}/article-detail-read-success/http-response.adoc[]
 
 === 게시글 목록 조회(페이지)
 ==== 기본정보

--- a/board-system-app/src/main/kotlin/com/ttasjwi/board/system/app/config/ComponentScanConfig.kt
+++ b/board-system-app/src/main/kotlin/com/ttasjwi/board/system/app/config/ComponentScanConfig.kt
@@ -12,6 +12,7 @@ import org.springframework.context.annotation.FilterType
         "com.ttasjwi.board.system.articlecomment",
         "com.ttasjwi.board.system.articlelike",
         "com.ttasjwi.board.system.articleview",
+        "com.ttasjwi.board.system.articleread",
         "com.ttasjwi.board.system.board",
         "com.ttasjwi.board.system.user",
         "com.ttasjwi.board.system.emailsender",

--- a/board-system-article-read/article-read-application-input-port/src/main/kotlin/com/ttasjwi/board/system/articleread/domain/ArticleDetailReadUseCase.kt
+++ b/board-system-article-read/article-read-application-input-port/src/main/kotlin/com/ttasjwi/board/system/articleread/domain/ArticleDetailReadUseCase.kt
@@ -1,0 +1,46 @@
+package com.ttasjwi.board.system.articleread.domain
+
+import java.time.ZonedDateTime
+
+interface ArticleDetailReadUseCase {
+
+    fun read(articleId: Long): ArticleDetailReadResponse
+}
+
+data class ArticleDetailReadResponse(
+    val articleId: String, // 게시글 모듈에서 관리됨 (게시글 테이블)
+    val title: String, // 게시글 모듈에서 관리됨(게시글 테이블)
+    val content: String, // 게시글 모듈에서 관리됨(게시글 테이블)
+    val board: Board, // 게시판 모듈에서 관리됨 (게시판 테이블)
+    val articleCategory: ArticleCategory, // 게시판 모듈에서 관리됨 (게시글 카테고리 테이블)
+    val writer: Writer, // 게시글 모듈에서 관리됨 (게시판 테이블)
+    val viewCount: Long, // 조회수 모듈에서 관리됨 (Redis)
+    val commentCount: Long, // 댓글 모듈에서 관리됨 (게시글 댓글수 테이블)
+    val liked: Boolean, // 좋아요 모듈에서 관리됨 (게시글 좋아요 테이블)
+    val likeCount: Long, // 좋아요 모듈에서 관리됨 (게시글 좋아요수 테이블)
+    val disliked: Boolean, // 좋아요 모듈에서 관리됨 (게시글 싫어요 테이블)
+    val dislikeCount: Long, // 좋아요 모듈에서 관리됨 (게시글 싫어요수 테이블)
+    val createdAt: ZonedDateTime, // 게시글 모듈에서 관리됨 (게시글 테이블)
+    val modifiedAt: ZonedDateTime, // 게시글 모듈에서 관리됨 (게시글 테이블)
+) {
+
+    data class Board(
+        val boardId: String,
+        val name: String,
+        val slug: String,
+    )
+
+    data class ArticleCategory(
+        val articleCategoryId: String,
+        val name: String,
+        val slug: String,
+        val allowSelfDelete: Boolean,
+        val allowLike: Boolean,
+        val allowDislike: Boolean,
+    )
+
+    data class Writer(
+        val writerId: String,
+        val nickname: String, // 작성시점 닉네임
+    )
+}

--- a/board-system-article-read/article-read-application-output-port/build.gradle.kts
+++ b/board-system-article-read/article-read-application-output-port/build.gradle.kts
@@ -1,0 +1,7 @@
+dependencies {
+    implementation(project(":board-system-common:core"))
+    testFixturesImplementation(testFixtures(project(":board-system-common:core")))
+
+    implementation(project(":board-system-article-read:article-read-domain"))
+    testFixturesImplementation(testFixtures(project(":board-system-article-read:article-read-domain")))
+}

--- a/board-system-article-read/article-read-application-output-port/src/main/kotlin/com/ttasjwi/board/system/articleread/domain/port/ArticleDetailStorage.kt
+++ b/board-system-article-read/article-read-application-output-port/src/main/kotlin/com/ttasjwi/board/system/articleread/domain/port/ArticleDetailStorage.kt
@@ -1,0 +1,8 @@
+package com.ttasjwi.board.system.articleread.domain.port
+
+import com.ttasjwi.board.system.articleread.domain.model.ArticleDetail
+
+interface ArticleDetailStorage {
+
+    fun read(articleId: Long, userId: Long?): ArticleDetail?
+}

--- a/board-system-article-read/article-read-application-output-port/src/main/kotlin/com/ttasjwi/board/system/articleread/domain/port/ArticleViewCountStorage.kt
+++ b/board-system-article-read/article-read-application-output-port/src/main/kotlin/com/ttasjwi/board/system/articleread/domain/port/ArticleViewCountStorage.kt
@@ -1,0 +1,6 @@
+package com.ttasjwi.board.system.articleread.domain.port
+
+interface ArticleViewCountStorage {
+
+    fun readViewCount(articleId: Long): Long
+}

--- a/board-system-article-read/article-read-application-output-port/src/test/kotlin/com/ttasjwi/board/system/articleread/domain/port/fixture/ArticleDetailStorageFixtureTest.kt
+++ b/board-system-article-read/article-read-application-output-port/src/test/kotlin/com/ttasjwi/board/system/articleread/domain/port/fixture/ArticleDetailStorageFixtureTest.kt
@@ -1,0 +1,106 @@
+package com.ttasjwi.board.system.articleread.domain.port.fixture
+
+import com.ttasjwi.board.system.articleread.domain.model.fixture.articleDetailFixture
+import com.ttasjwi.board.system.common.time.fixture.appDateTimeFixture
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("[article-read-application-output-port] ArticleDetailStorageFixture 테스트")
+class ArticleDetailStorageFixtureTest {
+
+    private lateinit var articleDetailStorageFixture: ArticleDetailStorageFixture
+
+    @BeforeEach
+    fun setup() {
+        articleDetailStorageFixture = ArticleDetailStorageFixture()
+    }
+
+    @Test
+    @DisplayName("조회 성공 테스트")
+    fun testSuccess() {
+        // given
+        val articleId = 41L
+        val title = "우리 늘봄이 귀엽죠"
+        val content = "너무 귀여워 늘봄이"
+        val articleCategoryId = 25L
+        val articleCategoryName = "사진"
+        val articleCategorySlug = "picture"
+        val articleCategoryAllowSelfDelete = true
+        val articleCategoryAllowLike = true
+        val articleCategoryAllowDislike = false
+        val boardId = 4L
+        val boardName = "고양이"
+        val boardSlug = "cat"
+        val writerId = 9L
+        val writerNickname = "땃쥐"
+        val commentCount = 7L
+        val liked = true
+        val likeCount = 5L
+        val disliked = false
+        val dislikeCount = 0L
+        val createdAt= appDateTimeFixture(minute = 30)
+        val modifiedAt = appDateTimeFixture(minute = 30)
+
+        // when
+        val savedArticleDetail = articleDetailFixture(
+            articleId = articleId,
+            title = title,
+            content = content,
+            articleCategoryId = articleCategoryId,
+            articleCategoryName = articleCategoryName,
+            articleCategorySlug = articleCategorySlug,
+            articleCategoryAllowSelfDelete = articleCategoryAllowSelfDelete,
+            articleCategoryAllowLike = articleCategoryAllowLike,
+            articleCategoryAllowDislike = articleCategoryAllowDislike,
+            boardId = boardId,
+            boardName = boardName,
+            boardSlug = boardSlug,
+            writerId = writerId,
+            writerNickname = writerNickname,
+            commentCount = commentCount,
+            liked = liked,
+            likeCount = likeCount,
+            disliked = disliked,
+            dislikeCount = dislikeCount,
+            createdAt = createdAt,
+            modifiedAt = modifiedAt,
+        )
+        articleDetailStorageFixture.save(savedArticleDetail)
+
+        // when
+        val findArticleDetail = articleDetailStorageFixture.read(savedArticleDetail.articleId, 456L)!!
+
+        // then
+        assertThat(findArticleDetail.articleId).isEqualTo(articleId)
+        assertThat(findArticleDetail.title).isEqualTo(title)
+        assertThat(findArticleDetail.content).isEqualTo(content)
+        assertThat(findArticleDetail.articleCategory.articleCategoryId).isEqualTo(articleCategoryId)
+        assertThat(findArticleDetail.articleCategory.name).isEqualTo(articleCategoryName)
+        assertThat(findArticleDetail.articleCategory.slug).isEqualTo(articleCategorySlug)
+        assertThat(findArticleDetail.articleCategory.allowSelfDelete).isEqualTo(articleCategoryAllowSelfDelete)
+        assertThat(findArticleDetail.articleCategory.allowLike).isEqualTo(articleCategoryAllowLike)
+        assertThat(findArticleDetail.articleCategory.allowDislike).isEqualTo(articleCategoryAllowDislike)
+        assertThat(findArticleDetail.board.boardId).isEqualTo(boardId)
+        assertThat(findArticleDetail.board.name).isEqualTo(boardName)
+        assertThat(findArticleDetail.board.slug).isEqualTo(boardSlug)
+        assertThat(findArticleDetail.writer.writerId).isEqualTo(writerId)
+        assertThat(findArticleDetail.writer.nickname).isEqualTo(writerNickname)
+        assertThat(findArticleDetail.commentCount).isEqualTo(commentCount)
+        assertThat(findArticleDetail.liked).isEqualTo(liked)
+        assertThat(findArticleDetail.likeCount).isEqualTo(likeCount)
+        assertThat(findArticleDetail.disliked).isEqualTo(disliked)
+        assertThat(findArticleDetail.dislikeCount).isEqualTo(dislikeCount)
+        assertThat(findArticleDetail.createdAt).isEqualTo(createdAt)
+        assertThat(findArticleDetail.modifiedAt).isEqualTo(modifiedAt)
+    }
+
+
+    @Test
+    @DisplayName("조회 실패 테스트")
+    fun testNotFound() {
+        val findArticleDetail = articleDetailStorageFixture.read(85747L, 5416L)
+        assertThat(findArticleDetail).isNull()
+    }
+}

--- a/board-system-article-read/article-read-application-output-port/src/test/kotlin/com/ttasjwi/board/system/articleread/domain/port/fixture/ArticleViewCountStorageFixtureTest.kt
+++ b/board-system-article-read/article-read-application-output-port/src/test/kotlin/com/ttasjwi/board/system/articleread/domain/port/fixture/ArticleViewCountStorageFixtureTest.kt
@@ -1,0 +1,47 @@
+package com.ttasjwi.board.system.articleread.domain.port.fixture
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("[article-read-application-output-port] ArticleViewCountStorageFixture 테스트")
+class ArticleViewCountStorageFixtureTest {
+
+    private lateinit var articleViewCountStorageFixture: ArticleViewCountStorageFixture
+
+
+    @BeforeEach
+    fun setup() {
+        articleViewCountStorageFixture = ArticleViewCountStorageFixture()
+    }
+
+    @Test
+    @DisplayName("조회수 저장 후 조회 테스트")
+    fun testSuccess() {
+        // given
+        val articleId = 34L
+        val viewCount = 348L
+
+
+        articleViewCountStorageFixture.save(articleId, viewCount)
+
+        // when
+        val findViewCount = articleViewCountStorageFixture.readViewCount(articleId)
+
+        // then
+        assertThat(findViewCount).isEqualTo(viewCount)
+    }
+
+
+    @Test
+    @DisplayName("조회수가 저장되어 있지 않다면, 조회수 조회 시도시, 0이 반환된다.")
+    fun testNotFound() {
+        // given
+        // when
+        val findViewCount = articleViewCountStorageFixture.readViewCount(131415L)
+
+        // then
+        assertThat(findViewCount).isEqualTo(0L)
+    }
+}

--- a/board-system-article-read/article-read-application-output-port/src/testFixtures/kotlin/com/ttasjwi/board/system/articleread/domain/port/fixture/ArticleDetailStorageFixture.kt
+++ b/board-system-article-read/article-read-application-output-port/src/testFixtures/kotlin/com/ttasjwi/board/system/articleread/domain/port/fixture/ArticleDetailStorageFixture.kt
@@ -1,0 +1,17 @@
+package com.ttasjwi.board.system.articleread.domain.port.fixture
+
+import com.ttasjwi.board.system.articleread.domain.model.ArticleDetail
+import com.ttasjwi.board.system.articleread.domain.port.ArticleDetailStorage
+
+class ArticleDetailStorageFixture : ArticleDetailStorage {
+
+    private val storage = mutableMapOf<Long, ArticleDetail>()
+
+    fun save(articleDetail: ArticleDetail) {
+        storage[articleDetail.articleId] = articleDetail
+    }
+
+    override fun read(articleId: Long, userId: Long?): ArticleDetail? {
+        return storage[articleId]
+    }
+}

--- a/board-system-article-read/article-read-application-output-port/src/testFixtures/kotlin/com/ttasjwi/board/system/articleread/domain/port/fixture/ArticleViewCountStorageFixture.kt
+++ b/board-system-article-read/article-read-application-output-port/src/testFixtures/kotlin/com/ttasjwi/board/system/articleread/domain/port/fixture/ArticleViewCountStorageFixture.kt
@@ -1,0 +1,17 @@
+package com.ttasjwi.board.system.articleread.domain.port.fixture
+
+import com.ttasjwi.board.system.articleread.domain.port.ArticleViewCountStorage
+
+class ArticleViewCountStorageFixture : ArticleViewCountStorage {
+
+
+    private val storage = mutableMapOf<Long, Long>()
+
+    fun save(articleId: Long, viewCount: Long) {
+        storage[articleId] = viewCount
+    }
+
+    override fun readViewCount(articleId: Long): Long {
+        return storage[articleId] ?: return 0L
+    }
+}

--- a/board-system-article-read/article-read-application-service/build.gradle.kts
+++ b/board-system-article-read/article-read-application-service/build.gradle.kts
@@ -1,0 +1,14 @@
+
+dependencies {
+    implementation(project(":board-system-common:core"))
+    testImplementation(testFixtures(project(":board-system-common:core")))
+
+    implementation(project(":board-system-article-read:article-read-domain"))
+    testImplementation(testFixtures(project(":board-system-article-read:article-read-domain")))
+
+    implementation(project(":board-system-article-read:article-read-application-input-port"))
+    implementation(project(":board-system-article-read:article-read-application-output-port"))
+    testImplementation(testFixtures(project(":board-system-article-read:article-read-application-output-port")))
+
+    implementation(project(":board-system-common:logger"))
+}

--- a/board-system-article-read/article-read-application-service/src/main/kotlin/com/ttasjwi/board/system/articleread/domain/ArticleDetailReadUseCaseImpl.kt
+++ b/board-system-article-read/article-read-application-service/src/main/kotlin/com/ttasjwi/board/system/articleread/domain/ArticleDetailReadUseCaseImpl.kt
@@ -1,0 +1,17 @@
+package com.ttasjwi.board.system.articleread.domain
+
+import com.ttasjwi.board.system.articleread.domain.mapper.ArticleDetailReadQueryMapper
+import com.ttasjwi.board.system.articleread.domain.processor.ArticleDetailReadProcessor
+import com.ttasjwi.board.system.common.annotation.component.UseCase
+
+@UseCase
+internal class ArticleDetailReadUseCaseImpl(
+    private val queryMapper: ArticleDetailReadQueryMapper,
+    private val processor: ArticleDetailReadProcessor
+) : ArticleDetailReadUseCase {
+
+    override fun read(articleId: Long): ArticleDetailReadResponse {
+        val query = queryMapper.mapToQuery(articleId)
+        return processor.read(query)
+    }
+}

--- a/board-system-article-read/article-read-application-service/src/main/kotlin/com/ttasjwi/board/system/articleread/domain/dto/ArticleDetailReadQuery.kt
+++ b/board-system-article-read/article-read-application-service/src/main/kotlin/com/ttasjwi/board/system/articleread/domain/dto/ArticleDetailReadQuery.kt
@@ -1,0 +1,8 @@
+package com.ttasjwi.board.system.articleread.domain.dto
+
+import com.ttasjwi.board.system.common.auth.AuthUser
+
+internal data class ArticleDetailReadQuery(
+    val articleId: Long,
+    val authUser: AuthUser?,
+)

--- a/board-system-article-read/article-read-application-service/src/main/kotlin/com/ttasjwi/board/system/articleread/domain/mapper/ArticleDetailReadQueryMapper.kt
+++ b/board-system-article-read/article-read-application-service/src/main/kotlin/com/ttasjwi/board/system/articleread/domain/mapper/ArticleDetailReadQueryMapper.kt
@@ -1,0 +1,18 @@
+package com.ttasjwi.board.system.articleread.domain.mapper
+
+import com.ttasjwi.board.system.articleread.domain.dto.ArticleDetailReadQuery
+import com.ttasjwi.board.system.common.annotation.component.ApplicationQueryMapper
+import com.ttasjwi.board.system.common.auth.AuthUserLoader
+
+@ApplicationQueryMapper
+internal class ArticleDetailReadQueryMapper(
+    private val authUserLoader: AuthUserLoader,
+) {
+
+    fun mapToQuery(articleId: Long): ArticleDetailReadQuery {
+        return ArticleDetailReadQuery(
+            articleId = articleId,
+            authUser = authUserLoader.loadCurrentAuthUser()
+        )
+    }
+}

--- a/board-system-article-read/article-read-application-service/src/main/kotlin/com/ttasjwi/board/system/articleread/domain/processor/ArticleDetailReadProcessor.kt
+++ b/board-system-article-read/article-read-application-service/src/main/kotlin/com/ttasjwi/board/system/articleread/domain/processor/ArticleDetailReadProcessor.kt
@@ -1,0 +1,58 @@
+package com.ttasjwi.board.system.articleread.domain.processor
+
+import com.ttasjwi.board.system.articleread.domain.ArticleDetailReadResponse
+import com.ttasjwi.board.system.articleread.domain.dto.ArticleDetailReadQuery
+import com.ttasjwi.board.system.articleread.domain.exception.ArticleNotFoundException
+import com.ttasjwi.board.system.articleread.domain.model.ArticleDetail
+import com.ttasjwi.board.system.articleread.domain.port.ArticleDetailStorage
+import com.ttasjwi.board.system.articleread.domain.port.ArticleViewCountStorage
+import com.ttasjwi.board.system.common.annotation.component.ApplicationProcessor
+
+@ApplicationProcessor
+internal class ArticleDetailReadProcessor(
+    private val articleDetailStorage: ArticleDetailStorage,
+    private val articleViewCountStorage: ArticleViewCountStorage,
+) {
+
+    fun read(query: ArticleDetailReadQuery): ArticleDetailReadResponse {
+        val articleDetail = articleDetailStorage.read(query.articleId, query.authUser?.userId)
+            ?: throw ArticleNotFoundException(query.articleId)
+
+        val viewCount = articleViewCountStorage.readViewCount(query.articleId)
+
+        return makeResponse(articleDetail, viewCount)
+    }
+
+    private fun makeResponse(articleDetail: ArticleDetail, articleViewCount: Long): ArticleDetailReadResponse {
+        return ArticleDetailReadResponse(
+            articleId = articleDetail.articleId.toString(),
+            title = articleDetail.title,
+            content = articleDetail.content,
+            board = ArticleDetailReadResponse.Board(
+                boardId = articleDetail.board.boardId.toString(),
+                name = articleDetail.board.name,
+                slug = articleDetail.board.slug,
+            ),
+            articleCategory = ArticleDetailReadResponse.ArticleCategory(
+                articleCategoryId = articleDetail.articleCategory.articleCategoryId.toString(),
+                name = articleDetail.articleCategory.name,
+                slug = articleDetail.articleCategory.slug,
+                allowSelfDelete = articleDetail.articleCategory.allowSelfDelete,
+                allowLike = articleDetail.articleCategory.allowLike,
+                allowDislike = articleDetail.articleCategory.allowDislike,
+            ),
+            writer = ArticleDetailReadResponse.Writer(
+                writerId = articleDetail.writer.writerId.toString(),
+                nickname = articleDetail.writer.nickname,
+            ),
+            viewCount = articleViewCount,
+            commentCount = articleDetail.commentCount,
+            liked = articleDetail.liked,
+            likeCount = articleDetail.likeCount,
+            disliked = articleDetail.disliked,
+            dislikeCount = articleDetail.dislikeCount,
+            createdAt = articleDetail.createdAt.toZonedDateTime(),
+            modifiedAt = articleDetail.modifiedAt.toZonedDateTime()
+        )
+    }
+}

--- a/board-system-article-read/article-read-application-service/src/test/kotlin/com/ttasjwi/board/system/articleread/domain/ArticleDetailReadUseCaseImplTest.kt
+++ b/board-system-article-read/article-read-application-service/src/test/kotlin/com/ttasjwi/board/system/articleread/domain/ArticleDetailReadUseCaseImplTest.kt
@@ -1,0 +1,75 @@
+package com.ttasjwi.board.system.articleread.domain
+
+import com.ttasjwi.board.system.articleread.domain.model.fixture.articleDetailFixture
+import com.ttasjwi.board.system.articleread.domain.port.fixture.ArticleDetailStorageFixture
+import com.ttasjwi.board.system.articleread.domain.port.fixture.ArticleViewCountStorageFixture
+import com.ttasjwi.board.system.articleread.domain.test.support.TestContainer
+import com.ttasjwi.board.system.common.auth.Role
+import com.ttasjwi.board.system.common.auth.fixture.AuthUserLoaderFixture
+import com.ttasjwi.board.system.common.auth.fixture.authUserFixture
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("[article-read-application-service] ArticleDetailReadUseCaseImpl 테스트")
+class ArticleDetailReadUseCaseImplTest {
+
+    private lateinit var articleDetailReadUseCase: ArticleDetailReadUseCase
+    private lateinit var authUserLoaderFixture: AuthUserLoaderFixture
+    private lateinit var articleDetailStorageFixture: ArticleDetailStorageFixture
+    private lateinit var articleViewCountStorageFixture: ArticleViewCountStorageFixture
+
+    @BeforeEach
+    fun setUp() {
+        val container = TestContainer.create()
+        articleDetailReadUseCase = container.articleDetailReadUseCase
+
+        authUserLoaderFixture = container.authUserLoaderFixture
+        articleDetailStorageFixture = container.articleDetailStorageFixture
+        articleViewCountStorageFixture = container.articleViewCountStorageFixture
+    }
+
+
+    @Test
+    @DisplayName("성공 테스트")
+    fun testSuccess() {
+        // given
+        val articleId = 13455L
+        val authUser = authUserFixture(userId = 34L, role = Role.USER)
+        authUserLoaderFixture.changeAuthUser(authUser)
+
+        val articleDetail = articleDetailFixture(articleId = articleId)
+        articleDetailStorageFixture.save(articleDetail)
+
+        val viewCount = 8L
+        articleViewCountStorageFixture.save(articleId, viewCount)
+
+        // when
+        val response = articleDetailReadUseCase.read(articleId)
+
+        // then
+        assertThat(response.articleId).isEqualTo(articleId.toString())
+        assertThat(response.title).isEqualTo(articleDetail.title)
+        assertThat(response.content).isEqualTo(articleDetail.content)
+        assertThat(response.board.boardId).isEqualTo(articleDetail.board.boardId.toString())
+        assertThat(response.board.name).isEqualTo(articleDetail.board.name)
+        assertThat(response.board.slug).isEqualTo(articleDetail.board.slug)
+        assertThat(response.articleCategory.articleCategoryId).isEqualTo(articleDetail.articleCategory.articleCategoryId.toString())
+        assertThat(response.articleCategory.name).isEqualTo(articleDetail.articleCategory.name)
+        assertThat(response.articleCategory.slug).isEqualTo(articleDetail.articleCategory.slug)
+        assertThat(response.articleCategory.allowSelfDelete).isEqualTo(articleDetail.articleCategory.allowSelfDelete)
+        assertThat(response.articleCategory.allowLike).isEqualTo(articleDetail.articleCategory.allowLike)
+        assertThat(response.articleCategory.allowDislike).isEqualTo(articleDetail.articleCategory.allowDislike)
+        assertThat(response.writer.writerId).isEqualTo(articleDetail.writer.writerId.toString())
+        assertThat(response.writer.nickname).isEqualTo(articleDetail.writer.nickname)
+        assertThat(response.viewCount).isEqualTo(viewCount)
+        assertThat(response.commentCount).isEqualTo(articleDetail.commentCount)
+        assertThat(response.liked).isEqualTo(articleDetail.liked)
+        assertThat(response.likeCount).isEqualTo(articleDetail.likeCount)
+        assertThat(response.disliked).isEqualTo(articleDetail.disliked)
+        assertThat(response.dislikeCount).isEqualTo(articleDetail.dislikeCount)
+        assertThat(response.createdAt).isEqualTo(articleDetail.createdAt.toZonedDateTime())
+        assertThat(response.modifiedAt).isEqualTo(articleDetail.modifiedAt.toZonedDateTime())
+    }
+}

--- a/board-system-article-read/article-read-application-service/src/test/kotlin/com/ttasjwi/board/system/articleread/domain/mapper/ArticleDetailReadQueryMapperTest.kt
+++ b/board-system-article-read/article-read-application-service/src/test/kotlin/com/ttasjwi/board/system/articleread/domain/mapper/ArticleDetailReadQueryMapperTest.kt
@@ -1,0 +1,62 @@
+package com.ttasjwi.board.system.articleread.domain.mapper
+
+import com.ttasjwi.board.system.articleread.domain.test.support.TestContainer
+import com.ttasjwi.board.system.common.auth.AuthUser
+import com.ttasjwi.board.system.common.auth.Role
+import com.ttasjwi.board.system.common.auth.fixture.AuthUserLoaderFixture
+import com.ttasjwi.board.system.common.auth.fixture.authUserFixture
+import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("[article-read-application-service] ArticleDetailReadQueryMapper 테스트")
+class ArticleDetailReadQueryMapperTest {
+
+    private lateinit var articleDetailReadQueryMapper: ArticleDetailReadQueryMapper
+    private lateinit var authUserLoaderFixture: AuthUserLoaderFixture
+
+
+    @BeforeEach
+    fun setup() {
+        val container = TestContainer.create()
+        articleDetailReadQueryMapper = container.articleDetailReadQueryMapper
+        authUserLoaderFixture = container.authUserLoaderFixture
+    }
+
+
+    @Test
+    @DisplayName("성공 - 인증사용자")
+    fun testSuccess1() {
+        // given
+        val articleId = 13455L
+        val authUser = authUserFixture(userId = 34L, role = Role.USER)
+        authUserLoaderFixture.changeAuthUser(authUser)
+
+
+        // when
+        val query = articleDetailReadQueryMapper.mapToQuery(articleId)
+
+
+        // then
+        assertThat(query.articleId).isEqualTo(articleId)
+        assertThat(query.authUser).isEqualTo(authUser)
+    }
+
+
+    @Test
+    @DisplayName("성공 - 미인증 사용자")
+    fun testSuccess2() {
+        // given
+        val articleId= 235L
+        authUserLoaderFixture.changeAuthUser(null)
+
+        // when
+        val query = articleDetailReadQueryMapper.mapToQuery(articleId)
+
+        // then
+        assertThat(query.articleId).isEqualTo(articleId)
+        assertThat(query.authUser).isNull()
+    }
+}

--- a/board-system-article-read/article-read-application-service/src/test/kotlin/com/ttasjwi/board/system/articleread/domain/processor/ArticleDetailReadProcessorTest.kt
+++ b/board-system-article-read/article-read-application-service/src/test/kotlin/com/ttasjwi/board/system/articleread/domain/processor/ArticleDetailReadProcessorTest.kt
@@ -1,0 +1,146 @@
+package com.ttasjwi.board.system.articleread.domain.processor
+
+import com.ttasjwi.board.system.articleread.domain.dto.ArticleDetailReadQuery
+import com.ttasjwi.board.system.articleread.domain.exception.ArticleNotFoundException
+import com.ttasjwi.board.system.articleread.domain.model.fixture.articleDetailFixture
+import com.ttasjwi.board.system.articleread.domain.port.fixture.ArticleDetailStorageFixture
+import com.ttasjwi.board.system.articleread.domain.port.fixture.ArticleViewCountStorageFixture
+import com.ttasjwi.board.system.articleread.domain.test.support.TestContainer
+import com.ttasjwi.board.system.common.auth.Role
+import com.ttasjwi.board.system.common.auth.fixture.authUserFixture
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+
+@DisplayName("[article-read-application-service] ArticleDetailReadProcessor 테스트")
+class ArticleDetailReadProcessorTest {
+
+    private lateinit var articleDetailReadProcessor :ArticleDetailReadProcessor
+    private lateinit var articleDetailStorageFixture: ArticleDetailStorageFixture
+    private lateinit var articleViewCountStorageFixture: ArticleViewCountStorageFixture
+
+    @BeforeEach
+    fun setup() {
+        val container = TestContainer.create()
+        articleDetailReadProcessor = container.articleDetailReadProcessor
+
+        articleDetailStorageFixture = container.articleDetailStorageFixture
+        articleViewCountStorageFixture = container.articleViewCountStorageFixture
+    }
+
+
+    @Test
+    @DisplayName("성공 테스트 - 인증 사용자")
+    fun testSuccess1() {
+        // given
+        val articleId= 15L
+        val query = ArticleDetailReadQuery(
+            articleId = articleId,
+            authUser = authUserFixture(userId = 24L, role = Role.USER)
+        )
+
+        val articleDetail = articleDetailFixture(articleId = articleId)
+        articleDetailStorageFixture.save(articleDetail)
+
+        val viewCount = 8L
+        articleViewCountStorageFixture.save(articleId, viewCount)
+
+        // when
+        val response = articleDetailReadProcessor.read(query)
+
+        // then
+        assertThat(response.articleId).isEqualTo(articleId.toString())
+        assertThat(response.title).isEqualTo(articleDetail.title)
+        assertThat(response.content).isEqualTo(articleDetail.content)
+        assertThat(response.board.boardId).isEqualTo(articleDetail.board.boardId.toString())
+        assertThat(response.board.name).isEqualTo(articleDetail.board.name)
+        assertThat(response.board.slug).isEqualTo(articleDetail.board.slug)
+        assertThat(response.articleCategory.articleCategoryId).isEqualTo(articleDetail.articleCategory.articleCategoryId.toString())
+        assertThat(response.articleCategory.name).isEqualTo(articleDetail.articleCategory.name)
+        assertThat(response.articleCategory.slug).isEqualTo(articleDetail.articleCategory.slug)
+        assertThat(response.articleCategory.allowSelfDelete).isEqualTo(articleDetail.articleCategory.allowSelfDelete)
+        assertThat(response.articleCategory.allowLike).isEqualTo(articleDetail.articleCategory.allowLike)
+        assertThat(response.articleCategory.allowDislike).isEqualTo(articleDetail.articleCategory.allowDislike)
+        assertThat(response.writer.writerId).isEqualTo(articleDetail.writer.writerId.toString())
+        assertThat(response.writer.nickname).isEqualTo(articleDetail.writer.nickname)
+        assertThat(response.viewCount).isEqualTo(viewCount)
+        assertThat(response.commentCount).isEqualTo(articleDetail.commentCount)
+        assertThat(response.liked).isEqualTo(articleDetail.liked)
+        assertThat(response.likeCount).isEqualTo(articleDetail.likeCount)
+        assertThat(response.disliked).isEqualTo(articleDetail.disliked)
+        assertThat(response.dislikeCount).isEqualTo(articleDetail.dislikeCount)
+        assertThat(response.createdAt).isEqualTo(articleDetail.createdAt.toZonedDateTime())
+        assertThat(response.modifiedAt).isEqualTo(articleDetail.modifiedAt.toZonedDateTime())
+    }
+
+
+    @Test
+    @DisplayName("성공 테스트 - 미인증 사용자")
+    fun testSuccess2() {
+        // given
+        val articleId= 15L
+        val query = ArticleDetailReadQuery(
+            articleId = articleId,
+            authUser = null
+        )
+
+        val articleDetail = articleDetailFixture(articleId = articleId)
+        articleDetailStorageFixture.save(articleDetail)
+
+        val viewCount = 8L
+        articleViewCountStorageFixture.save(articleDetail.articleId, viewCount)
+
+        // when
+        val response = articleDetailReadProcessor.read(query)
+
+        // then
+        assertThat(response.articleId).isEqualTo(articleId.toString())
+        assertThat(response.title).isEqualTo(articleDetail.title)
+        assertThat(response.content).isEqualTo(articleDetail.content)
+        assertThat(response.board.boardId).isEqualTo(articleDetail.board.boardId.toString())
+        assertThat(response.board.name).isEqualTo(articleDetail.board.name)
+        assertThat(response.board.slug).isEqualTo(articleDetail.board.slug)
+        assertThat(response.articleCategory.articleCategoryId).isEqualTo(articleDetail.articleCategory.articleCategoryId.toString())
+        assertThat(response.articleCategory.name).isEqualTo(articleDetail.articleCategory.name)
+        assertThat(response.articleCategory.slug).isEqualTo(articleDetail.articleCategory.slug)
+        assertThat(response.articleCategory.allowSelfDelete).isEqualTo(articleDetail.articleCategory.allowSelfDelete)
+        assertThat(response.articleCategory.allowLike).isEqualTo(articleDetail.articleCategory.allowLike)
+        assertThat(response.articleCategory.allowDislike).isEqualTo(articleDetail.articleCategory.allowDislike)
+        assertThat(response.writer.writerId).isEqualTo(articleDetail.writer.writerId.toString())
+        assertThat(response.writer.nickname).isEqualTo(articleDetail.writer.nickname)
+        assertThat(response.viewCount).isEqualTo(viewCount)
+        assertThat(response.commentCount).isEqualTo(articleDetail.commentCount)
+        assertThat(response.liked).isEqualTo(articleDetail.liked)
+        assertThat(response.likeCount).isEqualTo(articleDetail.likeCount)
+        assertThat(response.disliked).isEqualTo(articleDetail.disliked)
+        assertThat(response.dislikeCount).isEqualTo(articleDetail.dislikeCount)
+        assertThat(response.createdAt).isEqualTo(articleDetail.createdAt.toZonedDateTime())
+        assertThat(response.modifiedAt).isEqualTo(articleDetail.modifiedAt.toZonedDateTime())
+    }
+
+
+    @Test
+    @DisplayName("실패 테스트 - 게시글 없을 때")
+    fun testNotFound() {
+        // given
+        val articleId= 15L
+        val query = ArticleDetailReadQuery(
+            articleId = articleId,
+            authUser = authUserFixture(userId = 24L, role = Role.USER)
+        )
+
+        val viewCount = 8L
+        articleViewCountStorageFixture.save(articleId, viewCount)
+
+        // when
+        val exception = assertThrows<ArticleNotFoundException> {
+            articleDetailReadProcessor.read(query)
+        }
+
+        // then
+        assertThat(exception.args).containsExactly("articleId", articleId)
+    }
+}

--- a/board-system-article-read/article-read-application-service/src/test/kotlin/com/ttasjwi/board/system/articleread/domain/test/support/TestContainer.kt
+++ b/board-system-article-read/article-read-application-service/src/test/kotlin/com/ttasjwi/board/system/articleread/domain/test/support/TestContainer.kt
@@ -1,0 +1,56 @@
+package com.ttasjwi.board.system.articleread.domain.test.support
+
+import com.ttasjwi.board.system.articleread.domain.ArticleDetailReadUseCase
+import com.ttasjwi.board.system.articleread.domain.ArticleDetailReadUseCaseImpl
+import com.ttasjwi.board.system.articleread.domain.mapper.ArticleDetailReadQueryMapper
+import com.ttasjwi.board.system.articleread.domain.port.fixture.ArticleDetailStorageFixture
+import com.ttasjwi.board.system.articleread.domain.port.fixture.ArticleViewCountStorageFixture
+import com.ttasjwi.board.system.articleread.domain.processor.ArticleDetailReadProcessor
+import com.ttasjwi.board.system.common.auth.AuthUserLoader
+import com.ttasjwi.board.system.common.auth.fixture.AuthUserLoaderFixture
+
+internal class TestContainer private constructor(){
+
+    companion object {
+        fun create(): TestContainer {
+            return TestContainer()
+        }
+    }
+
+
+    val authUserLoaderFixture: AuthUserLoaderFixture by lazy {
+        AuthUserLoaderFixture()
+    }
+
+    // port
+    val articleDetailStorageFixture: ArticleDetailStorageFixture by lazy {
+        ArticleDetailStorageFixture()
+    }
+
+    val articleViewCountStorageFixture: ArticleViewCountStorageFixture by lazy {
+        ArticleViewCountStorageFixture()
+    }
+
+    // mapper
+    val articleDetailReadQueryMapper: ArticleDetailReadQueryMapper by lazy {
+        ArticleDetailReadQueryMapper(
+            authUserLoader = authUserLoaderFixture,
+        )
+    }
+
+    // processor
+    val articleDetailReadProcessor: ArticleDetailReadProcessor by lazy {
+        ArticleDetailReadProcessor(
+            articleDetailStorage = articleDetailStorageFixture,
+            articleViewCountStorage = articleViewCountStorageFixture,
+        )
+    }
+
+    // useCase
+    val articleDetailReadUseCase: ArticleDetailReadUseCase by lazy {
+        ArticleDetailReadUseCaseImpl(
+            queryMapper = articleDetailReadQueryMapper,
+            processor = articleDetailReadProcessor
+        )
+    }
+}

--- a/board-system-article-read/article-read-domain/build.gradle.kts
+++ b/board-system-article-read/article-read-domain/build.gradle.kts
@@ -1,0 +1,4 @@
+dependencies {
+    implementation(project(":board-system-common:core"))
+    testFixturesImplementation(testFixtures(project(":board-system-common:core")))
+}

--- a/board-system-article-read/article-read-domain/src/main/kotlin/com/ttasjwi/board/system/articleread/domain/exception/ArticleNotFoundException.kt
+++ b/board-system-article-read/article-read-domain/src/main/kotlin/com/ttasjwi/board/system/articleread/domain/exception/ArticleNotFoundException.kt
@@ -1,0 +1,14 @@
+package com.ttasjwi.board.system.articleread.domain.exception
+
+import com.ttasjwi.board.system.common.exception.CustomException
+import com.ttasjwi.board.system.common.exception.ErrorStatus
+
+class ArticleNotFoundException(
+    articleId: Long,
+) : CustomException(
+    status = ErrorStatus.NOT_FOUND,
+    code = "Error.ArticleNotFound",
+    source = "articleId",
+    args = listOf("articleId", articleId),
+    debugMessage = "조건에 부합하는 게시글을 찾지 못 했습니다. (articleId = $articleId)",
+)

--- a/board-system-article-read/article-read-domain/src/main/kotlin/com/ttasjwi/board/system/articleread/domain/model/ArticleDetail.kt
+++ b/board-system-article-read/article-read-domain/src/main/kotlin/com/ttasjwi/board/system/articleread/domain/model/ArticleDetail.kt
@@ -1,0 +1,39 @@
+package com.ttasjwi.board.system.articleread.domain.model
+
+import com.ttasjwi.board.system.common.time.AppDateTime
+
+interface ArticleDetail {
+    val articleId: Long
+    val title: String
+    val content: String
+    val articleCategory: ArticleCategory
+    val board: Board
+    val writer: Writer
+    val commentCount: Long
+    val liked: Boolean
+    val likeCount: Long
+    val disliked: Boolean
+    val dislikeCount: Long
+    val createdAt: AppDateTime
+    val modifiedAt: AppDateTime
+
+    interface Writer {
+        val writerId: Long
+        val nickname: String
+    }
+
+    interface ArticleCategory {
+        val articleCategoryId: Long
+        val name: String
+        val slug: String
+        val allowSelfDelete: Boolean
+        val allowLike: Boolean
+        val allowDislike: Boolean
+    }
+
+    interface Board {
+        val boardId: Long
+        val name: String
+        val slug: String
+    }
+}

--- a/board-system-article-read/article-read-domain/src/test/kotlin/com/ttasjwi/board/system/articleread/domain/exception/ArticleNotFoundExceptionTest.kt
+++ b/board-system-article-read/article-read-domain/src/test/kotlin/com/ttasjwi/board/system/articleread/domain/exception/ArticleNotFoundExceptionTest.kt
@@ -1,0 +1,25 @@
+package com.ttasjwi.board.system.articleread.domain.exception
+
+import com.ttasjwi.board.system.common.exception.ErrorStatus
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("[article-read-domain] ArticleNotFoundException 테스트")
+class ArticleNotFoundExceptionTest {
+
+    @Test
+    @DisplayName("예외 기본값 테스트")
+    fun test() {
+        val articleId = 12455674599L
+        val exception = ArticleNotFoundException(articleId = articleId)
+
+        assertThat(exception.status).isEqualTo(ErrorStatus.NOT_FOUND)
+        assertThat(exception.code).isEqualTo("Error.ArticleNotFound")
+        assertThat(exception.source).isEqualTo("articleId")
+        assertThat(exception.args).containsExactly("articleId", articleId)
+        assertThat(exception.message).isEqualTo(exception.debugMessage)
+        assertThat(exception.cause).isNull()
+        assertThat(exception.debugMessage).isEqualTo("조건에 부합하는 게시글을 찾지 못 했습니다. (articleId = $articleId)")
+    }
+}

--- a/board-system-article-read/article-read-domain/src/test/kotlin/com/ttasjwi/board/system/articleread/domain/model/fixture/ArticleDetailFixtureTest.kt
+++ b/board-system-article-read/article-read-domain/src/test/kotlin/com/ttasjwi/board/system/articleread/domain/model/fixture/ArticleDetailFixtureTest.kt
@@ -1,0 +1,99 @@
+package com.ttasjwi.board.system.articleread.domain.model.fixture
+
+import com.ttasjwi.board.system.common.time.fixture.appDateTimeFixture
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("[article-read-domain] ArticleDetailFixture 테스트")
+class ArticleDetailFixtureTest {
+
+
+    @Test
+    @DisplayName("디폴트 파라미터 형태로 잘 생성되는 지 테스트")
+    fun test1() {
+        // given
+        // when
+        val articleDetail = articleDetailFixture()
+
+        // then
+        assertThat(articleDetail).isNotNull
+    }
+
+
+    @Test
+    @DisplayName("커스텀 파라미터 테스트")
+    fun test2() {
+        // given
+        val articleId = 41L
+        val title = "우리 늘봄이 귀엽죠"
+        val content = "너무 귀여워 늘봄이"
+        val articleCategoryId = 25L
+        val articleCategoryName = "사진"
+        val articleCategorySlug = "picture"
+        val articleCategoryAllowSelfDelete = true
+        val articleCategoryAllowLike = true
+        val articleCategoryAllowDislike = false
+        val boardId = 4L
+        val boardName = "고양이"
+        val boardSlug = "cat"
+        val writerId = 9L
+        val writerNickname = "땃쥐"
+        val commentCount = 7L
+        val liked = true
+        val likeCount = 5L
+        val disliked = false
+        val dislikeCount = 0L
+        val createdAt= appDateTimeFixture(minute = 30)
+        val modifiedAt = appDateTimeFixture(minute = 30)
+
+        // when
+        val articleDetail = articleDetailFixture(
+            articleId = articleId,
+            title = title,
+            content = content,
+            articleCategoryId = articleCategoryId,
+            articleCategoryName = articleCategoryName,
+            articleCategorySlug = articleCategorySlug,
+            articleCategoryAllowSelfDelete = articleCategoryAllowSelfDelete,
+            articleCategoryAllowLike = articleCategoryAllowLike,
+            articleCategoryAllowDislike = articleCategoryAllowDislike,
+            boardId = boardId,
+            boardName = boardName,
+            boardSlug = boardSlug,
+            writerId = writerId,
+            writerNickname = writerNickname,
+            commentCount = commentCount,
+            liked = liked,
+            likeCount = likeCount,
+            disliked = disliked,
+            dislikeCount = dislikeCount,
+            createdAt = createdAt,
+            modifiedAt = modifiedAt,
+        )
+
+        // then
+        assertThat(articleDetail.articleId).isEqualTo(articleId)
+        assertThat(articleDetail.title).isEqualTo(title)
+        assertThat(articleDetail.content).isEqualTo(content)
+        assertThat(articleDetail.articleCategory.articleCategoryId).isEqualTo(articleCategoryId)
+        assertThat(articleDetail.articleCategory.name).isEqualTo(articleCategoryName)
+        assertThat(articleDetail.articleCategory.slug).isEqualTo(articleCategorySlug)
+        assertThat(articleDetail.articleCategory.allowSelfDelete).isEqualTo(articleCategoryAllowSelfDelete)
+        assertThat(articleDetail.articleCategory.allowLike).isEqualTo(articleCategoryAllowLike)
+        assertThat(articleDetail.articleCategory.allowDislike).isEqualTo(articleCategoryAllowDislike)
+        assertThat(articleDetail.board.boardId).isEqualTo(boardId)
+        assertThat(articleDetail.board.name).isEqualTo(boardName)
+        assertThat(articleDetail.board.slug).isEqualTo(boardSlug)
+        assertThat(articleDetail.writer.writerId).isEqualTo(writerId)
+        assertThat(articleDetail.writer.nickname).isEqualTo(writerNickname)
+        assertThat(articleDetail.commentCount).isEqualTo(commentCount)
+        assertThat(articleDetail.liked).isEqualTo(liked)
+        assertThat(articleDetail.likeCount).isEqualTo(likeCount)
+        assertThat(articleDetail.disliked).isEqualTo(disliked)
+        assertThat(articleDetail.dislikeCount).isEqualTo(dislikeCount)
+        assertThat(articleDetail.createdAt).isEqualTo(createdAt)
+        assertThat(articleDetail.modifiedAt).isEqualTo(modifiedAt)
+    }
+}
+

--- a/board-system-article-read/article-read-domain/src/testFixtures/kotlin/com/ttasjwi/board/system/articleread/domain/model/fixture/ArticleDetailFixture.kt
+++ b/board-system-article-read/article-read-domain/src/testFixtures/kotlin/com/ttasjwi/board/system/articleread/domain/model/fixture/ArticleDetailFixture.kt
@@ -1,0 +1,97 @@
+package com.ttasjwi.board.system.articleread.domain.model.fixture
+
+import com.ttasjwi.board.system.articleread.domain.model.ArticleDetail
+import com.ttasjwi.board.system.common.time.AppDateTime
+import com.ttasjwi.board.system.common.time.fixture.appDateTimeFixture
+
+fun articleDetailFixture(
+    articleId: Long = 1L,
+    title: String = "제목",
+    content: String = "본문",
+    articleCategoryId: Long = 2L,
+    articleCategoryName: String = "일반",
+    articleCategorySlug: String = "general",
+    articleCategoryAllowSelfDelete: Boolean = true,
+    articleCategoryAllowLike: Boolean = true,
+    articleCategoryAllowDislike: Boolean = true,
+    boardId: Long = 3L,
+    boardName: String = "테스트",
+    boardSlug: String = "test",
+    writerId: Long = 4L,
+    writerNickname: String = "테스트사용자",
+    commentCount: Long = 0L,
+    liked: Boolean = false,
+    likeCount: Long = 0L,
+    disliked: Boolean = false,
+    dislikeCount: Long = 0L,
+    createdAt: AppDateTime = appDateTimeFixture(minute = 0),
+    modifiedAt: AppDateTime = appDateTimeFixture(minute = 0)
+): ArticleDetail {
+    return TestArticleDetail(
+        articleId = articleId,
+        title = title,
+        content = content,
+        articleCategory = TestArticleDetail.ArticleCategory(
+            articleCategoryId = articleCategoryId,
+            name = articleCategoryName,
+            slug = articleCategorySlug,
+            allowSelfDelete = articleCategoryAllowSelfDelete,
+            allowLike = articleCategoryAllowLike,
+            allowDislike = articleCategoryAllowDislike
+        ),
+        board = TestArticleDetail.Board(
+            boardId = boardId,
+            name = boardName,
+            slug = boardSlug,
+        ),
+        writer = TestArticleDetail.Writer(
+            writerId = writerId,
+            nickname = writerNickname,
+        ),
+        commentCount = commentCount,
+        liked = liked,
+        likeCount = likeCount,
+        disliked = disliked,
+        dislikeCount = dislikeCount,
+        createdAt = createdAt,
+        modifiedAt = modifiedAt,
+    )
+}
+
+internal data class TestArticleDetail
+internal constructor(
+    override val articleId: Long,
+    override val title: String,
+    override val content: String,
+    override val articleCategory: ArticleDetail.ArticleCategory,
+    override val board: ArticleDetail.Board,
+    override val writer: ArticleDetail.Writer,
+    override val commentCount: Long,
+    override val liked: Boolean,
+    override val likeCount: Long,
+    override val disliked: Boolean,
+    override val dislikeCount: Long,
+    override val createdAt: AppDateTime,
+    override val modifiedAt: AppDateTime
+) : ArticleDetail {
+
+    internal data class ArticleCategory(
+        override val articleCategoryId: Long,
+        override val name: String,
+        override val slug: String,
+        override val allowSelfDelete: Boolean,
+        override val allowLike: Boolean,
+        override val allowDislike: Boolean
+    ) : ArticleDetail.ArticleCategory
+
+    internal data class Board(
+        override val boardId: Long,
+        override val name: String,
+        override val slug: String
+    ) : ArticleDetail.Board
+
+    internal data class Writer(
+        override val writerId: Long,
+        override val nickname: String
+    ) : ArticleDetail.Writer
+}

--- a/board-system-article-read/article-read-web-adapter/build.gradle.kts
+++ b/board-system-article-read/article-read-web-adapter/build.gradle.kts
@@ -1,0 +1,10 @@
+dependencies {
+    implementation(Dependencies.SPRING_BOOT_WEB.fullName)
+    implementation(project(":board-system-common:core"))
+    implementation(project(":board-system-article-read:article-read-application-input-port"))
+
+    testImplementation(Dependencies.SPRING_BOOT_SECURITY.fullName)
+    testImplementation(project(":board-system-test:restdocs-support"))
+    testImplementation("com.ninja-squad:springmockk:4.0.2")
+    testImplementation("org.springframework.boot:spring-boot-starter-aop")
+}

--- a/board-system-article-read/article-read-web-adapter/src/main/kotlin/com/ttasjwi/board/system/articleread/api/ArticleDetailReadController.kt
+++ b/board-system-article-read/article-read-web-adapter/src/main/kotlin/com/ttasjwi/board/system/articleread/api/ArticleDetailReadController.kt
@@ -1,0 +1,22 @@
+package com.ttasjwi.board.system.articleread.api
+
+import com.ttasjwi.board.system.articleread.domain.ArticleDetailReadResponse
+import com.ttasjwi.board.system.articleread.domain.ArticleDetailReadUseCase
+import com.ttasjwi.board.system.common.annotation.auth.PermitAll
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class ArticleDetailReadController(
+    private val articleDetailReadUseCase: ArticleDetailReadUseCase
+) {
+
+    @PermitAll
+    @GetMapping("/api/v2/articles/{articleId}")
+    fun read(@PathVariable("articleId") articleId: Long): ResponseEntity<ArticleDetailReadResponse> {
+        val response = articleDetailReadUseCase.read(articleId)
+        return ResponseEntity.ok(response)
+    }
+}

--- a/board-system-article-read/article-read-web-adapter/src/test/kotlin/com/ttasjwi/board/system/articleread/ArticleReadWebAdapterTestApplication.kt
+++ b/board-system-article-read/article-read-web-adapter/src/test/kotlin/com/ttasjwi/board/system/articleread/ArticleReadWebAdapterTestApplication.kt
@@ -1,0 +1,12 @@
+package com.ttasjwi.board.system.articleread
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+@SpringBootApplication
+class ArticleReadWebAdapterTestApplication
+
+fun main(args: Array<String>) {
+    runApplication<ArticleReadWebAdapterTestApplication>(*args)
+}
+

--- a/board-system-article-read/article-read-web-adapter/src/test/kotlin/com/ttasjwi/board/system/articleread/api/ArticleDetailReadControllerTest.kt
+++ b/board-system-article-read/article-read-web-adapter/src/test/kotlin/com/ttasjwi/board/system/articleread/api/ArticleDetailReadControllerTest.kt
@@ -1,0 +1,202 @@
+package com.ttasjwi.board.system.articleread.api
+
+import com.ninjasquad.springmockk.MockkBean
+import com.ttasjwi.board.system.articleread.domain.ArticleDetailReadResponse
+import com.ttasjwi.board.system.articleread.domain.ArticleDetailReadUseCase
+import com.ttasjwi.board.system.articleread.test.base.ArticleReadRestDocsTest
+import com.ttasjwi.board.system.common.auth.Role
+import com.ttasjwi.board.system.common.time.fixture.appDateTimeFixture
+import com.ttasjwi.board.system.test.util.*
+import io.mockk.every
+import io.mockk.verify
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.request
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@DisplayName("[article-read-web-adapter] ArticleDetailReadController 테스트")
+@WebMvcTest(ArticleDetailReadController::class)
+class ArticleDetailReadControllerTest : ArticleReadRestDocsTest() {
+
+    @MockkBean
+    private lateinit var articleDetailReadUseCase: ArticleDetailReadUseCase
+
+    @Test
+    @DisplayName("성공 테스트")
+    fun testSuccess() {
+        // given
+        val urlPattern = "/api/v2/articles/{articleId}"
+        val articleId = 1245567L
+        val accessToken = generateAccessToken(
+            userId = 15L,
+            role = Role.USER,
+            issuedAt = appDateTimeFixture(minute = 0),
+            expiresAt = appDateTimeFixture(minute = 30),
+        )
+        changeCurrentTime(appDateTimeFixture(minute = 15))
+
+
+        val response = ArticleDetailReadResponse(
+            articleId = articleId.toString(),
+            title = "제목",
+            content = "본문",
+            articleCategory = ArticleDetailReadResponse.ArticleCategory(
+                articleCategoryId = "87364535667",
+                name = "일반",
+                slug = "general",
+                allowSelfDelete = true,
+                allowLike = true,
+                allowDislike = true
+            ),
+            board = ArticleDetailReadResponse.Board(
+                boardId = "131433451451",
+                name = "고양이",
+                slug = "cat"
+            ),
+            writer = ArticleDetailReadResponse.Writer(
+                writerId = "155557",
+                nickname = "땃쥐"
+            ),
+            viewCount = 8844L,
+            commentCount = 15L,
+            liked = true,
+            likeCount = 14L,
+            disliked = false,
+            dislikeCount = 14L,
+            createdAt = appDateTimeFixture(minute = 5).toZonedDateTime(),
+            modifiedAt = appDateTimeFixture(minute = 5).toZonedDateTime()
+        )
+        every { articleDetailReadUseCase.read(articleId) } returns response
+
+        // when
+        mockMvc
+            .perform(
+                request(
+                    HttpMethod.GET, urlPattern, articleId
+                )
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer ${accessToken.tokenValue}")
+            )
+            .andExpectAll(
+                status().isOk,
+                jsonPath("$.articleId").value(response.articleId),
+                jsonPath("$.title").value(response.title),
+                jsonPath("$.content").value(response.content),
+                jsonPath("$.board.boardId").value(response.board.boardId),
+                jsonPath("$.board.name").value(response.board.name),
+                jsonPath("$.board.slug").value(response.board.slug),
+                jsonPath("$.articleCategory.articleCategoryId").value(response.articleCategory.articleCategoryId),
+                jsonPath("$.articleCategory.name").value(response.articleCategory.name),
+                jsonPath("$.articleCategory.slug").value(response.articleCategory.slug),
+                jsonPath("$.articleCategory.name").value(response.articleCategory.name),
+                jsonPath("$.articleCategory.allowSelfDelete").value(response.articleCategory.allowSelfDelete),
+                jsonPath("$.articleCategory.allowLike").value(response.articleCategory.allowLike),
+                jsonPath("$.articleCategory.allowDislike").value(response.articleCategory.allowDislike),
+                jsonPath("$.writer.writerId").value(response.writer.writerId),
+                jsonPath("$.writer.nickname").value(response.writer.nickname),
+                jsonPath("$.viewCount").value(response.viewCount),
+                jsonPath("$.commentCount").value(response.commentCount),
+                jsonPath("$.liked").value(response.liked),
+                jsonPath("$.likeCount").value(response.likeCount),
+                jsonPath("$.disliked").value(response.disliked),
+                jsonPath("$.dislikeCount").value(response.dislikeCount),
+                jsonPath("$.createdAt").value("2025-01-01T00:05:00+09:00"),
+                jsonPath("$.modifiedAt").value("2025-01-01T00:05:00+09:00"),
+            )
+            .andDocument(
+                identifier = "article-detail-read-success",
+                requestHeaders(
+                    HttpHeaders.AUTHORIZATION
+                            headerMeans "인증에 필요한 토큰('Bearer [액세스토큰]' 형태)"
+                            example "Bearer 액세스토큰"
+                            isOptional true,
+                ),
+                pathParameters(
+                    "articleId"
+                            paramMeans "게시글 식별자(Id)"
+                ),
+                responseBody(
+                    "articleId"
+                            type STRING
+                            means "게시글 식별자(Id)",
+                    "title"
+                            type STRING
+                            means "게시글 제목",
+
+                    "content"
+                            type STRING
+                            means "게시글 본문",
+                    "board"
+                            subSectionType "Board"
+                            means "게시글이 속한 게시판 정보",
+                    "board.boardId"
+                            type STRING
+                            means "게시글이 속한 게시판 식별자(Id)",
+                    "board.name"
+                            type STRING
+                            means "게시글이 속한 게시판 이름",
+                    "board.slug"
+                            type STRING
+                            means "게시글이 속한 게시판 슬러그(게시글 구분 영문자)",
+                    "articleCategory"
+                            subSectionType "ArticleCategory"
+                            means "게시글이 속한 카테고리",
+                    "articleCategory.articleCategoryId"
+                            type STRING
+                            means "게시글이 속한 게시글 카테고리 식별자(Id)",
+                    "articleCategory.name"
+                            type STRING
+                            means "게시글이 속한 게시글 카테고리 이름",
+                    "articleCategory.slug"
+                            type STRING
+                            means "게시글이 속한 게시글 카테고리 슬러그(게시글 카테고리 구분 영문자)",
+                    "articleCategory.allowSelfDelete"
+                            type BOOLEAN
+                            means "작성자가 스스로 게시글 삭제 또는 수정을 할 수 있는 지 여부",
+                    "articleCategory.allowLike"
+                            type BOOLEAN
+                            means "사용자들이 게시글을 좋아요 할 수 있는 지 여부",
+                    "articleCategory.allowDislike"
+                            type BOOLEAN
+                            means "사용자들이 게시글을 싫어요 할 수 있는 지 여부",
+                    "writer"
+                            subSectionType "Writer"
+                            means "작성자 정보",
+                    "writer.writerId"
+                            type STRING
+                            means "작성자 식별자(Id)",
+                    "writer.nickname"
+                            type STRING
+                            means "작성시점의 작성자 닉네임",
+                    "viewCount"
+                            type NUMBER
+                            means "게시글의 조회수",
+                    "commentCount"
+                            type NUMBER
+                            means "게시글의 댓글수",
+                    "liked"
+                            type BOOLEAN
+                            means "조회자가 게시글을 좋아요 했는지 여부(미인증 사용자는 false)",
+                    "likeCount"
+                            type NUMBER
+                            means "게시글의 좋아요 수",
+                    "disliked"
+                            type BOOLEAN
+                            means "조회자가 게시글을 싫어요 했는지 여부(미인증 사용자는 false)",
+                    "dislikeCount"
+                            type NUMBER
+                            means "게시글의 싫어요 수",
+                    "createdAt"
+                            type DATETIME
+                            means "작성 시각",
+                    "modifiedAt"
+                            type DATETIME
+                            means "마지막 수정 시각",
+                )
+            )
+        verify(exactly = 1) { articleDetailReadUseCase.read(articleId) }
+    }
+}

--- a/board-system-article-read/article-read-web-adapter/src/test/kotlin/com/ttasjwi/board/system/articleread/test/base/ArticleReadRestDocsTest.kt
+++ b/board-system-article-read/article-read-web-adapter/src/test/kotlin/com/ttasjwi/board/system/articleread/test/base/ArticleReadRestDocsTest.kt
@@ -1,0 +1,8 @@
+package com.ttasjwi.board.system.articleread.test.base
+
+import com.ttasjwi.board.system.articleread.test.config.ArticleReadRestDocsTestConfig
+import com.ttasjwi.board.system.test.base.RestDocsTest
+import org.springframework.context.annotation.Import
+
+@Import(ArticleReadRestDocsTestConfig::class)
+abstract class ArticleReadRestDocsTest : RestDocsTest()

--- a/board-system-article-read/article-read-web-adapter/src/test/kotlin/com/ttasjwi/board/system/articleread/test/config/ArticleReadRestDocsTestConfig.kt
+++ b/board-system-article-read/article-read-web-adapter/src/test/kotlin/com/ttasjwi/board/system/articleread/test/config/ArticleReadRestDocsTestConfig.kt
@@ -1,0 +1,25 @@
+package com.ttasjwi.board.system.articleread.test.config
+
+import com.ttasjwi.board.system.common.infra.websupport.auth.config.CoreSecurityDsl
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.invoke
+import org.springframework.security.web.SecurityFilterChain
+
+@TestConfiguration
+class ArticleReadRestDocsTestConfig(
+    private val coreSecurityDsl: CoreSecurityDsl
+) {
+
+    @Bean
+    fun testSecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
+        coreSecurityDsl.apply(http)
+        http {
+            authorizeHttpRequests {
+                authorize(anyRequest, permitAll)
+            }
+        }
+        return http.build()
+    }
+}

--- a/board-system-infrastructure/database-adapter/build.gradle.kts
+++ b/board-system-infrastructure/database-adapter/build.gradle.kts
@@ -7,6 +7,9 @@ dependencies {
     runtimeOnly(Dependencies.MYSQL_DRIVER.fullName)
     implementation(Dependencies.P6SPY_DATASOURCE_DECORATOR.fullName)
 
+    implementation(Dependencies.QUERY_DSL_JPA.fullName)
+    kapt(Dependencies.QUERY_DSL_APT.fullName)
+
     implementation(project(":board-system-common:core"))
     testImplementation(testFixtures(project(":board-system-common:core")))
 
@@ -39,4 +42,9 @@ dependencies {
     implementation(project(":board-system-article-view:article-view-domain"))
     testImplementation(testFixtures(project(":board-system-article-view:article-view-domain")))
     implementation(project(":board-system-article-view:article-view-application-output-port"))
+
+    // article-read
+    implementation(project(":board-system-article-read:article-read-domain"))
+    testImplementation(testFixtures(project(":board-system-article-read:article-read-domain")))
+    implementation(project(":board-system-article-read:article-read-application-output-port"))
 }

--- a/board-system-infrastructure/database-adapter/src/main/kotlin/com/ttasjwi/board/system/articleread/infra/persistence/ArticleDetailStorageImpl.kt
+++ b/board-system-infrastructure/database-adapter/src/main/kotlin/com/ttasjwi/board/system/articleread/infra/persistence/ArticleDetailStorageImpl.kt
@@ -1,0 +1,104 @@
+package com.ttasjwi.board.system.articleread.infra.persistence
+
+import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.core.types.dsl.Expressions
+import com.querydsl.jpa.JPAExpressions
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.ttasjwi.board.system.articleread.domain.model.ArticleDetail
+import com.ttasjwi.board.system.articleread.domain.port.ArticleDetailStorage
+import com.ttasjwi.board.system.articleread.infra.persistence.dto.QQueryDslArticleDetail
+import com.ttasjwi.board.system.articleread.infra.persistence.dto.QQueryDslArticleDetail_ArticleCategory
+import com.ttasjwi.board.system.articleread.infra.persistence.dto.QQueryDslArticleDetail_Board
+import com.ttasjwi.board.system.articleread.infra.persistence.dto.QQueryDslArticleDetail_Writer
+import org.springframework.stereotype.Component
+import com.ttasjwi.board.system.articleread.infra.persistence.jpa.QJpaArticle.jpaArticle as article
+import com.ttasjwi.board.system.articleread.infra.persistence.jpa.QJpaArticleCategory.jpaArticleCategory as articleCategory
+import com.ttasjwi.board.system.articleread.infra.persistence.jpa.QJpaArticleCommentCount.jpaArticleCommentCount as articleCommentCount
+import com.ttasjwi.board.system.articleread.infra.persistence.jpa.QJpaArticleDislike.jpaArticleDislike as articleDislike
+import com.ttasjwi.board.system.articleread.infra.persistence.jpa.QJpaArticleDislikeCount.jpaArticleDislikeCount as articleDislikeCount
+import com.ttasjwi.board.system.articleread.infra.persistence.jpa.QJpaArticleLike.jpaArticleLike as articleLike
+import com.ttasjwi.board.system.articleread.infra.persistence.jpa.QJpaArticleLikeCount.jpaArticleLikeCount as articleLikeCount
+import com.ttasjwi.board.system.articleread.infra.persistence.jpa.QJpaBoard.jpaBoard as board
+
+@Component("articleReadArticleDetailStorage")
+class ArticleDetailStorageImpl(
+    private val queryFactory: JPAQueryFactory
+) : ArticleDetailStorage {
+
+    override fun read(articleId: Long, userId: Long?): ArticleDetail? {
+        return queryFactory
+            .select(
+                QQueryDslArticleDetail(
+                    article.articleId,
+                    article.title,
+                    article.content,
+                    QQueryDslArticleDetail_ArticleCategory(
+                        article.articleCategoryId,
+                        articleCategory.name,
+                        articleCategory.slug,
+                        articleCategory.allowSelfDelete,
+                        articleCategory.allowLike,
+                        articleCategory.allowDislike,
+                    ),
+                    QQueryDslArticleDetail_Board(
+                        article.boardId,
+                        board.name,
+                        board.slug,
+                    ),
+                    QQueryDslArticleDetail_Writer(
+                        article.writerId,
+                        article.writerNickname
+                    ),
+                    articleCommentCount.commentCount.coalesce(0L),
+                    articleLiked(articleId, userId),
+                    articleLikeCount.likeCount.coalesce(0L),
+                    articleDisliked(articleId, userId),
+                    articleDislikeCount.dislikeCount.coalesce(0L),
+                    article.createdAt,
+                    article.modifiedAt
+                )
+            )
+            .from(
+                article
+            )
+            .where(
+                article.articleId.eq(articleId)
+            )
+            .innerJoin(articleCategory).on(articleCategory.articleCategoryId.eq(article.articleCategoryId))
+            .innerJoin(board).on(board.boardId.eq(article.boardId))
+            .leftJoin(articleCommentCount).on(articleCommentCount.articleId.eq(article.articleId))
+            .leftJoin(articleLikeCount).on(articleLikeCount.articleId.eq(article.articleId))
+            .leftJoin(articleDislikeCount).on(articleDislikeCount.articleId.eq(article.articleId))
+            .fetchOne()
+    }
+
+    private fun articleLiked(articleId: Long, userId: Long?): BooleanExpression {
+        return if (userId != null) {
+            JPAExpressions
+                .selectOne()
+                .from(articleLike)
+                .where(
+                    articleLike.articleId.eq(articleId),
+                    articleLike.userId.eq(userId),
+                )
+                .exists()
+        } else {
+            Expressions.FALSE
+        }
+    }
+
+    private fun articleDisliked(articleId: Long, userId: Long?): BooleanExpression {
+        return if (userId != null) {
+            JPAExpressions
+                .selectOne()
+                .from(articleDislike)
+                .where(
+                    articleDislike.articleId.eq(articleId),
+                    articleDislike.userId.eq(userId),
+                )
+                .exists()
+        } else {
+            Expressions.FALSE
+        }
+    }
+}

--- a/board-system-infrastructure/database-adapter/src/main/kotlin/com/ttasjwi/board/system/articleread/infra/persistence/dto/QueryDslArticleDetail.kt
+++ b/board-system-infrastructure/database-adapter/src/main/kotlin/com/ttasjwi/board/system/articleread/infra/persistence/dto/QueryDslArticleDetail.kt
@@ -1,0 +1,51 @@
+package com.ttasjwi.board.system.articleread.infra.persistence.dto
+
+import com.querydsl.core.annotations.QueryProjection
+import com.ttasjwi.board.system.articleread.domain.model.ArticleDetail
+import com.ttasjwi.board.system.common.time.AppDateTime
+import java.time.LocalDateTime
+
+class QueryDslArticleDetail
+@QueryProjection constructor(
+    override val articleId: Long,
+    override val title: String,
+    override val content: String,
+    override val articleCategory: ArticleDetail.ArticleCategory,
+    override val board: ArticleDetail.Board,
+    override val writer: ArticleDetail.Writer,
+    override val commentCount: Long,
+    override val liked: Boolean,
+    override val likeCount: Long,
+    override val disliked: Boolean,
+    override val dislikeCount: Long,
+    createdAt: LocalDateTime,
+    modifiedAt: LocalDateTime
+) : ArticleDetail {
+
+    override val createdAt: AppDateTime = AppDateTime.from(createdAt)
+    override val modifiedAt: AppDateTime = AppDateTime.from(modifiedAt)
+
+    data class ArticleCategory @QueryProjection constructor(
+        override val articleCategoryId: Long,
+        override val name: String,
+        override val slug: String,
+        override val allowSelfDelete: Boolean,
+        override val allowLike: Boolean,
+        override val allowDislike: Boolean
+    ): ArticleDetail.ArticleCategory
+
+    data class Board @QueryProjection constructor(
+        override val boardId: Long,
+        override val name: String,
+        override val slug: String
+    ): ArticleDetail.Board
+
+    data class Writer @QueryProjection constructor(
+        override val writerId: Long,
+        override val nickname: String
+    ): ArticleDetail.Writer
+
+    override fun toString(): String {
+        return "QueryDslArticleDetail(articleId=$articleId, title='$title', content='$content', articleCategory=$articleCategory, board=$board, writer=$writer, commentCount=$commentCount, liked=$liked, likeCount=$likeCount, disliked=$disliked, dislikeCount=$dislikeCount, createdAt=$createdAt, modifiedAt=$modifiedAt)"
+    }
+}

--- a/board-system-infrastructure/database-adapter/src/main/kotlin/com/ttasjwi/board/system/articleread/infra/persistence/jpa/JpaArticle.kt
+++ b/board-system-infrastructure/database-adapter/src/main/kotlin/com/ttasjwi/board/system/articleread/infra/persistence/jpa/JpaArticle.kt
@@ -1,0 +1,40 @@
+package com.ttasjwi.board.system.articleread.infra.persistence.jpa
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity(name = "ArticleReadJpaArticle")
+@Table(name = "articles")
+class JpaArticle(
+
+    @Id
+    @Column(name = "article_id")
+    val articleId: Long,
+
+    @Column(name = "title")
+    val title: String,
+
+    @Column(name = "content")
+    val content: String,
+
+    @Column(name = "board_id")
+    val boardId: Long,
+
+    @Column(name = "article_category_id")
+    var articleCategoryId: Long,
+
+    @Column(name = "writer_id")
+    val writerId: Long,
+
+    @Column(name = "writer_nickname")
+    val writerNickname: String,
+
+    @Column(name = "created_at")
+    val createdAt: LocalDateTime,
+
+    @Column(name = "modified_at")
+    val modifiedAt: LocalDateTime,
+)

--- a/board-system-infrastructure/database-adapter/src/main/kotlin/com/ttasjwi/board/system/articleread/infra/persistence/jpa/JpaArticleCategory.kt
+++ b/board-system-infrastructure/database-adapter/src/main/kotlin/com/ttasjwi/board/system/articleread/infra/persistence/jpa/JpaArticleCategory.kt
@@ -1,0 +1,37 @@
+package com.ttasjwi.board.system.articleread.infra.persistence.jpa
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity(name = "ArticleReadJpaArticleCategory")
+@Table(name = "article_categories")
+class JpaArticleCategory(
+
+    @Id
+    @Column(name = "article_category_id")
+    val articleCategoryId: Long,
+
+    @Column(name = "board_id", nullable = false)
+    val boardId: Long,
+
+    @Column(name = "name", length = 20, nullable = false)
+    var name: String,
+
+    @Column(name = "slug", length = 8, nullable = false)
+    var slug: String,
+
+    @Column(name = "allow_self_delete", nullable = false)
+    var allowSelfDelete: Boolean,
+
+    @Column(name = "allow_like", nullable = false)
+    var allowLike: Boolean,
+
+    @Column(name = "allow_dislike", nullable = false)
+    var allowDislike: Boolean,
+
+    @Column(name = "created_at", columnDefinition = "DATETIME", nullable = false)
+    val createdAt: LocalDateTime,
+)

--- a/board-system-infrastructure/database-adapter/src/main/kotlin/com/ttasjwi/board/system/articleread/infra/persistence/jpa/JpaArticleCommentCount.kt
+++ b/board-system-infrastructure/database-adapter/src/main/kotlin/com/ttasjwi/board/system/articleread/infra/persistence/jpa/JpaArticleCommentCount.kt
@@ -1,0 +1,18 @@
+package com.ttasjwi.board.system.articleread.infra.persistence.jpa
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity(name = "ArticleReadJpaArticleCommentCount")
+@Table(name = "article_comment_counts")
+class JpaArticleCommentCount(
+
+    @Id
+    @Column(name = "article_id")
+    val articleId: Long,
+
+    @Column(name = "comment_count")
+    val commentCount: Long
+)

--- a/board-system-infrastructure/database-adapter/src/main/kotlin/com/ttasjwi/board/system/articleread/infra/persistence/jpa/JpaArticleDislike.kt
+++ b/board-system-infrastructure/database-adapter/src/main/kotlin/com/ttasjwi/board/system/articleread/infra/persistence/jpa/JpaArticleDislike.kt
@@ -1,0 +1,24 @@
+package com.ttasjwi.board.system.articleread.infra.persistence.jpa
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity(name = "ArticleReadJpaArticleDislike")
+@Table(name = "article_dislikes")
+class JpaArticleDislike(
+    @Id
+    @Column(name = "article_dislike_id")
+    val articleDislikeId: Long,
+
+    @Column(name = "article_id")
+    val articleId: Long,
+
+    @Column(name = "user_id")
+    val userId: Long,
+
+    @Column(name = "created_at")
+    val createdAt: LocalDateTime
+)

--- a/board-system-infrastructure/database-adapter/src/main/kotlin/com/ttasjwi/board/system/articleread/infra/persistence/jpa/JpaArticleDislikeCount.kt
+++ b/board-system-infrastructure/database-adapter/src/main/kotlin/com/ttasjwi/board/system/articleread/infra/persistence/jpa/JpaArticleDislikeCount.kt
@@ -1,0 +1,36 @@
+package com.ttasjwi.board.system.articleread.infra.persistence.jpa
+
+import com.ttasjwi.board.system.articlelike.domain.model.ArticleDislikeCount
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity(name = "ArticleReadJpaArticleDislikeCount")
+@Table(name = "article_dislike_counts")
+class JpaArticleDislikeCount(
+    @Id
+    @Column(name = "article_id")
+    val articleId: Long,
+
+    @Column(name = "dislike_count")
+    val dislikeCount: Long,
+) {
+
+    companion object {
+
+        fun from(articleDislikeCount: ArticleDislikeCount): JpaArticleDislikeCount {
+            return JpaArticleDislikeCount(
+                articleId = articleDislikeCount.articleId,
+                dislikeCount = articleDislikeCount.dislikeCount
+            )
+        }
+    }
+
+    fun restoreDomain(): ArticleDislikeCount {
+        return ArticleDislikeCount.restore(
+            articleId = this.articleId,
+            dislikeCount = this.dislikeCount
+        )
+    }
+}

--- a/board-system-infrastructure/database-adapter/src/main/kotlin/com/ttasjwi/board/system/articleread/infra/persistence/jpa/JpaArticleLike.kt
+++ b/board-system-infrastructure/database-adapter/src/main/kotlin/com/ttasjwi/board/system/articleread/infra/persistence/jpa/JpaArticleLike.kt
@@ -1,0 +1,24 @@
+package com.ttasjwi.board.system.articleread.infra.persistence.jpa
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity(name = "ArticleReadJpaArticleLike")
+@Table(name = "article_likes")
+class JpaArticleLike(
+    @Id
+    @Column(name = "article_like_id")
+    val articleLikeId: Long,
+
+    @Column(name = "article_id")
+    val articleId: Long,
+
+    @Column(name = "user_id")
+    val userId: Long,
+
+    @Column(name = "created_at")
+    val createdAt: LocalDateTime
+)

--- a/board-system-infrastructure/database-adapter/src/main/kotlin/com/ttasjwi/board/system/articleread/infra/persistence/jpa/JpaArticleLikeCount.kt
+++ b/board-system-infrastructure/database-adapter/src/main/kotlin/com/ttasjwi/board/system/articleread/infra/persistence/jpa/JpaArticleLikeCount.kt
@@ -1,0 +1,17 @@
+package com.ttasjwi.board.system.articleread.infra.persistence.jpa
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity(name = "ArticleReadJpaArticleLikeCount")
+@Table(name = "article_like_counts")
+class JpaArticleLikeCount(
+    @Id
+    @Column(name = "article_id")
+    val articleId: Long,
+
+    @Column(name = "like_count")
+    val likeCount: Long,
+)

--- a/board-system-infrastructure/database-adapter/src/main/kotlin/com/ttasjwi/board/system/articleread/infra/persistence/jpa/JpaBoard.kt
+++ b/board-system-infrastructure/database-adapter/src/main/kotlin/com/ttasjwi/board/system/articleread/infra/persistence/jpa/JpaBoard.kt
@@ -1,0 +1,31 @@
+package com.ttasjwi.board.system.articleread.infra.persistence.jpa
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity(name = "ArticleReadJpaBoard")
+@Table(name = "boards")
+class JpaBoard(
+
+    @Id
+    @Column(name = "board_id")
+    val boardId: Long,
+
+    @Column(name = "name")
+    val name: String,
+
+    @Column(name = "description")
+    val description: String,
+
+    @Column(name = "manager_id")
+    val managerId: Long,
+
+    @Column(name = "slug")
+    val slug: String,
+
+    @Column(name = "created_at")
+    val createdAt: LocalDateTime,
+)

--- a/board-system-infrastructure/database-adapter/src/main/kotlin/com/ttasjwi/board/system/articleread/infra/persistence/jpa/JpaUser.kt
+++ b/board-system-infrastructure/database-adapter/src/main/kotlin/com/ttasjwi/board/system/articleread/infra/persistence/jpa/JpaUser.kt
@@ -1,0 +1,34 @@
+package com.ttasjwi.board.system.articleread.infra.persistence.jpa
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity(name = "ArticleReadJpaUser")
+@Table(name = "users")
+class JpaUser(
+
+    @Id
+    @Column(name = "user_id")
+    val userId: Long,
+
+    @Column(name = "email")
+    val email: String,
+
+    @Column(name = "password")
+    val password: String,
+
+    @Column(name = "username")
+    val username: String,
+
+    @Column(name = "nickname")
+    val nickname: String,
+
+    @Column(name = "role")
+    val role: String,
+
+    @Column(name = "registered_at")
+    val registeredAt: LocalDateTime,
+)

--- a/board-system-infrastructure/database-adapter/src/main/kotlin/com/ttasjwi/board/system/common/infra/databasesupport/config/JpaConfig.kt
+++ b/board-system-infrastructure/database-adapter/src/main/kotlin/com/ttasjwi/board/system/common/infra/databasesupport/config/JpaConfig.kt
@@ -1,6 +1,9 @@
 package com.ttasjwi.board.system.common.infra.databasesupport.config
 
+import com.querydsl.jpa.impl.JPAQueryFactory
+import jakarta.persistence.EntityManager
 import org.springframework.boot.autoconfigure.domain.EntityScan
+import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories
 
@@ -9,4 +12,10 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories
     basePackages = ["com.ttasjwi.board"]
 )
 @EntityScan(basePackages = ["com.ttasjwi.board"])
-class JpaConfig
+class JpaConfig {
+
+    @Bean
+    fun jpaQueryFactory(entityManager: EntityManager): JPAQueryFactory {
+        return JPAQueryFactory(entityManager)
+    }
+}

--- a/board-system-infrastructure/database-adapter/src/test/kotlin/com/ttasjwi/board/system/articleread/infra/persistence/ArticleDetailStorageImplTest.kt
+++ b/board-system-infrastructure/database-adapter/src/test/kotlin/com/ttasjwi/board/system/articleread/infra/persistence/ArticleDetailStorageImplTest.kt
@@ -1,0 +1,389 @@
+package com.ttasjwi.board.system.articleread.infra.persistence
+
+import com.ttasjwi.board.system.articleread.infra.persistence.jpa.*
+import com.ttasjwi.board.system.common.time.fixture.appDateTimeFixture
+import com.ttasjwi.board.system.test.DataBaseIntegrationTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("[article-read-database-adapter] ArticleDetailStorageImpl 테스트")
+class ArticleDetailStorageImplTest : DataBaseIntegrationTest() {
+
+    @Nested
+    @DisplayName("read: 게시글 상세 조회")
+    inner class ReadTest {
+
+        @Test
+        @DisplayName("게시글을 찾지 못했을 경우, null 반환")
+        fun articleNotFoundTest() {
+            // given
+            val articleId = 1237176453413L
+            val userId = null
+
+            // when
+            val articleDetail = articleReadArticleDetailStorage.read(articleId, userId)
+
+            // then
+            assertThat(articleDetail).isNull()
+        }
+
+
+        @Test
+        @DisplayName("게시글 조회 성공시, 게시글 기본 정보 및 게시판/게시글 카테고리 정보가 잘 조회되는 지 확인")
+        fun testSuccessCommon() {
+            // given
+            val board = JpaBoard(
+                boardId = 1341359813905137L,
+                name = "고양이",
+                description = "고양이 게시판입니다.",
+                managerId = 11459014851L,
+                slug = "cat",
+                createdAt = appDateTimeFixture(minute = 23).toLocalDateTime()
+            )
+            entityManager.persist(board)
+
+            val articleCategory = JpaArticleCategory(
+                articleCategoryId = 45843951154L,
+                boardId = board.boardId,
+                name = "일반",
+                slug = "general",
+                allowSelfDelete = true,
+                allowLike = true,
+                allowDislike = true,
+                createdAt = appDateTimeFixture(minute = 27).toLocalDateTime()
+            )
+            entityManager.persist(articleCategory)
+
+            val article = JpaArticle(
+                articleId = 8384744815925L,
+                title = "야옹야옹",
+                content = "응애응애야오옹",
+                boardId = board.boardId,
+                articleCategoryId = articleCategory.articleCategoryId,
+                writerId = 944495345048L,
+                writerNickname = "땃쥐",
+                createdAt = appDateTimeFixture(minute = 44).toLocalDateTime(),
+                modifiedAt = appDateTimeFixture(minute = 49).toLocalDateTime()
+            )
+            entityManager.persist(article)
+
+            val articleId = article.articleId
+            val userId = null
+
+            // when
+            val articleDetail = articleReadArticleDetailStorage.read(articleId, userId)!!
+
+            // then
+            assertThat(articleDetail.articleId).isEqualTo(article.articleId)
+            assertThat(articleDetail.title).isEqualTo(article.title)
+            assertThat(articleDetail.content).isEqualTo(article.content)
+            assertThat(articleDetail.articleCategory.articleCategoryId).isEqualTo(article.articleCategoryId)
+            assertThat(articleDetail.articleCategory.name).isEqualTo(articleCategory.name)
+            assertThat(articleDetail.articleCategory.slug).isEqualTo(articleCategory.slug)
+            assertThat(articleDetail.articleCategory.allowSelfDelete).isEqualTo(articleCategory.allowSelfDelete)
+            assertThat(articleDetail.articleCategory.allowLike).isEqualTo(articleCategory.allowLike)
+            assertThat(articleDetail.articleCategory.allowDislike).isEqualTo(articleCategory.allowDislike)
+            assertThat(articleDetail.board.boardId).isEqualTo(article.boardId)
+            assertThat(articleDetail.board.name).isEqualTo(board.name)
+            assertThat(articleDetail.board.slug).isEqualTo(board.slug)
+            assertThat(articleDetail.writer.writerId).isEqualTo(article.writerId)
+            assertThat(articleDetail.writer.nickname).isEqualTo(article.writerNickname)
+            assertThat(articleDetail.createdAt.toLocalDateTime()).isEqualTo(article.createdAt)
+            assertThat(articleDetail.modifiedAt.toLocalDateTime()).isEqualTo(article.modifiedAt)
+        }
+
+        @Test
+        @DisplayName("좋아요수, 싫어요수, 댓글수가 저장되어 있을 경우, 값이 잘 조회되는 지 테스트")
+        fun testLikeDislikeCommentCountNotNull() {
+            // given
+            val board = JpaBoard(
+                boardId = 1341359813905137L,
+                name = "고양이",
+                description = "고양이 게시판입니다.",
+                managerId = 11459014851L,
+                slug = "cat",
+                createdAt = appDateTimeFixture(minute = 23).toLocalDateTime()
+            )
+            entityManager.persist(board)
+
+            val articleCategory = JpaArticleCategory(
+                articleCategoryId = 45843951154L,
+                boardId = board.boardId,
+                name = "일반",
+                slug = "general",
+                allowSelfDelete = true,
+                allowLike = true,
+                allowDislike = true,
+                createdAt = appDateTimeFixture(minute = 27).toLocalDateTime()
+            )
+            entityManager.persist(articleCategory)
+
+            val article = JpaArticle(
+                articleId = 8384744815925L,
+                title = "야옹야옹",
+                content = "응애응애야오옹",
+                boardId = board.boardId,
+                articleCategoryId = articleCategory.articleCategoryId,
+                writerId = 944495345048L,
+                writerNickname = "땃쥐",
+                createdAt = appDateTimeFixture(minute = 44).toLocalDateTime(),
+                modifiedAt = appDateTimeFixture(minute = 49).toLocalDateTime()
+            )
+            entityManager.persist(article)
+
+
+            val articleLikeCount = JpaArticleLikeCount(
+                articleId = article.articleId,
+                likeCount = 1341355L,
+            )
+            entityManager.persist(articleLikeCount)
+
+            val articleDisLikeCount = JpaArticleDislikeCount(
+                articleId = article.articleId,
+                dislikeCount = 1455L,
+            )
+            entityManager.persist(articleDisLikeCount)
+
+            val articleCommentCount = JpaArticleCommentCount(
+                articleId = article.articleId,
+                commentCount = 134134166L,
+            )
+            entityManager.persist(articleCommentCount)
+
+            val articleId = article.articleId
+            val userId = null
+
+            // when
+            val articleDetail = articleReadArticleDetailStorage.read(articleId, userId)!!
+
+            // then
+            assertThat(articleDetail.commentCount).isEqualTo(articleCommentCount.commentCount)
+            assertThat(articleDetail.likeCount).isEqualTo(articleLikeCount.likeCount)
+            assertThat(articleDetail.dislikeCount).isEqualTo(articleDisLikeCount.dislikeCount)
+        }
+
+
+        @Test
+        @DisplayName("좋아요수, 싫어요수, 댓글수가 없을 경우, 값이 0으로 조회되는 지 테스트")
+        fun testLikeDislikeCommentCountNull() {
+            // given
+            val board = JpaBoard(
+                boardId = 1341359813905137L,
+                name = "고양이",
+                description = "고양이 게시판입니다.",
+                managerId = 11459014851L,
+                slug = "cat",
+                createdAt = appDateTimeFixture(minute = 23).toLocalDateTime()
+            )
+            entityManager.persist(board)
+
+            val articleCategory = JpaArticleCategory(
+                articleCategoryId = 45843951154L,
+                boardId = board.boardId,
+                name = "일반",
+                slug = "general",
+                allowSelfDelete = true,
+                allowLike = true,
+                allowDislike = true,
+                createdAt = appDateTimeFixture(minute = 27).toLocalDateTime()
+            )
+            entityManager.persist(articleCategory)
+
+            val article = JpaArticle(
+                articleId = 8384744815925L,
+                title = "야옹야옹",
+                content = "응애응애야오옹",
+                boardId = board.boardId,
+                articleCategoryId = articleCategory.articleCategoryId,
+                writerId = 944495345048L,
+                writerNickname = "땃쥐",
+                createdAt = appDateTimeFixture(minute = 44).toLocalDateTime(),
+                modifiedAt = appDateTimeFixture(minute = 49).toLocalDateTime()
+            )
+            entityManager.persist(article)
+
+            val articleId = article.articleId
+            val userId = null
+
+            // when
+            val articleDetail = articleReadArticleDetailStorage.read(articleId, userId)!!
+
+            // then
+            assertThat(articleDetail.commentCount).isEqualTo(0L)
+            assertThat(articleDetail.likeCount).isEqualTo(0L)
+            assertThat(articleDetail.dislikeCount).isEqualTo(0L)
+        }
+
+
+        @Test
+        @DisplayName("성공 - 회원아이디 값이 없을 경우, 좋아요 / 싫어요 여부는 false 로 반환된다.")
+        fun whenUserIdIsNullThenLikedAndDislikedAreFalse() {
+            // given
+            val board = JpaBoard(
+                boardId = 1341359813905137L,
+                name = "고양이",
+                description = "고양이 게시판입니다.",
+                managerId = 11459014851L,
+                slug = "cat",
+                createdAt = appDateTimeFixture(minute = 23).toLocalDateTime()
+            )
+            entityManager.persist(board)
+
+            val articleCategory = JpaArticleCategory(
+                articleCategoryId = 45843951154L,
+                boardId = board.boardId,
+                name = "일반",
+                slug = "general",
+                allowSelfDelete = true,
+                allowLike = true,
+                allowDislike = true,
+                createdAt = appDateTimeFixture(minute = 27).toLocalDateTime()
+            )
+            entityManager.persist(articleCategory)
+
+            val article = JpaArticle(
+                articleId = 8384744815925L,
+                title = "야옹야옹",
+                content = "응애응애야오옹",
+                boardId = board.boardId,
+                articleCategoryId = articleCategory.articleCategoryId,
+                writerId = 944495345048L,
+                writerNickname = "땃쥐",
+                createdAt = appDateTimeFixture(minute = 44).toLocalDateTime(),
+                modifiedAt = appDateTimeFixture(minute = 49).toLocalDateTime()
+            )
+            entityManager.persist(article)
+
+            val articleId = article.articleId
+            val userId = null
+
+            // when
+            val articleDetail = articleReadArticleDetailStorage.read(articleId, userId)!!
+
+            // then
+            assertThat(articleDetail.liked).isFalse()
+            assertThat(articleDetail.disliked).isFalse()
+        }
+
+
+        @Test
+        @DisplayName("사용자의 좋아요, 싫어요 내역이 없을 경우 좋아요/싫어요 여부는 false 로 반환된다.")
+        fun testLikedAndDislikedNull() {
+            // given
+            val board = JpaBoard(
+                boardId = 1341359813905137L,
+                name = "고양이",
+                description = "고양이 게시판입니다.",
+                managerId = 11459014851L,
+                slug = "cat",
+                createdAt = appDateTimeFixture(minute = 23).toLocalDateTime()
+            )
+            entityManager.persist(board)
+
+            val articleCategory = JpaArticleCategory(
+                articleCategoryId = 45843951154L,
+                boardId = board.boardId,
+                name = "일반",
+                slug = "general",
+                allowSelfDelete = true,
+                allowLike = true,
+                allowDislike = true,
+                createdAt = appDateTimeFixture(minute = 27).toLocalDateTime()
+            )
+            entityManager.persist(articleCategory)
+
+            val article = JpaArticle(
+                articleId = 8384744815925L,
+                title = "야옹야옹",
+                content = "응애응애야오옹",
+                boardId = board.boardId,
+                articleCategoryId = articleCategory.articleCategoryId,
+                writerId = 944495345048L,
+                writerNickname = "땃쥐",
+                createdAt = appDateTimeFixture(minute = 44).toLocalDateTime(),
+                modifiedAt = appDateTimeFixture(minute = 49).toLocalDateTime()
+            )
+            entityManager.persist(article)
+
+            val articleId = article.articleId
+            val userId = 8134151351513515L
+
+            // when
+            val articleDetail = articleReadArticleDetailStorage.read(articleId, userId)!!
+
+            // then
+            assertThat(articleDetail.liked).isFalse()
+            assertThat(articleDetail.disliked).isFalse()
+        }
+
+        @Test
+        @DisplayName("좋아요, 싫어요 내역이 있을 경우 좋아요/싫어요 여부는 true 로 반환된다.")
+        fun testLikedAndDislikedNotNull() {
+            // given
+            val userId = 8134151351513515L
+
+
+            val board = JpaBoard(
+                boardId = 1341359813905137L,
+                name = "고양이",
+                description = "고양이 게시판입니다.",
+                managerId = 11459014851L,
+                slug = "cat",
+                createdAt = appDateTimeFixture(minute = 23).toLocalDateTime()
+            )
+            entityManager.persist(board)
+
+            val articleCategory = JpaArticleCategory(
+                articleCategoryId = 45843951154L,
+                boardId = board.boardId,
+                name = "일반",
+                slug = "general",
+                allowSelfDelete = true,
+                allowLike = true,
+                allowDislike = true,
+                createdAt = appDateTimeFixture(minute = 27).toLocalDateTime()
+            )
+            entityManager.persist(articleCategory)
+
+            val article = JpaArticle(
+                articleId = 8384744815925L,
+                title = "야옹야옹",
+                content = "응애응애야오옹",
+                boardId = board.boardId,
+                articleCategoryId = articleCategory.articleCategoryId,
+                writerId = 944495345048L,
+                writerNickname = "땃쥐",
+                createdAt = appDateTimeFixture(minute = 44).toLocalDateTime(),
+                modifiedAt = appDateTimeFixture(minute = 49).toLocalDateTime()
+            )
+            entityManager.persist(article)
+
+            val articleId = article.articleId
+
+            val articleLike = JpaArticleLike(
+                articleLikeId = 3585585785L,
+                articleId = article.articleId,
+                userId = userId,
+                createdAt = appDateTimeFixture(minute =51).toLocalDateTime()
+            )
+            entityManager.persist(articleLike)
+
+            val articleDislike = JpaArticleDislike(
+                articleDislikeId = 48585776767676L,
+                articleId = article.articleId,
+                userId = userId,
+                createdAt = appDateTimeFixture(minute=53).toLocalDateTime()
+            )
+            entityManager.persist(articleDislike)
+
+            // when
+            val articleDetail = articleReadArticleDetailStorage.read(articleId, userId)!!
+
+            // then
+            assertThat(articleDetail.liked).isTrue()
+            assertThat(articleDetail.disliked).isTrue()
+        }
+    }
+}

--- a/board-system-infrastructure/database-adapter/src/test/kotlin/com/ttasjwi/board/system/test/DataBaseIntegrationTest.kt
+++ b/board-system-infrastructure/database-adapter/src/test/kotlin/com/ttasjwi/board/system/test/DataBaseIntegrationTest.kt
@@ -64,6 +64,9 @@ abstract class DataBaseIntegrationTest {
     protected lateinit var articleViewArticlePersistenceAdapter: com.ttasjwi.board.system.articleview.infra.persistence.ArticlePersistenceAdapter
 
     @Autowired
+    protected lateinit var articleReadArticleDetailStorage: com.ttasjwi.board.system.articleread.infra.persistence.ArticleDetailStorageImpl
+
+    @Autowired
     protected lateinit var entityManager: EntityManager
 
     protected fun flushAndClearEntityManager() {

--- a/board-system-infrastructure/database-adapter/src/test/kotlin/com/ttasjwi/board/system/user/infra/persistence/UserPersistenceAdapterTest.kt
+++ b/board-system-infrastructure/database-adapter/src/test/kotlin/com/ttasjwi/board/system/user/infra/persistence/UserPersistenceAdapterTest.kt
@@ -93,7 +93,7 @@ class UserPersistenceAdapterTest : DataBaseIntegrationTest() {
         @Test
         fun test2() {
             // given
-            val userId = 1557L
+            val userId = 31414134151557L
 
             // when
             val findUser = userUserPersistenceAdapter.findByIdOrNull(userId)

--- a/board-system-infrastructure/redis-adapter/build.gradle.kts
+++ b/board-system-infrastructure/redis-adapter/build.gradle.kts
@@ -22,4 +22,9 @@ dependencies {
     implementation(project(":board-system-article-view:article-view-domain"))
     implementation(project(":board-system-article-view:article-view-application-output-port"))
     testImplementation(testFixtures(project(":board-system-article-view:article-view-domain")))
+
+    // article-read
+    implementation(project(":board-system-article-read:article-read-domain"))
+    implementation(project(":board-system-article-read:article-read-application-output-port"))
+    testImplementation(testFixtures(project(":board-system-article-read:article-read-domain")))
 }

--- a/board-system-infrastructure/redis-adapter/src/main/kotlin/com/ttasjwi/board/system/articleread/infra/persistence/ArticleViewCountStorageImpl.kt
+++ b/board-system-infrastructure/redis-adapter/src/main/kotlin/com/ttasjwi/board/system/articleread/infra/persistence/ArticleViewCountStorageImpl.kt
@@ -1,0 +1,24 @@
+package com.ttasjwi.board.system.articleread.infra.persistence
+
+import com.ttasjwi.board.system.articleread.domain.port.ArticleViewCountStorage
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Component
+
+@Component("articleReadArticleViewCountStorageImpl")
+class ArticleViewCountStorageImpl(
+    private val redisTemplate: StringRedisTemplate
+) : ArticleViewCountStorage {
+
+    companion object {
+        private const val KEY_PATTERN = "board-system::article-view::article::%s::view-count"
+    }
+
+    override fun readViewCount(articleId: Long): Long {
+        val key = generateKey(articleId)
+        return redisTemplate.opsForValue().get(key)?.toLong() ?: return 0L
+    }
+
+    private fun generateKey(articleId: Long): String {
+        return KEY_PATTERN.format(articleId)
+    }
+}

--- a/board-system-infrastructure/redis-adapter/src/test/kotlin/com/ttasjwi/board/system/articleread/infra/persistence/ArticleViewCountStorageImplTest.kt
+++ b/board-system-infrastructure/redis-adapter/src/test/kotlin/com/ttasjwi/board/system/articleread/infra/persistence/ArticleViewCountStorageImplTest.kt
@@ -1,0 +1,57 @@
+package com.ttasjwi.board.system.articleread.infra.persistence
+
+import com.ttasjwi.board.system.test.RedisAdapterTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("[article-read-redis-adapter] ArticleViewCountStorageImpl 테스트")
+class ArticleViewCountStorageImplTest : RedisAdapterTest() {
+
+    companion object {
+        private const val KEY_PATTERN = "board-system::article-view::article::%s::view-count"
+    }
+
+    @BeforeEach
+    fun tearDown() {
+        val keys = redisTemplate.keys("board-system::article-view::article::*::view-count")
+        if (keys.isNotEmpty()) {
+            redisTemplate.delete(keys)
+        }
+    }
+
+    @Test
+    @DisplayName("조회수 저장 후 조회 성공 테스트")
+    fun readSuccessTest() {
+        // given
+        val articleId = 123153L
+        val redisKey = generateRedisKey(articleId)
+        val savedViewCount = 8L
+        redisTemplate.opsForValue().set(redisKey, savedViewCount.toString())
+
+        // when
+        val findViewCount = articleReadArticleViewCountStorageImpl.readViewCount(articleId)
+
+        // then
+        assertThat(findViewCount).isEqualTo(savedViewCount)
+    }
+
+
+    @Test
+    @DisplayName("조회수가 저장되어 있지않은 게시글 Id로 조회 시 조회수는 0이 반환된다.")
+    fun notFoundTest() {
+        // given
+        val articleId = 12143125L
+
+        // when
+        val viewCount = articleReadArticleViewCountStorageImpl.readViewCount(articleId)
+
+        // then
+        assertThat(viewCount).isEqualTo(0L)
+    }
+
+    private fun generateRedisKey(articleId: Long): String {
+        return KEY_PATTERN.format(articleId)
+    }
+}

--- a/board-system-infrastructure/redis-adapter/src/test/kotlin/com/ttasjwi/board/system/articleview/infra/persistence/ArticleViewCountPersistenceAdapterTest.kt
+++ b/board-system-infrastructure/redis-adapter/src/test/kotlin/com/ttasjwi/board/system/articleview/infra/persistence/ArticleViewCountPersistenceAdapterTest.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 
 @DisplayName("[article-view-redis-adapter] ArticleViewCountPersistenceAdapter 테스트")
-class ArticleViewCountPersistencePortFixtureTest : RedisAdapterTest() {
+class ArticleViewCountPersistenceAdapterTest : RedisAdapterTest() {
 
     @BeforeEach
     fun tearDown() {

--- a/board-system-infrastructure/redis-adapter/src/test/kotlin/com/ttasjwi/board/system/test/RedisAdapterTest.kt
+++ b/board-system-infrastructure/redis-adapter/src/test/kotlin/com/ttasjwi/board/system/test/RedisAdapterTest.kt
@@ -1,5 +1,6 @@
 package com.ttasjwi.board.system.test
 
+import com.ttasjwi.board.system.articleread.infra.persistence.ArticleViewCountStorageImpl
 import com.ttasjwi.board.system.articleview.infra.persistence.ArticleViewCountLockPersistenceAdapter
 import com.ttasjwi.board.system.articleview.infra.persistence.ArticleViewCountPersistenceAdapter
 import com.ttasjwi.board.system.user.infra.persistence.EmailVerificationPersistenceAdapter
@@ -30,6 +31,9 @@ abstract class RedisAdapterTest {
 
     @Autowired
     protected lateinit var articleViewCountLockPersistenceAdapter: ArticleViewCountLockPersistenceAdapter
+
+    @Autowired
+    protected lateinit var articleReadArticleViewCountStorageImpl: ArticleViewCountStorageImpl
 
     @Autowired
     protected lateinit var redisTemplate: StringRedisTemplate

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id(Plugins.KOTLIN_JVM.id) version Plugins.KOTLIN_JVM.version
     id(Plugins.KOTLIN_SPRING.id) version Plugins.KOTLIN_SPRING.version apply false
     id(Plugins.SPRING_BOOT.id) version Plugins.SPRING_BOOT.version apply false
+    id(Plugins.KAPT.id) version Plugins.KAPT.version apply false
     id(Plugins.SPRING_DEPENDENCY_MANAGEMENT.id) version Plugins.SPRING_DEPENDENCY_MANAGEMENT.version
     id(Plugins.JAVA_TEST_FIXTURES.id)
 }
@@ -14,6 +15,7 @@ allprojects {
     apply { plugin(Plugins.SPRING_BOOT.id) }
     apply { plugin(Plugins.SPRING_DEPENDENCY_MANAGEMENT.id) }
     apply { plugin(Plugins.JAVA_TEST_FIXTURES.id) }
+    apply { plugin(Plugins.KAPT.id) }
 
     java {
         toolchain {

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -29,6 +29,10 @@ enum class Dependencies(
     // mysql
     MYSQL_DRIVER(groupId = "com.mysql", artifactId = "mysql-connector-j"),
 
+    // querydsl
+    QUERY_DSL_JPA(groupId = "com.querydsl", artifactId = "querydsl-jpa", version = "5.1.0", classifier = "jakarta"),
+    QUERY_DSL_APT(groupId = "com.querydsl", artifactId = "querydsl-apt", version = "5.1.0", classifier = "jakarta"),
+
     // yaml message
     YAML_RESOURCE_BUNDLE(groupId = "dev.akkinoc.util", artifactId = "yaml-resource-bundle", version = "2.13.1"),
 

--- a/buildSrc/src/main/kotlin/Plugins.kt
+++ b/buildSrc/src/main/kotlin/Plugins.kt
@@ -6,6 +6,7 @@ enum class Plugins(
     KOTLIN_JVM(id = "org.jetbrains.kotlin.jvm", version = "1.9.25"),
     KOTLIN_SPRING(id = "org.jetbrains.kotlin.plugin.spring", version = "1.9.25"),
     KOTLIN_JPA(id = "org.jetbrains.kotlin.plugin.jpa", version = "1.9.25"),
+    KAPT(id="org.jetbrains.kotlin.kapt", version ="1.9.25"),
 
     SPRING_BOOT(id = "org.springframework.boot", version = "3.4.3"),
     SPRING_DEPENDENCY_MANAGEMENT(id = "io.spring.dependency-management", version = "1.1.7"),

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -65,6 +65,14 @@ include(
     "board-system-article-view:article-view-application-output-port",
     "board-system-article-view:article-view-domain",
 
+    // article-read ===================================================================================
+    "board-system-article-read",
+    "board-system-article-read:article-read-web-adapter",
+    "board-system-article-read:article-read-application-input-port",
+    "board-system-article-read:article-read-application-service",
+    "board-system-article-read:article-read-application-output-port",
+    "board-system-article-read:article-read-domain",
+
     // email-sender ==============================================================================
     "board-system-email-sender",
 


### PR DESCRIPTION
# JIRA
- [BRD-148]

---

# 개요
- 기존의 article 모듈에서 개발한 게시글 단건조회 기능에 살을 붙여서 좋아요수, 댓글수, 싫어요수 등의 기능을 덧붙일 수도 있긴하다.
  - 하지만 그렇게 할 경우 기능 맥락간 순환 참조가 발생한다.
    - 예를 들어 좋아요 맥락에서는 게시글 맥락을 의존한다. 그러나 게시글 맥락도 좋아요 기능을 의존하게 된다면, 이는 맥락간의 순환참조를 의미한다. (상호간의 순환참조는 상호간 강한 결합을 만들어버리고, 이는 기능 유지보수를 힘들게 만드는 원인이 된다.)
    - 게시글 읽기 맥락을 따로 분리하고, 게시글 읽기 맥락에서 게시글/댓글/좋아요/조회수 맥락을 의존하게 되면 순환참조 문제를 해결할 수 있다. (맥락간 의존 방향성 통제)
- 게시글 작성/수정 트래픽과 읽기 트래픽은 그 수량이 다르다. 그런데 향후 서비스가 커졌을 때 읽기 트래픽만 많아진다면? 읽기 트래픽을 위한 서비스를 따로 분리하고 이 기능을 좀 더 읽기에 특화해서 커스터마이징 하는 것이 유지보수면에서 더 효율적이다. (읽기 서비스만을 따로 확장시켜나갈 수 있고, 수평확장면에서도 효율적이다.)

---

# 조회 전략
- 현재 내가 만든 서비스는 모놀리스 시스템이다.
- 내부적으로 회원/게시판/게시글/좋아요/댓글/조회수 모듈을 따로 분리하고 있긴하지만 이들은 일단 물리적으로 같은 데이터베이스를 사용한다.
  - 관계적 데이터베이스 : MySQL
  - 인메모리 데이터베이스 : Redis
- 현재는 같은 데이터베이스를 사용한다는 장점을 살려, JOIN 쿼리를 사용해서 서로 다른 맥락의 데이터들을 취합해서 한방 쿼리를 통해 데이터를 조회하는 전략을 취할 것이다.

---

# 성능 개선 가능성
- 기본적으로 성능 개선 방향은 MySQL 질의 시, 쿼리를 튜닝해보고 인덱스를 활용해 성능을 개선시키는 전략을 사용한다.
- 그럼에서 성능 개선이 더 필요하다면? Redis 에 일부 데이터를 캐싱하는 전략도 고민해볼 것이다.

---

# 서비스가 분리됐을 경우?
- 서비스가 분리되면 데이터베이스도 분리되는 경우가 많다.
- 이 경우 Kafka 와 같은 이벤트 스트림을 활용해 각 서비스간 의존을 가능한 선에서 끊고(모두 끊는건 불가능하다. 대신 의존 방향성을 통제해가면서), 이벤트를 기반으로 데이터를 간접적으로 전송하는 방식을 취할 것이다.
  - 게시글이 생성됐다면 게시글 생성 이벤트를 발행하고, 이 이벤트를 게시글 조회 서비스가 구독해서 게시글을 별도로 저장한다.
  - 게시판이 생성/변경됐다면 게시판 생성 이벤트를 발행하고, 이 이벤트를 게시글 조회 서비스가 구독해서 게시판을 별도로 저장한다.
  - 게시글 카테고리가 생성/변경됐다면 게시글 카테고리 생성/변경 이벤트를 발행하고 이 이벤트를 게시글 조회 서비스가 구독해서 별도로 게시글 카레고리를 저장한다.
  - 게시글 조회수 증가는 매우 자주 일어나는 일이여서 매번 이벤트로 전송해서 내역을 변경하는 것은 네트워크 비용 문제를 야기할 수 있다. 조회수는 필요에 따라 조회수 서비스에서 조회해서 가져오는 것도 괜찮을 것 같다.


[BRD-148]: https://ttasjwi.atlassian.net/browse/BRD-148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ