### PR TITLE
Feature: (BRD-99) 게시글 수정 API 구현

### DIFF
--- a/board-system-app/src/docs/asciidoc/article-api.adoc
+++ b/board-system-app/src/docs/asciidoc/article-api.adoc
@@ -79,3 +79,26 @@ include::{snippets}/article-summary-infinite-scroll-read-success/response-fields
 ==== 예시
 include::{snippets}/article-summary-infinite-scroll-read-success/http-request.adoc[]
 include::{snippets}/article-summary-infinite-scroll-read-success/http-response.adoc[]
+
+=== 게시글 수정
+==== 기본정보
+- 메서드 : PUT
+- URL : `/api/v1/articles/{articleId}`
+- 권한 : 인증된 사용자 누구든지(게시글 작성자)
+- 인증방식 : 액세스 토큰
+
+게시글을 수정합니다.
+게시글 작성자만 게시글을 수정할 있고, 게시글의 카테고리 정책상 게시글을 수정할 수 있어야합니다.
+게시글의 본문, 내용이 기존과 같을 경우 게시글은 실제 변경되지 않고, 둘 중 하나가 변경되면 실제 변경됩니다. (이때 게시글의 수정일도 현재 시간으로 변경됩니다.)
+
+==== 요청
+include::{snippets}/article-update-success/request-headers.adoc[]
+include::{snippets}/article-update-success/path-parameters.adoc[]
+include::{snippets}/article-update-success/request-fields.adoc[]
+
+==== 응답
+include::{snippets}/article-update-success/response-fields.adoc[]
+
+==== 예시
+include::{snippets}/article-update-success/http-request.adoc[]
+include::{snippets}/article-update-success/http-response.adoc[]

--- a/board-system-article/article-application-input-port/src/main/kotlin/com/ttasjwi/board/system/article/domain/ArticleUpdateUseCase.kt
+++ b/board-system-article/article-application-input-port/src/main/kotlin/com/ttasjwi/board/system/article/domain/ArticleUpdateUseCase.kt
@@ -1,0 +1,24 @@
+package com.ttasjwi.board.system.article.domain
+
+import java.time.ZonedDateTime
+
+interface ArticleUpdateUseCase {
+    fun update(articleId: Long, request: ArticleUpdateRequest): ArticleUpdateResponse
+}
+
+data class ArticleUpdateRequest(
+    val title: String?,
+    val content: String?,
+)
+
+data class ArticleUpdateResponse(
+    val articleId: String,
+    val title: String,
+    val content: String,
+    val boardId: String,
+    val articleCategoryId: String,
+    val writerId: String,
+    val writerNickname: String,
+    val createdAt: ZonedDateTime,
+    val modifiedAt: ZonedDateTime,
+)

--- a/board-system-article/article-application-service/src/main/kotlin/com/ttasjwi/board/system/article/domain/ArticleUpdateUseCaseImpl.kt
+++ b/board-system-article/article-application-service/src/main/kotlin/com/ttasjwi/board/system/article/domain/ArticleUpdateUseCaseImpl.kt
@@ -1,0 +1,33 @@
+package com.ttasjwi.board.system.article.domain
+
+import com.ttasjwi.board.system.article.domain.mapper.ArticleUpdateCommandMapper
+import com.ttasjwi.board.system.article.domain.model.Article
+import com.ttasjwi.board.system.article.domain.processor.ArticleUpdateProcessor
+import com.ttasjwi.board.system.common.annotation.component.UseCase
+
+@UseCase
+internal class ArticleUpdateUseCaseImpl(
+    private val articleUpdateCommandMapper: ArticleUpdateCommandMapper,
+    private val articleUpdateProcessor: ArticleUpdateProcessor,
+) : ArticleUpdateUseCase {
+
+    override fun update(articleId: Long, request: ArticleUpdateRequest): ArticleUpdateResponse {
+        val command = articleUpdateCommandMapper.mapToCommand(articleId, request)
+        val article = articleUpdateProcessor.update(command)
+        return makeResponse(article)
+    }
+
+    private fun makeResponse(article: Article): ArticleUpdateResponse {
+        return ArticleUpdateResponse(
+            articleId = article.articleId.toString(),
+            title = article.title,
+            content= article.content,
+            boardId = article.boardId.toString(),
+            articleCategoryId = article.articleCategoryId.toString(),
+            writerId = article.writerId.toString(),
+            writerNickname = article.writerNickname,
+            createdAt = article.createdAt.toZonedDateTime(),
+            modifiedAt = article.modifiedAt.toZonedDateTime(),
+        )
+    }
+}

--- a/board-system-article/article-application-service/src/main/kotlin/com/ttasjwi/board/system/article/domain/dto/ArticleUpdateCommand.kt
+++ b/board-system-article/article-application-service/src/main/kotlin/com/ttasjwi/board/system/article/domain/dto/ArticleUpdateCommand.kt
@@ -1,0 +1,12 @@
+package com.ttasjwi.board.system.article.domain.dto
+
+import com.ttasjwi.board.system.common.auth.AuthUser
+import com.ttasjwi.board.system.common.time.AppDateTime
+
+class ArticleUpdateCommand(
+    val articleId: Long,
+    val title: String,
+    val content: String,
+    val authUser: AuthUser,
+    val currentTime: AppDateTime
+)

--- a/board-system-article/article-application-service/src/main/kotlin/com/ttasjwi/board/system/article/domain/mapper/ArticleUpdateCommandMapper.kt
+++ b/board-system-article/article-application-service/src/main/kotlin/com/ttasjwi/board/system/article/domain/mapper/ArticleUpdateCommandMapper.kt
@@ -1,0 +1,61 @@
+package com.ttasjwi.board.system.article.domain.mapper
+
+import com.ttasjwi.board.system.article.domain.ArticleUpdateRequest
+import com.ttasjwi.board.system.article.domain.dto.ArticleUpdateCommand
+import com.ttasjwi.board.system.article.domain.policy.ArticleContentPolicy
+import com.ttasjwi.board.system.article.domain.policy.ArticleTitlePolicy
+import com.ttasjwi.board.system.common.annotation.component.ApplicationCommandMapper
+import com.ttasjwi.board.system.common.auth.AuthUserLoader
+import com.ttasjwi.board.system.common.exception.NullArgumentException
+import com.ttasjwi.board.system.common.exception.ValidationExceptionCollector
+import com.ttasjwi.board.system.common.time.TimeManager
+
+@ApplicationCommandMapper
+internal class ArticleUpdateCommandMapper(
+    private val articleTitlePolicy: ArticleTitlePolicy,
+    private val articleContentPolicy: ArticleContentPolicy,
+    private val authUserLoader: AuthUserLoader,
+    private val timeManager: TimeManager,
+) {
+
+    fun mapToCommand(articleId: Long, request: ArticleUpdateRequest): ArticleUpdateCommand {
+        val exceptionCollector = ValidationExceptionCollector()
+
+        val title = getTitle(request.title, exceptionCollector)
+        val content = getContent(request.content, exceptionCollector)
+
+        exceptionCollector.throwIfNotEmpty()
+
+        return ArticleUpdateCommand(
+            articleId = articleId,
+            title = title!!,
+            content = content!!,
+            authUser = authUserLoader.loadCurrentAuthUser()!!,
+            currentTime = timeManager.now(),
+        )
+    }
+
+    private fun getTitle(title: String?, exceptionCollector: ValidationExceptionCollector): String? {
+        if (title == null) {
+            exceptionCollector.addCustomExceptionOrThrow(NullArgumentException("title"))
+            return null
+        }
+        return articleTitlePolicy.validate(title)
+            .getOrElse {
+                exceptionCollector.addCustomExceptionOrThrow(it)
+                return null
+            }
+    }
+
+    private fun getContent(content: String?, exceptionCollector: ValidationExceptionCollector): String? {
+        if (content == null) {
+            exceptionCollector.addCustomExceptionOrThrow(NullArgumentException("content"))
+            return null
+        }
+        return articleContentPolicy.validate(content)
+            .getOrElse {
+                exceptionCollector.addCustomExceptionOrThrow(it)
+                return null
+            }
+    }
+}

--- a/board-system-article/article-application-service/src/main/kotlin/com/ttasjwi/board/system/article/domain/processor/ArticleUpdateProcessor.kt
+++ b/board-system-article/article-application-service/src/main/kotlin/com/ttasjwi/board/system/article/domain/processor/ArticleUpdateProcessor.kt
@@ -1,0 +1,74 @@
+package com.ttasjwi.board.system.article.domain.processor
+
+import com.ttasjwi.board.system.article.domain.dto.ArticleUpdateCommand
+import com.ttasjwi.board.system.article.domain.exception.ArticleNotFoundException
+import com.ttasjwi.board.system.article.domain.exception.ArticleUpdateNotAllowedByCategoryRuleException
+import com.ttasjwi.board.system.article.domain.exception.ArticleUpdateNotAllowedByWriterMismatchException
+import com.ttasjwi.board.system.article.domain.model.Article
+import com.ttasjwi.board.system.article.domain.model.ArticleCategory
+import com.ttasjwi.board.system.article.domain.port.ArticleCategoryPersistencePort
+import com.ttasjwi.board.system.article.domain.port.ArticlePersistencePort
+import com.ttasjwi.board.system.common.annotation.component.ApplicationProcessor
+import org.springframework.transaction.annotation.Transactional
+
+@ApplicationProcessor
+internal class ArticleUpdateProcessor(
+    private val articlePersistencePort: ArticlePersistencePort,
+    private val articleCategoryPersistencePort: ArticleCategoryPersistencePort
+) {
+
+    @Transactional
+    fun update(command: ArticleUpdateCommand): Article {
+        // 게시글 조회
+        val article = getArticle(command.articleId)
+
+        // 소유자 여부 확인
+        checkAuthority(article, command.authUser.userId)
+
+        // 게시글 카테고리 조회
+        val articleCategory = getArticleCategory(command.articleId, article.articleCategoryId)
+
+        // 게시글 수정 정책 확인
+        checkUpdatable(article.articleId, articleCategory)
+
+        // 게시글 수정
+        val updateResult = article.update(command.title, command.content, command.currentTime)
+
+        // 실제 수정되지 않았다면 게시글을 그대로 반환, 수정됐다면 저장 후 반환
+        // 확장가능성 : 실제 수정됐다면 게시글 저장 후, 수정됐다는 이벤트를 발행하기?
+        return when (updateResult) {
+            Article.UpdateResult.UNCHANGED -> article
+            Article.UpdateResult.CHANGED -> {
+                articlePersistencePort.save(article)
+                article
+            }
+        }
+    }
+
+    private fun getArticle(articleId: Long): Article {
+        return articlePersistencePort.findByIdOrNull(articleId)
+            ?: throw ArticleNotFoundException(source = "articleId", argument = articleId)
+    }
+
+    private fun checkAuthority(article: Article, userId: Long) {
+        if (!article.isWriter(userId)) {
+            throw ArticleUpdateNotAllowedByWriterMismatchException(article.articleId, userId)
+        }
+    }
+
+    private fun getArticleCategory(articleId: Long, articleCategoryId: Long): ArticleCategory {
+        // 게시글의 카테고리는 반드시 존재해야하므로,
+        // 만약 게시글 카테고리가 조회 안 됐다면 서버 내부 예외로 간주
+        return articleCategoryPersistencePort.findByIdOrNull(articleCategoryId = articleCategoryId)
+            ?: throw IllegalStateException("게시글 카테고리 조회 실패! (articleId=$articleId, articleCategoryId=$articleCategoryId)")
+    }
+
+    private fun checkUpdatable(articleId: Long, articleCategory: ArticleCategory) {
+        if (!articleCategory.allowSelfEditDelete) {
+            throw ArticleUpdateNotAllowedByCategoryRuleException(
+                articleId = articleId,
+                articleCategoryId = articleCategory.articleCategoryId,
+            )
+        }
+    }
+}

--- a/board-system-article/article-application-service/src/test/kotlin/com/ttasjwi/board/system/article/domain/ArticleUpdateUseCaseImplTest.kt
+++ b/board-system-article/article-application-service/src/test/kotlin/com/ttasjwi/board/system/article/domain/ArticleUpdateUseCaseImplTest.kt
@@ -1,0 +1,91 @@
+package com.ttasjwi.board.system.article.domain
+
+import com.ttasjwi.board.system.article.domain.model.fixture.articleCategoryFixture
+import com.ttasjwi.board.system.article.domain.model.fixture.articleFixture
+import com.ttasjwi.board.system.article.domain.port.fixture.ArticleCategoryPersistencePortFixture
+import com.ttasjwi.board.system.article.domain.port.fixture.ArticlePersistencePortFixture
+import com.ttasjwi.board.system.article.domain.test.support.TestContainer
+import com.ttasjwi.board.system.common.auth.AuthUser
+import com.ttasjwi.board.system.common.auth.Role
+import com.ttasjwi.board.system.common.auth.fixture.authUserFixture
+import com.ttasjwi.board.system.common.time.AppDateTime
+import com.ttasjwi.board.system.common.time.fixture.appDateTimeFixture
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("[article-application-service] ArticleUpdateUseCaseImpl 테스트")
+class ArticleUpdateUseCaseImplTest {
+
+    private lateinit var useCase: ArticleUpdateUseCase
+    private lateinit var authUser: AuthUser
+    private lateinit var currentTime: AppDateTime
+    private lateinit var articlePersistencePortFixture: ArticlePersistencePortFixture
+    private lateinit var articleCategoryPersistencePortFixture: ArticleCategoryPersistencePortFixture
+
+    @BeforeEach
+    fun setup() {
+        val container = TestContainer.create()
+        useCase = container.articleUpdateUseCase
+
+        currentTime = appDateTimeFixture(minute = 3)
+        authUser = authUserFixture(userId = 1234558L, role = Role.USER)
+
+        container.timeManagerFixture.changeCurrentTime(currentTime)
+        container.authUserLoaderFixture.changeAuthUser(authUser)
+
+        articlePersistencePortFixture = container.articlePersistencePortFixture
+        articleCategoryPersistencePortFixture = container.articleCategoryPersistencePortFixture
+    }
+
+    @Test
+    @DisplayName("성공 테스트")
+    fun testSuccess() {
+        // given
+        val prevTitle = "title"
+        val prevContent = "content"
+
+        val newTitle = "new title"
+        val newContent = "new content"
+
+        val article = articlePersistencePortFixture.save(
+            articleFixture(
+                title = prevTitle,
+                content = prevContent,
+                writerId = authUser.userId,
+                createdAt = appDateTimeFixture(minute = 0),
+                modifiedAt = appDateTimeFixture(minute = 0)
+            )
+        )
+
+        articleCategoryPersistencePortFixture.save(
+            articleCategoryFixture(
+                articleCategoryId = article.articleCategoryId,
+                allowSelfEditDelete = true
+            )
+        )
+
+        val articleId = article.articleId
+        val request = ArticleUpdateRequest(
+            title = newTitle,
+            content = newContent,
+        )
+
+        // when
+        val response = useCase.update(articleId, request)
+
+        // then
+        val findArticle = articlePersistencePortFixture.findByIdOrNull(article.articleId)!!
+
+        assertThat(response.articleId).isEqualTo(articleId.toString())
+        assertThat(response.title).isEqualTo(request.title)
+        assertThat(response.content).isEqualTo(request.content)
+        assertThat(response.modifiedAt).isEqualTo(currentTime.toZonedDateTime())
+
+        assertThat(findArticle.articleId).isEqualTo(articleId)
+        assertThat(findArticle.title).isEqualTo(response.title)
+        assertThat(findArticle.content).isEqualTo(response.content)
+        assertThat(findArticle.modifiedAt).isEqualTo(currentTime)
+    }
+}

--- a/board-system-article/article-application-service/src/test/kotlin/com/ttasjwi/board/system/article/domain/mapper/ArticleUpdateCommandMapperTest.kt
+++ b/board-system-article/article-application-service/src/test/kotlin/com/ttasjwi/board/system/article/domain/mapper/ArticleUpdateCommandMapperTest.kt
@@ -1,0 +1,148 @@
+package com.ttasjwi.board.system.article.domain.mapper
+
+import com.ttasjwi.board.system.article.domain.ArticleUpdateRequest
+import com.ttasjwi.board.system.article.domain.policy.fixture.ArticleContentPolicyFixture
+import com.ttasjwi.board.system.article.domain.policy.fixture.ArticleTitlePolicyFixture
+import com.ttasjwi.board.system.article.domain.test.support.TestContainer
+import com.ttasjwi.board.system.common.auth.AuthUser
+import com.ttasjwi.board.system.common.auth.Role
+import com.ttasjwi.board.system.common.auth.fixture.authUserFixture
+import com.ttasjwi.board.system.common.exception.CustomException
+import com.ttasjwi.board.system.common.exception.NullArgumentException
+import com.ttasjwi.board.system.common.exception.ValidationExceptionCollector
+import com.ttasjwi.board.system.common.time.AppDateTime
+import com.ttasjwi.board.system.common.time.fixture.appDateTimeFixture
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+@DisplayName("[article-application-service] ArticleUpdateCommandMapper 테스트")
+class ArticleUpdateCommandMapperTest {
+    private lateinit var articleUpdateCommandMapper: ArticleUpdateCommandMapper
+    private lateinit var authUser: AuthUser
+    private lateinit var currentTime: AppDateTime
+
+    @BeforeEach
+    fun setup() {
+        val container = TestContainer.create()
+        articleUpdateCommandMapper = container.articleUpdateCommandMapper
+
+        currentTime = appDateTimeFixture(minute = 14)
+        authUser = authUserFixture(userId = 1234558L, role = Role.USER)
+
+        container.timeManagerFixture.changeCurrentTime(currentTime)
+        container.authUserLoaderFixture.changeAuthUser(authUser)
+    }
+
+
+    @Test
+    @DisplayName("입력값들이 유효하면 명령이 생성된다.")
+    fun successTest() {
+        // given
+        val articleId = 123455L
+        val request = ArticleUpdateRequest(
+            title = "새 제목",
+            content = "새 본문",
+        )
+
+        // when
+        val command = articleUpdateCommandMapper.mapToCommand(articleId, request)
+
+        // then
+        assertThat(command.articleId).isEqualTo(articleId)
+        assertThat(command.title).isEqualTo(request.title)
+        assertThat(command.content).isEqualTo(request.content)
+        assertThat(command.authUser).isEqualTo(authUser)
+        assertThat(command.currentTime).isEqualTo(currentTime)
+    }
+
+    @Test
+    @DisplayName("게시글 제목이 누락되면 예외 발생")
+    fun titleNullTest() {
+        // given
+        val articleId = 123455L
+        val request = ArticleUpdateRequest(
+            title = null,
+            content = "새 본문",
+        )
+
+        // when
+        val ex = assertThrows<ValidationExceptionCollector> {
+            articleUpdateCommandMapper.mapToCommand(articleId, request)
+        }
+
+        // then
+        val exceptions = ex.getExceptions()
+        assertThat(exceptions.size).isEqualTo(1)
+        assertThat(exceptions[0]).isInstanceOf(NullArgumentException::class.java)
+        assertThat(exceptions[0].source).isEqualTo("title")
+    }
+
+    @Test
+    @DisplayName("제목 포맷이 유효하지 않으면 예외 발생")
+    fun invalidTitleFormatTest() {
+        // given
+        val articleId = 123455L
+        val request = ArticleUpdateRequest(
+            title = ArticleTitlePolicyFixture.ERROR_TITLE,
+            content = "새 본문",
+        )
+
+        // when
+        val ex = assertThrows<ValidationExceptionCollector> {
+            articleUpdateCommandMapper.mapToCommand(articleId, request)
+        }
+
+        // then
+        val exceptions = ex.getExceptions()
+        assertThat(exceptions.size).isEqualTo(1)
+        assertThat(exceptions[0]).isInstanceOf(CustomException::class.java)
+        assertThat(exceptions[0].message).isEqualTo("픽스쳐 예외 : 게시글 제목의 포맷이 유효하지 않습니다.")
+    }
+
+    @Test
+    @DisplayName("게시글 본문이 누락되면 예외 발생")
+    fun contentNullTest() {
+        // given
+        val articleId = 123455L
+        val request = ArticleUpdateRequest(
+            title = "새 제목",
+            content = null,
+        )
+
+        // when
+        val ex = assertThrows<ValidationExceptionCollector> {
+            articleUpdateCommandMapper.mapToCommand(articleId, request)
+        }
+
+        // then
+        val exceptions = ex.getExceptions()
+        assertThat(exceptions.size).isEqualTo(1)
+        assertThat(exceptions[0]).isInstanceOf(NullArgumentException::class.java)
+        assertThat(exceptions[0].source).isEqualTo("content")
+    }
+
+    @Test
+    @DisplayName("본문 포맷이 유효하지 않으면 예외 발생")
+    fun invalidContentFormatTest() {
+        // given
+        val articleId = 123455L
+        val request = ArticleUpdateRequest(
+            title = "새 제목",
+            content = ArticleContentPolicyFixture.ERROR_CONTENT,
+        )
+
+        // when
+        val ex = assertThrows<ValidationExceptionCollector> {
+            articleUpdateCommandMapper.mapToCommand(articleId, request)
+        }
+
+        // then
+        val exceptions = ex.getExceptions()
+        assertThat(exceptions.size).isEqualTo(1)
+        assertThat(exceptions[0]).isInstanceOf(CustomException::class.java)
+        assertThat(exceptions[0].message).isEqualTo("픽스쳐 예외 : 게시글 본문의 포맷이 유효하지 않습니다.")
+    }
+}

--- a/board-system-article/article-application-service/src/test/kotlin/com/ttasjwi/board/system/article/domain/processor/ArticleUpdateProcessorTest.kt
+++ b/board-system-article/article-application-service/src/test/kotlin/com/ttasjwi/board/system/article/domain/processor/ArticleUpdateProcessorTest.kt
@@ -1,0 +1,296 @@
+package com.ttasjwi.board.system.article.domain.processor
+
+import com.ttasjwi.board.system.article.domain.dto.ArticleUpdateCommand
+import com.ttasjwi.board.system.article.domain.exception.ArticleNotFoundException
+import com.ttasjwi.board.system.article.domain.exception.ArticleUpdateNotAllowedByCategoryRuleException
+import com.ttasjwi.board.system.article.domain.exception.ArticleUpdateNotAllowedByWriterMismatchException
+import com.ttasjwi.board.system.article.domain.model.fixture.articleCategoryFixture
+import com.ttasjwi.board.system.article.domain.model.fixture.articleFixture
+import com.ttasjwi.board.system.article.domain.port.fixture.ArticleCategoryPersistencePortFixture
+import com.ttasjwi.board.system.article.domain.port.fixture.ArticlePersistencePortFixture
+import com.ttasjwi.board.system.article.domain.test.support.TestContainer
+import com.ttasjwi.board.system.common.auth.Role
+import com.ttasjwi.board.system.common.auth.fixture.authUserFixture
+import com.ttasjwi.board.system.common.time.fixture.appDateTimeFixture
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+@DisplayName("[article-application-service] ArticleUpdateProcessor 테스트")
+class ArticleUpdateProcessorTest {
+
+    private lateinit var processor: ArticleUpdateProcessor
+    private lateinit var articlePersistencePortFixture: ArticlePersistencePortFixture
+    private lateinit var articleCategoryPersistencePortFixture: ArticleCategoryPersistencePortFixture
+
+    @BeforeEach
+    fun setUp() {
+        val container = TestContainer.create()
+        processor = container.articleUpdateProcessor
+        articlePersistencePortFixture = container.articlePersistencePortFixture
+        articleCategoryPersistencePortFixture = container.articleCategoryPersistencePortFixture
+    }
+
+    @Test
+    @DisplayName("성공 - 게시글 제목/내용 변경 됐을 때")
+    fun testSuccess1() {
+        // given
+        val prevTitle = "title"
+        val prevContent = "content"
+
+        val newTitle = "new title"
+        val newContent = "new content"
+        val user = authUserFixture(userId = 12345L, role = Role.USER)
+
+        val article = articlePersistencePortFixture.save(
+            articleFixture(
+                title = prevTitle,
+                content = prevContent,
+                writerId = user.userId,
+                createdAt = appDateTimeFixture(minute = 0),
+                modifiedAt = appDateTimeFixture(minute = 0)
+            )
+        )
+
+        articleCategoryPersistencePortFixture.save(
+            articleCategoryFixture(
+                articleCategoryId = article.articleCategoryId,
+                allowSelfEditDelete = true
+            )
+        )
+
+        val command = ArticleUpdateCommand(
+            title = newTitle,
+            content = newContent,
+            articleId = article.articleId,
+            authUser = user,
+            currentTime = appDateTimeFixture(minute = 3),
+        )
+
+        // when
+        val updatedArticle = processor.update(command)
+
+        // then
+        val findArticle = articlePersistencePortFixture.findByIdOrNull(article.articleId)!!
+
+        assertThat(updatedArticle.articleId).isEqualTo(command.articleId)
+        assertThat(updatedArticle.title).isEqualTo(newTitle)
+        assertThat(updatedArticle.content).isEqualTo(newContent)
+        assertThat(updatedArticle.modifiedAt).isEqualTo(command.currentTime)
+
+        assertThat(findArticle.articleId).isEqualTo(command.articleId)
+        assertThat(findArticle.title).isEqualTo(updatedArticle.title)
+        assertThat(findArticle.content).isEqualTo(updatedArticle.content)
+        assertThat(findArticle.modifiedAt).isEqualTo(updatedArticle.modifiedAt)
+    }
+
+    @Test
+    @DisplayName("성공 - 게시글 제목/내용 변경 안 됐을 때")
+    fun testSuccess2() {
+        // given
+        val prevTitle = "title"
+        val prevContent = "content"
+
+        val newTitle = "title"
+        val newContent = "content"
+        val user = authUserFixture(userId = 12345L, role = Role.USER)
+
+        val article = articlePersistencePortFixture.save(
+            articleFixture(
+                title = prevTitle,
+                content = prevContent,
+                writerId = user.userId,
+                createdAt = appDateTimeFixture(minute = 0),
+                modifiedAt = appDateTimeFixture(minute = 0)
+            )
+        )
+
+        articleCategoryPersistencePortFixture.save(
+            articleCategoryFixture(
+                articleCategoryId = article.articleCategoryId,
+                allowSelfEditDelete = true
+            )
+        )
+
+        val command = ArticleUpdateCommand(
+            title = newTitle,
+            content = newContent,
+            articleId = article.articleId,
+            authUser = user,
+            currentTime = appDateTimeFixture(minute = 3),
+        )
+
+        // when
+        val updatedArticle = processor.update(command)
+
+        // then
+        val findArticle = articlePersistencePortFixture.findByIdOrNull(article.articleId)!!
+
+        assertThat(updatedArticle.articleId).isEqualTo(command.articleId)
+        assertThat(updatedArticle.title).isEqualTo(prevTitle)
+        assertThat(updatedArticle.content).isEqualTo(prevContent)
+        assertThat(updatedArticle.modifiedAt).isEqualTo(appDateTimeFixture(minute = 0))
+
+        assertThat(findArticle.articleId).isEqualTo(command.articleId)
+        assertThat(findArticle.title).isEqualTo(updatedArticle.title)
+        assertThat(findArticle.content).isEqualTo(updatedArticle.content)
+        assertThat(findArticle.modifiedAt).isEqualTo(updatedArticle.modifiedAt)
+    }
+
+    @Test
+    @DisplayName("실패 - 게시글 조회 실패")
+    fun testArticleNotFound() {
+        // given
+        val newTitle = "new title"
+        val newContent = "new content"
+        val user = authUserFixture(userId = 12345L, role = Role.USER)
+
+        val command = ArticleUpdateCommand(
+            title = newTitle,
+            content = newContent,
+            articleId = 53413413L,
+            authUser = user,
+            currentTime = appDateTimeFixture(minute = 3),
+        )
+
+        // when
+        val exception = assertThrows<ArticleNotFoundException> {
+            processor.update(command)
+        }
+
+        // then
+        assertThat(exception.args).containsExactly("articleId", command.articleId)
+    }
+
+    @Test
+    @DisplayName("실패 - 글 작성자가 아닌 사람이 수정할 때")
+    fun testWriterMismatch() {
+        // given
+        val prevTitle = "title"
+        val prevContent = "content"
+
+        val newTitle = "new title"
+        val newContent = "new content"
+        val user = authUserFixture(userId = 12345L, role = Role.USER)
+
+        val article = articlePersistencePortFixture.save(
+            articleFixture(
+                title = prevTitle,
+                content = prevContent,
+                writerId = 14141235L,
+                createdAt = appDateTimeFixture(minute = 0),
+                modifiedAt = appDateTimeFixture(minute = 0)
+            )
+        )
+
+        articleCategoryPersistencePortFixture.save(
+            articleCategoryFixture(
+                articleCategoryId = article.articleCategoryId,
+                allowSelfEditDelete = true
+            )
+        )
+
+        val command = ArticleUpdateCommand(
+            title = newTitle,
+            content = newContent,
+            articleId = article.articleId,
+            authUser = user,
+            currentTime = appDateTimeFixture(minute = 3),
+        )
+
+        // when
+        val exception = assertThrows<ArticleUpdateNotAllowedByWriterMismatchException> {
+            processor.update(command)
+        }
+
+        // then
+        assertThat(exception.args).containsExactly(command.articleId, command.authUser.userId)
+    }
+
+    @Test
+    @DisplayName("실패 - 게시글 카테고리 조회 실패 (서버 에러)")
+    fun testArticleCategoryNotFound() {
+        // given
+        val prevTitle = "title"
+        val prevContent = "content"
+
+        val newTitle = "new title"
+        val newContent = "new content"
+        val user = authUserFixture(userId = 12345L, role = Role.USER)
+
+        val article = articlePersistencePortFixture.save(
+            articleFixture(
+                title = prevTitle,
+                content = prevContent,
+                writerId = user.userId,
+                createdAt = appDateTimeFixture(minute = 0),
+                modifiedAt = appDateTimeFixture(minute = 0)
+            )
+        )
+
+        val command = ArticleUpdateCommand(
+            title = newTitle,
+            content = newContent,
+            articleId = article.articleId,
+            authUser = user,
+            currentTime = appDateTimeFixture(minute = 3),
+        )
+
+        // when
+        val exception = assertThrows<IllegalStateException> {
+            processor.update(command)
+        }
+
+        // then
+        assertThat(exception.message).isEqualTo("게시글 카테고리 조회 실패! (articleId=${command.articleId}, articleCategoryId=${article.articleCategoryId})")
+    }
+
+    // 실패 : 게시글 카테고리 정책에 의해 게시글 수정이 불가능할 때
+    @Test
+    @DisplayName("실패 - 게시글 카테고리 정책에 의해 게시글 수정이 불가능할 때")
+    fun testFailedCausedByArticleCategoryRule() {
+        // given
+        val prevTitle = "title"
+        val prevContent = "content"
+
+        val newTitle = "new title"
+        val newContent = "new content"
+        val user = authUserFixture(userId = 12345L, role = Role.USER)
+
+        val article = articlePersistencePortFixture.save(
+            articleFixture(
+                title = prevTitle,
+                content = prevContent,
+                writerId = user.userId,
+                createdAt = appDateTimeFixture(minute = 0),
+                modifiedAt = appDateTimeFixture(minute = 0)
+            )
+        )
+
+        articleCategoryPersistencePortFixture.save(
+            articleCategoryFixture(
+                articleCategoryId = article.articleCategoryId,
+                allowSelfEditDelete = false
+            )
+        )
+
+        val command = ArticleUpdateCommand(
+            title = newTitle,
+            content = newContent,
+            articleId = article.articleId,
+            authUser = user,
+            currentTime = appDateTimeFixture(minute = 3),
+        )
+
+        // when
+        val exception = assertThrows<ArticleUpdateNotAllowedByCategoryRuleException> {
+            processor.update(command)
+        }
+
+        // then
+        assertThat(exception.args).containsExactly(command.articleId, article.articleCategoryId)
+    }
+
+}

--- a/board-system-article/article-application-service/src/test/kotlin/com/ttasjwi/board/system/article/domain/test/support/TestContainer.kt
+++ b/board-system-article/article-application-service/src/test/kotlin/com/ttasjwi/board/system/article/domain/test/support/TestContainer.kt
@@ -1,9 +1,11 @@
 package com.ttasjwi.board.system.article.domain.test.support
 
 import com.ttasjwi.board.system.article.domain.*
+import com.ttasjwi.board.system.article.domain.dto.ArticleUpdateCommand
 import com.ttasjwi.board.system.article.domain.mapper.ArticleCreateCommandMapper
 import com.ttasjwi.board.system.article.domain.mapper.ArticleInfiniteScrollReadQueryMapper
 import com.ttasjwi.board.system.article.domain.mapper.ArticlePageReadQueryMapper
+import com.ttasjwi.board.system.article.domain.mapper.ArticleUpdateCommandMapper
 import com.ttasjwi.board.system.article.domain.policy.fixture.ArticleContentPolicyFixture
 import com.ttasjwi.board.system.article.domain.policy.fixture.ArticleTitlePolicyFixture
 import com.ttasjwi.board.system.article.domain.port.fixture.ArticleCategoryPersistencePortFixture
@@ -12,6 +14,7 @@ import com.ttasjwi.board.system.article.domain.port.fixture.ArticleWriterNicknam
 import com.ttasjwi.board.system.article.domain.processor.ArticleCreateProcessor
 import com.ttasjwi.board.system.article.domain.processor.ArticleInfiniteScrollReadProcessor
 import com.ttasjwi.board.system.article.domain.processor.ArticlePageReadProcessor
+import com.ttasjwi.board.system.article.domain.processor.ArticleUpdateProcessor
 import com.ttasjwi.board.system.common.auth.fixture.AuthUserLoaderFixture
 import com.ttasjwi.board.system.common.time.fixture.TimeManagerFixture
 
@@ -45,6 +48,15 @@ internal class TestContainer private constructor() {
         )
     }
 
+    val articleUpdateCommandMapper: ArticleUpdateCommandMapper by lazy {
+        ArticleUpdateCommandMapper(
+            articleTitlePolicy = articleTitlePolicyFixture,
+            articleContentPolicy = articleContentPolicyFixture,
+            authUserLoader = authUserLoaderFixture,
+            timeManager = timeManagerFixture,
+        )
+    }
+
     // query mapper
     val articlePageReadQueryMapper: ArticlePageReadQueryMapper by lazy {
         ArticlePageReadQueryMapper()
@@ -59,6 +71,13 @@ internal class TestContainer private constructor() {
             articlePersistencePort = articlePersistencePortFixture,
             articleCategoryPersistencePort = articleCategoryPersistencePortFixture,
             articleWriterNicknamePersistencePort = articleWriterNicknamePersistencePortFixture,
+        )
+    }
+
+    val articleUpdateProcessor: ArticleUpdateProcessor by lazy {
+        ArticleUpdateProcessor(
+            articlePersistencePort = articlePersistencePortFixture,
+            articleCategoryPersistencePort = articleCategoryPersistencePortFixture,
         )
     }
 
@@ -79,6 +98,13 @@ internal class TestContainer private constructor() {
         ArticleCreateUseCaseImpl(
             commandMapper = articleCreateCommandMapper,
             processor = articleCreateProcessor,
+        )
+    }
+
+    val articleUpdateUseCase: ArticleUpdateUseCase by lazy {
+        ArticleUpdateUseCaseImpl(
+            articleUpdateCommandMapper = articleUpdateCommandMapper,
+            articleUpdateProcessor = articleUpdateProcessor,
         )
     }
 

--- a/board-system-article/article-domain/src/main/kotlin/com/ttasjwi/board/system/article/domain/exception/ArticleUpdateNotAllowedByCategoryRuleException.kt
+++ b/board-system-article/article-domain/src/main/kotlin/com/ttasjwi/board/system/article/domain/exception/ArticleUpdateNotAllowedByCategoryRuleException.kt
@@ -1,0 +1,15 @@
+package com.ttasjwi.board.system.article.domain.exception
+
+import com.ttasjwi.board.system.common.exception.CustomException
+import com.ttasjwi.board.system.common.exception.ErrorStatus
+
+class ArticleUpdateNotAllowedByCategoryRuleException(
+    articleId: Long,
+    articleCategoryId: Long,
+): CustomException(
+    status = ErrorStatus.FORBIDDEN,
+    code = "Error.ArticleUpdateNotAllowed.ByCategoryRule",
+    args = listOf(articleId, articleCategoryId),
+    source = "articleId",
+    debugMessage = "게시글의 카테고리 규칙에 따라, 게시글을 수정할 수 없습니다. (articleId=$articleId, articleCategoryId=$articleCategoryId)"
+)

--- a/board-system-article/article-domain/src/main/kotlin/com/ttasjwi/board/system/article/domain/exception/ArticleUpdateNotAllowedByWriterMismatchException.kt
+++ b/board-system-article/article-domain/src/main/kotlin/com/ttasjwi/board/system/article/domain/exception/ArticleUpdateNotAllowedByWriterMismatchException.kt
@@ -1,0 +1,15 @@
+package com.ttasjwi.board.system.article.domain.exception
+
+import com.ttasjwi.board.system.common.exception.CustomException
+import com.ttasjwi.board.system.common.exception.ErrorStatus
+
+class ArticleUpdateNotAllowedByWriterMismatchException(
+    articleId: Long,
+    requesterUserId: Long,
+): CustomException(
+    status = ErrorStatus.FORBIDDEN,
+    code = "Error.ArticleUpdateNotAllowed.ByWriterMismatch",
+    args = listOf(articleId, requesterUserId),
+    source = "articleId",
+    debugMessage = "게시글의 작성자가 아니므로, 게시글을 수정할 수 없습니다. (articleId=$articleId, requesterUserId=$requesterUserId)"
+)

--- a/board-system-article/article-domain/src/main/kotlin/com/ttasjwi/board/system/article/domain/model/Article.kt
+++ b/board-system-article/article-domain/src/main/kotlin/com/ttasjwi/board/system/article/domain/model/Article.kt
@@ -78,6 +78,24 @@ internal constructor(
         }
     }
 
+    fun isWriter(userId: Long): Boolean {
+        return this.writerId == userId
+    }
+
+    fun update(title: String, content: String, modifiedAt: AppDateTime): UpdateResult {
+        if (title == this.title && content == this.content) {
+            return UpdateResult.UNCHANGED
+        }
+        this.title = title
+        this.content = content
+        this.modifiedAt = modifiedAt
+        return UpdateResult.CHANGED
+    }
+
+    enum class UpdateResult {
+        CHANGED, UNCHANGED
+    }
+
     override fun toString(): String {
         return "Article(articleId=$articleId, title='$title', content='$content', boardId=$boardId, articleCategoryId=$articleCategoryId, writerId=$writerId, writerNickname='$writerNickname', createdAt=$createdAt, modifiedAt=$modifiedAt)"
     }

--- a/board-system-article/article-domain/src/test/kotlin/com/ttasjwi/board/system/article/domain/exception/ArticleCategoryNotFoundExceptionTest.kt
+++ b/board-system-article/article-domain/src/test/kotlin/com/ttasjwi/board/system/article/domain/exception/ArticleCategoryNotFoundExceptionTest.kt
@@ -5,7 +5,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 
-@DisplayName("ArticleCategoryNotFoundException: 게시글 카테고리를 찾지 못했을 때 발생하는 예외")
+@DisplayName("[article-domain] ArticleCategoryNotFoundException 테스트")
 class ArticleCategoryNotFoundExceptionTest {
     @Test
     @DisplayName("예외 기본값 테스트")

--- a/board-system-article/article-domain/src/test/kotlin/com/ttasjwi/board/system/article/domain/exception/ArticleNotFoundExceptionTest.kt
+++ b/board-system-article/article-domain/src/test/kotlin/com/ttasjwi/board/system/article/domain/exception/ArticleNotFoundExceptionTest.kt
@@ -5,7 +5,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 
-@DisplayName("ArticleNotFoundException: 게시글을 찾지 못했을 때 발생하는 예외")
+@DisplayName("[article-domain] ArticleNotFoundException 테스트")
 class ArticleNotFoundExceptionTest {
     @Test
     @DisplayName("예외 기본값 테스트")

--- a/board-system-article/article-domain/src/test/kotlin/com/ttasjwi/board/system/article/domain/exception/ArticleUpdateNotAllowedByCategoryRuleExceptionTest.kt
+++ b/board-system-article/article-domain/src/test/kotlin/com/ttasjwi/board/system/article/domain/exception/ArticleUpdateNotAllowedByCategoryRuleExceptionTest.kt
@@ -1,0 +1,29 @@
+package com.ttasjwi.board.system.article.domain.exception
+
+import com.ttasjwi.board.system.common.exception.ErrorStatus
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("[article-domain] ArticleUpdateNotAllowedExceptionByCategoryRuleException 테스트")
+class ArticleUpdateNotAllowedByCategoryRuleExceptionTest {
+
+    @Test
+    @DisplayName("예외 기본값 테스트")
+    fun test() {
+        val articleId = 12313541L
+        val articleCategoryId = 1213444L
+        val exception = ArticleUpdateNotAllowedByCategoryRuleException(
+            articleId = articleId,
+            articleCategoryId = articleCategoryId
+        )
+
+        assertThat(exception.status).isEqualTo(ErrorStatus.FORBIDDEN)
+        assertThat(exception.code).isEqualTo("Error.ArticleUpdateNotAllowed.ByCategoryRule")
+        assertThat(exception.source).isEqualTo("articleId")
+        assertThat(exception.args).containsExactly(articleId, articleCategoryId)
+        assertThat(exception.message).isEqualTo(exception.debugMessage)
+        assertThat(exception.cause).isNull()
+        assertThat(exception.debugMessage).isEqualTo("게시글의 카테고리 규칙에 따라, 게시글을 수정할 수 없습니다. (articleId=$articleId, articleCategoryId=$articleCategoryId)")
+    }
+}

--- a/board-system-article/article-domain/src/test/kotlin/com/ttasjwi/board/system/article/domain/exception/ArticleUpdateNotAllowedByWriterMismatchExceptionTest.kt
+++ b/board-system-article/article-domain/src/test/kotlin/com/ttasjwi/board/system/article/domain/exception/ArticleUpdateNotAllowedByWriterMismatchExceptionTest.kt
@@ -1,0 +1,29 @@
+package com.ttasjwi.board.system.article.domain.exception
+
+import com.ttasjwi.board.system.common.exception.ErrorStatus
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("[article-domain] ArticleUpdateNotAllowedByWriterMismatchException 테스트")
+class ArticleUpdateNotAllowedByWriterMismatchExceptionTest {
+
+    @Test
+    @DisplayName("예외 기본값 테스트")
+    fun test() {
+        val articleId = 12313541L
+        val requesterUserId = 1213444L
+        val exception = ArticleUpdateNotAllowedByWriterMismatchException(
+            articleId = articleId,
+            requesterUserId = requesterUserId
+        )
+
+        assertThat(exception.status).isEqualTo(ErrorStatus.FORBIDDEN)
+        assertThat(exception.code).isEqualTo("Error.ArticleUpdateNotAllowed.ByWriterMismatch")
+        assertThat(exception.source).isEqualTo("articleId")
+        assertThat(exception.args).containsExactly(articleId, requesterUserId)
+        assertThat(exception.message).isEqualTo(exception.debugMessage)
+        assertThat(exception.cause).isNull()
+        assertThat(exception.debugMessage).isEqualTo("게시글의 작성자가 아니므로, 게시글을 수정할 수 없습니다. (articleId=$articleId, requesterUserId=$requesterUserId)")
+    }
+}

--- a/board-system-article/article-domain/src/test/kotlin/com/ttasjwi/board/system/article/domain/exception/ArticleWriteNotAllowedExceptionTest.kt
+++ b/board-system-article/article-domain/src/test/kotlin/com/ttasjwi/board/system/article/domain/exception/ArticleWriteNotAllowedExceptionTest.kt
@@ -1,7 +1,6 @@
 package com.ttasjwi.board.system.article.domain.exception
 
 import com.ttasjwi.board.system.common.exception.ErrorStatus
-import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -15,12 +14,12 @@ class ArticleWriteNotAllowedExceptionTest {
         val articleCategoryId = 1213444L
         val exception = ArticleWriteNotAllowedException(articleCategoryId = articleCategoryId)
 
-        Assertions.assertThat(exception.status).isEqualTo(ErrorStatus.FORBIDDEN)
-        Assertions.assertThat(exception.code).isEqualTo("Error.ArticleWriteNotAllowed")
+        assertThat(exception.status).isEqualTo(ErrorStatus.FORBIDDEN)
+        assertThat(exception.code).isEqualTo("Error.ArticleWriteNotAllowed")
         assertThat(exception.source).isEqualTo("articleCategoryId")
         assertThat(exception.args).containsExactly(articleCategoryId)
         assertThat(exception.message).isEqualTo(exception.debugMessage)
-        Assertions.assertThat(exception.cause).isNull()
+        assertThat(exception.cause).isNull()
         assertThat(exception.debugMessage).isEqualTo("게시글 카테고리 정책에 의해 게시글 작성이 불가능합니다. (articleCategoryId=$articleCategoryId)")
     }
 }

--- a/board-system-article/article-domain/src/test/kotlin/com/ttasjwi/board/system/article/domain/exception/ArticleWriterNicknameNotFoundExceptionTest.kt
+++ b/board-system-article/article-domain/src/test/kotlin/com/ttasjwi/board/system/article/domain/exception/ArticleWriterNicknameNotFoundExceptionTest.kt
@@ -5,7 +5,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 
-@DisplayName("ArticleWriterNicknameNotFoundException: 게시글 작성시 사용자 닉네임 조회에 실패했을 때 발생하는 예외")
+@DisplayName("[article-domain] ArticleWriterNicknameNotFoundException 테스트")
 class ArticleWriterNicknameNotFoundExceptionTest {
     @Test
     @DisplayName("예외 기본값 테스트")

--- a/board-system-article/article-domain/src/test/kotlin/com/ttasjwi/board/system/article/domain/exception/InvalidArticleContentFormatExceptionTest.kt
+++ b/board-system-article/article-domain/src/test/kotlin/com/ttasjwi/board/system/article/domain/exception/InvalidArticleContentFormatExceptionTest.kt
@@ -6,7 +6,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 
-@DisplayName("InvalidArticleContentFormatException: 유효하지 않은 게시글 본문 포맷일 때 발생하는 예외")
+@DisplayName("[article-domain] InvalidArticleContentFormatException 테스트")
 class InvalidArticleContentFormatExceptionTest {
 
     @Test

--- a/board-system-article/article-domain/src/test/kotlin/com/ttasjwi/board/system/article/domain/exception/InvalidArticleTitleFormatExceptionTest.kt
+++ b/board-system-article/article-domain/src/test/kotlin/com/ttasjwi/board/system/article/domain/exception/InvalidArticleTitleFormatExceptionTest.kt
@@ -6,7 +6,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 
-@DisplayName("InvalidArticleTitleFormatException: 유효하지 않은 게시글 제목 포맷일 때 발생하는 예외")
+@DisplayName("[article-domain] InvalidArticleTitleFormatException: 유효하지 않은 게시글 제목 포맷일 때 발생하는 예외")
 class InvalidArticleTitleFormatExceptionTest {
 
     @Test

--- a/board-system-article/article-domain/src/test/kotlin/com/ttasjwi/board/system/article/domain/model/ArticleTest.kt
+++ b/board-system-article/article-domain/src/test/kotlin/com/ttasjwi/board/system/article/domain/model/ArticleTest.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-@DisplayName("Article: 게시글 테스트")
+@DisplayName("[article-domain] Article: 게시글 테스트")
 class ArticleTest {
 
     @Nested
@@ -96,6 +96,175 @@ class ArticleTest {
             assertThat(article.modifiedAt.toLocalDateTime()).isEqualTo(modifiedAt)
         }
     }
+
+    @Nested
+    @DisplayName("isWriter: 작성자가 맞는지 확인한다.")
+    inner class IsWriterTest {
+
+
+        @Test
+        @DisplayName("작성자가 맞으면 true 를 반환한다.")
+        fun test1() {
+            // given
+            val article = articleFixture(writerId = 125L)
+            val userId = article.writerId
+
+            // when
+            val isWriter = article.isWriter(userId)
+
+            // then
+            assertThat(isWriter).isTrue()
+        }
+
+
+        @Test
+        @DisplayName("작성자가 아니면 false 를 반환한다.")
+        fun test2() {
+            // given
+            val article = articleFixture(writerId = 125L)
+            val userId = 1345135L
+
+            // when
+            val isWriter = article.isWriter(userId)
+
+            // then
+            assertThat(isWriter).isFalse()
+        }
+    }
+
+    @Nested
+    @DisplayName("update: 게시글을 수정한다.")
+    inner class UpdateTest {
+
+        @Test
+        @DisplayName("제목, 본문의 내용 변경이 없으면 수정되지 않는다.")
+        fun test1() {
+            // given
+            val prevTitle = "title"
+            val prevContent = "content"
+            val newTitle = "title"
+            val newContent = "content"
+
+            val article = articleFixture(
+                title = prevTitle,
+                content = prevContent,
+                createdAt = appDateTimeFixture(minute = 0),
+                modifiedAt = appDateTimeFixture(minute = 0),
+            )
+
+            val modifiedAt = appDateTimeFixture(minute = 3)
+
+            // when
+            val updateResult = article.update(
+                title = newTitle,
+                content = newContent,
+                modifiedAt = modifiedAt,
+            )
+
+            // then
+            assertThat(updateResult).isEqualTo(Article.UpdateResult.UNCHANGED)
+            assertThat(article.title).isEqualTo(prevTitle)
+            assertThat(article.content).isEqualTo(prevContent)
+            assertThat(article.modifiedAt).isEqualTo(article.modifiedAt)
+        }
+
+        @Test
+        @DisplayName("제목이 달라지는 경우")
+        fun test2() {
+            // given
+            val prevTitle = "title"
+            val prevContent = "content"
+            val newTitle = "title222"
+            val newContent = "content"
+
+            val article = articleFixture(
+                title = prevTitle,
+                content = prevContent,
+                createdAt = appDateTimeFixture(minute = 0),
+                modifiedAt = appDateTimeFixture(minute = 0),
+            )
+
+            val modifiedAt = appDateTimeFixture(minute = 3)
+
+            // when
+            val updateResult = article.update(
+                title = newTitle,
+                content = newContent,
+                modifiedAt = modifiedAt,
+            )
+
+            // then
+            assertThat(updateResult).isEqualTo(Article.UpdateResult.CHANGED)
+            assertThat(article.title).isEqualTo(newTitle)
+            assertThat(article.content).isEqualTo(prevContent)
+            assertThat(article.modifiedAt).isEqualTo(modifiedAt)
+        }
+
+        @Test
+        @DisplayName("본문이 달라지는 경우")
+        fun test3() {
+            // given
+            val prevTitle = "title"
+            val prevContent = "content"
+            val newTitle = "title"
+            val newContent = "content222"
+
+            val article = articleFixture(
+                title = prevTitle,
+                content = prevContent,
+                createdAt = appDateTimeFixture(minute = 0),
+                modifiedAt = appDateTimeFixture(minute = 0),
+            )
+
+            val modifiedAt = appDateTimeFixture(minute = 3)
+
+            // when
+            val updateResult = article.update(
+                title = newTitle,
+                content = newContent,
+                modifiedAt = modifiedAt,
+            )
+
+            // then
+            assertThat(updateResult).isEqualTo(Article.UpdateResult.CHANGED)
+            assertThat(article.title).isEqualTo(prevTitle)
+            assertThat(article.content).isEqualTo(newContent)
+            assertThat(article.modifiedAt).isEqualTo(modifiedAt)
+        }
+
+        @Test
+        @DisplayName("제목, 본문이 모두 달라지는 경우")
+        fun test4() {
+            // given
+            val prevTitle = "title"
+            val prevContent = "content"
+            val newTitle = "title222"
+            val newContent = "content222"
+
+            val article = articleFixture(
+                title = prevTitle,
+                content = prevContent,
+                createdAt = appDateTimeFixture(minute = 0),
+                modifiedAt = appDateTimeFixture(minute = 0),
+            )
+
+            val modifiedAt = appDateTimeFixture(minute = 3)
+
+            // when
+            val updateResult = article.update(
+                title = newTitle,
+                content = newContent,
+                modifiedAt = modifiedAt,
+            )
+
+            // then
+            assertThat(updateResult).isEqualTo(Article.UpdateResult.CHANGED)
+            assertThat(article.title).isEqualTo(newTitle)
+            assertThat(article.content).isEqualTo(newContent)
+            assertThat(article.modifiedAt).isEqualTo(modifiedAt)
+        }
+    }
+
 
     @Nested
     @DisplayName("toString(): 디버깅 문자열을 반환한다.")

--- a/board-system-article/article-domain/src/test/kotlin/com/ttasjwi/board/system/article/domain/model/fixture/ArticleFixtureTest.kt
+++ b/board-system-article/article-domain/src/test/kotlin/com/ttasjwi/board/system/article/domain/model/fixture/ArticleFixtureTest.kt
@@ -5,7 +5,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 
-@DisplayName("ArticleFixture: 게시글 픽스쳐 테스트")
+@DisplayName("[article-domain] ArticleFixture: 게시글 픽스쳐 테스트")
 class ArticleFixtureTest {
 
     @Test

--- a/board-system-article/article-domain/src/test/kotlin/com/ttasjwi/board/system/article/domain/policy/ArticleContentPolicyImplTest.kt
+++ b/board-system-article/article-domain/src/test/kotlin/com/ttasjwi/board/system/article/domain/policy/ArticleContentPolicyImplTest.kt
@@ -4,7 +4,7 @@ import com.ttasjwi.board.system.article.domain.exception.InvalidArticleContentFo
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.*
 
-@DisplayName("ArticleContentPolicyImpl: 게시글 본문 정책 구현체 테스트")
+@DisplayName("[article-domain] ArticleContentPolicyImpl: 게시글 본문 정책 구현체 테스트")
 class ArticleContentPolicyImplTest {
 
     private lateinit var articleContentPolicy: ArticleContentPolicy

--- a/board-system-article/article-domain/src/test/kotlin/com/ttasjwi/board/system/article/domain/policy/ArticleTitlePolicyImplTest.kt
+++ b/board-system-article/article-domain/src/test/kotlin/com/ttasjwi/board/system/article/domain/policy/ArticleTitlePolicyImplTest.kt
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.*
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
-@DisplayName("ArticleContentPolicyImpl: 게시글 제목 정책 구현체 테스트")
+@DisplayName("[article-domain] ArticleContentPolicyImpl: 게시글 제목 정책 구현체 테스트")
 class ArticleTitlePolicyImplTest {
 
     private lateinit var articleTitlePolicy: ArticleTitlePolicy

--- a/board-system-article/article-domain/src/test/kotlin/com/ttasjwi/board/system/article/domain/policy/fixture/ArticleContentPolicyFixtureTest.kt
+++ b/board-system-article/article-domain/src/test/kotlin/com/ttasjwi/board/system/article/domain/policy/fixture/ArticleContentPolicyFixtureTest.kt
@@ -4,7 +4,7 @@ import com.ttasjwi.board.system.common.exception.CustomException
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.*
 
-@DisplayName("ArticleContentPolicyFixture: 게시글 본문 정책 픽스쳐 테스트")
+@DisplayName("[article-domain] ArticleContentPolicyFixture: 게시글 본문 정책 픽스쳐 테스트")
 class ArticleContentPolicyFixtureTest {
 
     private lateinit var articleContentPolicyFixture: ArticleContentPolicyFixture

--- a/board-system-article/article-domain/src/test/kotlin/com/ttasjwi/board/system/article/domain/policy/fixture/ArticleTitlePolicyFixtureTest.kt
+++ b/board-system-article/article-domain/src/test/kotlin/com/ttasjwi/board/system/article/domain/policy/fixture/ArticleTitlePolicyFixtureTest.kt
@@ -4,7 +4,7 @@ import com.ttasjwi.board.system.common.exception.CustomException
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.*
 
-@DisplayName("ArticleTitlePolicyFixture: 게시글 제목 정책 픽스쳐")
+@DisplayName("[article-domain] ArticleTitlePolicyFixture: 게시글 제목 정책 픽스쳐")
 class ArticleTitlePolicyFixtureTest {
 
     private lateinit var articleTitlePolicyFixture: ArticleTitlePolicyFixture

--- a/board-system-article/article-web-adapter/src/main/kotlin/com/ttasjwi/board/system/article/api/ArticleUpdateController.kt
+++ b/board-system-article/article-web-adapter/src/main/kotlin/com/ttasjwi/board/system/article/api/ArticleUpdateController.kt
@@ -1,0 +1,27 @@
+package com.ttasjwi.board.system.article.api
+
+import com.ttasjwi.board.system.article.domain.ArticleUpdateRequest
+import com.ttasjwi.board.system.article.domain.ArticleUpdateResponse
+import com.ttasjwi.board.system.article.domain.ArticleUpdateUseCase
+import com.ttasjwi.board.system.common.annotation.auth.RequireAuthenticated
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class ArticleUpdateController(
+    private val articleUpdateUseCase: ArticleUpdateUseCase
+) {
+
+    @RequireAuthenticated
+    @PutMapping("/api/v1/articles/{articleId}")
+    fun update(
+        @PathVariable("articleId") articleId: Long,
+        @RequestBody request: ArticleUpdateRequest,
+    ): ResponseEntity<ArticleUpdateResponse> {
+        val response = articleUpdateUseCase.update(articleId, request)
+        return ResponseEntity.ok(response)
+    }
+}

--- a/board-system-article/article-web-adapter/src/test/kotlin/com/ttasjwi/board/system/article/api/ArticleUpdateControllerTest.kt
+++ b/board-system-article/article-web-adapter/src/test/kotlin/com/ttasjwi/board/system/article/api/ArticleUpdateControllerTest.kt
@@ -1,0 +1,158 @@
+package com.ttasjwi.board.system.article.api
+
+import com.ninjasquad.springmockk.MockkBean
+import com.ttasjwi.board.system.article.domain.ArticleUpdateRequest
+import com.ttasjwi.board.system.article.domain.ArticleUpdateResponse
+import com.ttasjwi.board.system.article.domain.ArticleUpdateUseCase
+import com.ttasjwi.board.system.article.test.base.ArticleRestDocsTest
+import com.ttasjwi.board.system.common.auth.Role
+import com.ttasjwi.board.system.common.time.fixture.appDateTimeFixture
+import com.ttasjwi.board.system.test.util.*
+import io.mockk.every
+import io.mockk.verify
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.http.MediaType
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.request
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@DisplayName("[article-web-adapter] ArticleUpdateController 테스트")
+@WebMvcTest(ArticleUpdateController::class)
+class ArticleUpdateControllerTest : ArticleRestDocsTest() {
+
+    @MockkBean
+    private lateinit var articleUpdateUseCase: ArticleUpdateUseCase
+
+    @Test
+    @DisplayName("성공 테스트")
+    fun testSuccess() {
+        // given
+        val urlPattern = "/api/v1/articles/{articleId}"
+        val articleId = 1233151335L
+        val request = ArticleUpdateRequest(
+            title = "새 제목",
+            content = "새 본문",
+        )
+        val accessToken = generateAccessToken(
+            userId = 1557,
+            role = Role.USER,
+            issuedAt = appDateTimeFixture(),
+            expiresAt = appDateTimeFixture(minute = 30)
+        )
+        val currentTime = appDateTimeFixture(minute = 18)
+        changeCurrentTime(currentTime)
+
+        val response = ArticleUpdateResponse(
+            articleId = "1233151335",
+            title = request.title!!,
+            content = request.content!!,
+            boardId = "131433451451",
+            articleCategoryId = "1435135151",
+            writerId = accessToken.authUser.userId.toString(),
+            writerNickname = "땃쥐",
+            createdAt = appDateTimeFixture(minute = 10).toZonedDateTime(),
+            modifiedAt = currentTime.toZonedDateTime(),
+        )
+
+        every { articleUpdateUseCase.update(articleId, request) } returns response
+
+        mockMvc
+            .perform(
+                request(HttpMethod.PUT, urlPattern, articleId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(serializeToJson(request))
+                    .header("Authorization", "Bearer ${accessToken.tokenValue}")
+            )
+            .andExpectAll(
+                status().isOk,
+                jsonPath("$.articleId").value(response.articleId),
+                jsonPath("$.title").value(response.title),
+                jsonPath("$.content").value(response.content),
+                jsonPath("$.boardId").value(response.boardId),
+                jsonPath("$.articleCategoryId").value(response.articleCategoryId),
+                jsonPath("$.writerId").value(response.writerId),
+                jsonPath("$.writerNickname").value(response.writerNickname),
+                jsonPath("$.createdAt").value("2025-01-01T00:10:00+09:00"),
+                jsonPath("$.modifiedAt").value("2025-01-01T00:18:00+09:00")
+            )
+            .andDocument(
+                identifier = "article-update-success",
+                requestHeaders(
+                    HttpHeaders.AUTHORIZATION
+                            headerMeans "인증에 필요한 토큰('Bearer [액세스토큰]' 형태)"
+                            example "Bearer 액세스토큰",
+                ),
+                pathParameters(
+                    "articleId"
+                            paramMeans "게시글 식별자(Id)"
+                ),
+                requestBody(
+                    "title"
+                            type STRING
+                            means "게시글 제목"
+                            constraint "최대 50자. 공백만으로 구성되어선 안 됨.",
+                    "content"
+                            type STRING
+                            means "게시판 본문"
+                            constraint "최대 3000자.",
+                ),
+                responseBody(
+                    "articleId"
+                            type STRING
+                            means "게시글 식별자(Id)",
+                    "title"
+                            type STRING
+                            means "게시글 제목",
+
+                    "content"
+                            type STRING
+                            means "게시글 본문",
+                    "boardId"
+                            type STRING
+                            means "게시글이 속한 게시판 식별자(Id)",
+                    "articleCategoryId"
+                            type STRING
+                            means "게시글 카테고리 식별자(Id)",
+                    "writerId"
+                            type STRING
+                            means "작성자 식별자(Id)",
+                    "writerNickname"
+                            type STRING
+                            means "작성시점의 작성자 닉네임",
+                    "createdAt"
+                            type DATETIME
+                            means "작성 시각",
+                    "modifiedAt"
+                            type DATETIME
+                            means "마지막 수정 시각",
+                )
+            )
+        verify(exactly = 1) { articleUpdateUseCase.update(articleId, request) }
+    }
+
+    @Test
+    @DisplayName("미인증 사용자는 게시글을 수정할 수 없다.")
+    fun testUnauthenticated() {
+        // given
+        val urlPattern = "/api/v1/articles/{articleId}"
+        val articleId = 1233151335L
+        val request = ArticleUpdateRequest(
+            title = "새 제목",
+            content = "새 본문",
+        )
+
+        mockMvc
+            .perform(
+                request(HttpMethod.PUT, urlPattern, articleId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(serializeToJson(request))
+            )
+            .andExpectAll(
+                status().isUnauthorized,
+            )
+    }
+}


### PR DESCRIPTION
# JIRA 티켓
- [BRD-99]

---

# 개요
- 게시글 수정 API 를 구현한다.
- 게시글 작성자만 게시글을 수정할 수 있다. (관리자가 자유자재로 수정하는 것은 고려 x)
- 게시글 카테고리의 규칙에 따라 게시글 수정이 불가능할 경우 수정할 수 없다.
- 새 제목, 새 본문은 게시글 제목/본문 도메인 정책을 따름
- 데이터베이스 부하 경감을 위해 게시글 제목/본문 모두 변경되지 않았을 경우 실제 데이터베이스에 반영 안 함.
- 변경점이 있을 경우, 게시글의 수정시간도 최신으로 변경해야한다.

[BRD-99]: https://ttasjwi.atlassian.net/browse/BRD-99?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ