### PR TITLE
Test: (BRD-163) 성능 테스트를 위한 데이터 생성

### DIFF
--- a/board-system-app/build.gradle.kts
+++ b/board-system-app/build.gradle.kts
@@ -50,12 +50,20 @@ dependencies {
     testImplementation(project(":board-system-article-view:article-view-domain"))
     testImplementation(project(":board-system-article-view:article-view-application-input-port"))
 
+    // article-read
+    implementation(project(":board-system-article-read:article-read-web-adapter"))
+    implementation(project(":board-system-article-read:article-read-application-service"))
+
     // aop
     implementation("org.springframework.boot:spring-boot-starter-aop")
 
     // security
     implementation("org.springframework.security:spring-security-config")
     implementation("org.springframework.security:spring-security-web")
+
+
+    testImplementation(Dependencies.SPRING_BOOT_DATA_JPA.fullName)
+    testImplementation(project(":board-system-common:id-generator"))
 
     implementation(project(":board-system-infrastructure:jwt"))
     implementation(project(":board-system-infrastructure:database-adapter"))

--- a/board-system-app/src/test/kotlin/com/ttasjwi/board/system/app/article/data/ArticleDataInitializer.kt
+++ b/board-system-app/src/test/kotlin/com/ttasjwi/board/system/app/article/data/ArticleDataInitializer.kt
@@ -1,0 +1,63 @@
+package com.ttasjwi.board.system.app.article.data
+
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.io.File
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.util.*
+
+@Disabled
+class ArticleDataInitializer {
+
+    @Test
+    @DisplayName("게시글 벌크 삽입 csv 파일 생성")
+    fun initialize() {
+        val csvFile = File("articles.csv")
+        val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+
+        val totalArticleCount = 24_000_000L
+        val random = Random()
+
+        csvFile.bufferedWriter().use { writer ->
+
+            for (articleId in 1L..totalArticleCount) {
+                val paddedId = articleId.toString().padStart(8, '0')
+                val title = "title$paddedId"
+                val content = "content$paddedId"
+                val (boardId, articleCategoryId) = getRandomBoardArticleCategoryId(random)
+                val (writerId, writerNickname) = getRandomWriter(random)
+                val baseTime = LocalDateTime.of(2025, 6, 10, 0, 0)
+                val createdAt = baseTime.plusSeconds(articleId).format(formatter)
+                val modifiedAt = createdAt
+                writer.write("$articleId,$title,$content,$boardId,$articleCategoryId,$writerId,$writerNickname,$createdAt,$modifiedAt\n")
+
+                if (articleId % 100000 == 0L) {
+                    println("Written $articleId lines...")
+                }
+            }
+        }
+    }
+
+    private fun getRandomBoardArticleCategoryId(random: Random): Pair<Long, Long> {
+        val otherBoards = (2..500L).toList()  // 499개 게시판
+
+        // 50% 의 확률로 게시판 1번에 게시글 작성, 나머지 50% 확률을 499개 게시판이 분할
+        val boardId = if (random.nextDouble() < 0.5) {
+            1L
+        } else {
+            otherBoards[random.nextInt(otherBoards.size)]
+        }
+
+        val articleCategoryId = 4 * (boardId - 1) + random.nextLong(3L) + 1 // (일반, 질문, 정보)
+
+        return Pair(boardId, articleCategoryId)
+    }
+
+    private fun getRandomWriter(random: Random): Pair<Long, String> {
+        val userId = random.nextLong(12_000_000L) + 1L
+        val userNickname = "user${userId.toString().padStart(8, '0')}"
+        return Pair(userId, userNickname)
+    }
+}

--- a/board-system-app/src/test/kotlin/com/ttasjwi/board/system/app/articlecomment/data/ArticleCommentDataInitializer.kt
+++ b/board-system-app/src/test/kotlin/com/ttasjwi/board/system/app/articlecomment/data/ArticleCommentDataInitializer.kt
@@ -1,0 +1,143 @@
+package com.ttasjwi.board.system.app.articlecomment.data
+
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.io.BufferedWriter
+import java.io.File
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.util.Random
+
+@Disabled
+class ArticleCommentDataInitializer {
+
+    companion object {
+        private const val USER_COUNT = 12_000_000L
+        private const val ARTICLE_COUNT = 24_000_000L
+        private const val COMMENT_COUNT = 24_000_000L
+        private const val TARGET_ARTICLE_ID = 24_000_000L
+        private val baseTime = LocalDateTime.of(2025, 6, 10, 0, 0)
+        private val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+
+        // 게시글 별로, 최근 0-1개의 댓글 보관
+        // 게시글 Id -> (댓글Id, 댓글 작성자 Id)
+        // 최근 10만건정도까지 유지(오래된 순으로 만료됨)
+        private val articleCommentHistories = object : LinkedHashMap<Long, Pair<Long, Long>>(10_000, 0.75f, true) {
+            override fun removeEldestEntry(eldest: Map.Entry<Long, Pair<Long, Long>>): Boolean {
+                return size > 100_000
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("게시글 댓글 데이터 csv 파일 생성")
+    fun initialize() {
+        val csvFile = File("article-comments.csv")
+        val random = Random()
+
+        csvFile.bufferedWriter().use { writer ->
+
+            // 2400만 댓글 작성
+            for (articleCommentId in 1L..COMMENT_COUNT) {
+                // 50% 확률로 target 게시글에 댓글 작성
+                if (shouldWriterOnTargetArticle(random)) {
+                    makeCommentOnArticle(articleCommentId, TARGET_ARTICLE_ID, random, writer)
+                } else {
+                    // 그 외의 경우에는 나머지 게시글에 댓글 랜덤 작성
+                    val randomArticleId = random.nextLong(ARTICLE_COUNT - 1) + 1L
+                    makeCommentOnArticle(articleCommentId, randomArticleId, random, writer)
+                }
+
+            }
+        }
+    }
+
+    private fun shouldWriterOnTargetArticle(random: Random): Boolean {
+        val randomDouble = random.nextDouble()
+
+        // 50% 확률로 좋아요
+        return randomDouble < 0.5
+    }
+
+    private fun makeCommentOnArticle(articleCommentId: Long, articleId: Long, random: Random, writer: BufferedWriter) {
+        val writerId = random.nextLong(USER_COUNT) + 1L
+
+        // 해당 게시글에 댓글이 있는 경우, 대댓글 작성
+        if (hasParentComment(articleId)) {
+            val (parentCommentId, parentCommentWriterId) = getParentCommentInfo(articleId)
+
+            writeComment(
+                articleCommentId = articleCommentId,
+                articleId = articleId,
+                rootParentCommentId = parentCommentId,
+                writerId = writerId,
+                parentCommentWriterId = parentCommentWriterId,
+                writer = writer
+            )
+            removeCommentHistory(articleId)
+        } else {
+            // 댓글이 없다면, 루트댓글 작성
+            writeComment(
+                articleCommentId = articleCommentId,
+                articleId = articleId,
+                rootParentCommentId = articleCommentId,
+                writerId = writerId,
+                parentCommentWriterId = null,
+                writer = writer
+            )
+            saveCommentHistory(articleId, articleCommentId, writerId)
+        }
+    }
+
+    private fun hasParentComment(articleId: Long): Boolean {
+        return articleCommentHistories.containsKey(articleId)
+    }
+
+    private fun getParentCommentInfo(articleId: Long): Pair<Long, Long> {
+        return articleCommentHistories[articleId]!!
+    }
+
+    private fun removeCommentHistory(articleId: Long) {
+        articleCommentHistories.remove(articleId)
+    }
+
+    private fun saveCommentHistory(articleId: Long, articleCommentId: Long, commentWriterId : Long) {
+        articleCommentHistories[articleId] = Pair(articleCommentId, commentWriterId)
+    }
+
+
+    private fun writeComment(
+        articleCommentId: Long,
+        articleId: Long,
+        rootParentCommentId: Long,
+        writerId: Long,
+        parentCommentWriterId: Long?,
+        writer: BufferedWriter) {
+
+        val content = makeContent(articleCommentId)
+        val writerNickname = makeUserNickname(writerId)
+        val parentCommentWriterNickname = parentCommentWriterId?.let { makeUserNickname(it) }
+        val createdAt = baseTime.plusSeconds(articleCommentId).format(formatter)
+        val modifiedAt = createdAt
+        writer.write(
+            "$articleCommentId,$content,$articleId,$rootParentCommentId,$writerId,$writerNickname,${parentCommentWriterId ?: ""},${parentCommentWriterNickname ?: ""},NOT_DELETED,$createdAt,$modifiedAt\n"
+        )
+
+        if (articleCommentId % 100_000L == 0L) {
+            println("Written $articleCommentId lines...")
+        }
+    }
+
+    private fun makeContent(articleCommentId: Long): String {
+        return "content${makePaddedId(articleCommentId)}"
+    }
+
+    private fun makeUserNickname(userId: Long): String {
+        return "user${makePaddedId(userId)}"
+    }
+
+    private fun makePaddedId(id: Long): String {
+        return id.toString().padStart(8, '0')
+    }
+}

--- a/board-system-app/src/test/kotlin/com/ttasjwi/board/system/app/articlelike/data/ArticleDislikeDataInitializer.kt
+++ b/board-system-app/src/test/kotlin/com/ttasjwi/board/system/app/articlelike/data/ArticleDislikeDataInitializer.kt
@@ -1,0 +1,79 @@
+package com.ttasjwi.board.system.app.articlelike.data
+
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.io.BufferedWriter
+import java.io.File
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.util.Random
+
+@Disabled
+class ArticleDislikeDataInitializer {
+
+    companion object {
+        private const val USER_COUNT = 12_000_000L
+        private const val ARTICLE_COUNT = 24_000_000L
+        private val baseTime = LocalDateTime.of(2025, 6, 10, 0, 0)
+        private val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+        private var articleDislikeId = 0L
+    }
+
+    @Test
+    @DisplayName("게시글 싫어요 데이터 csv 파일 생성")
+    fun initialize() {
+        val csvFile = File("article-dislikes.csv")
+        val random = Random()
+
+        csvFile.bufferedWriter().use { writer ->
+
+            // 2400만 게시글에 대해서
+            for (articleId in 1L..ARTICLE_COUNT) {
+                // 60% 확률로 싫어요, 40% 확률로 싫어요 안 함
+                if (shouldDislike(random)) {
+                    makeDislike(articleId, random,  writer)
+                }
+            }
+        }
+    }
+
+    private fun shouldDislike(random: Random): Boolean {
+        val randomDouble = random.nextDouble()
+
+        // 60% 확률로 싫어요
+        return randomDouble < 0.6
+    }
+
+    private fun makeDislike(articleId: Long, random: Random, writer:BufferedWriter) {
+        val randomDouble = random.nextDouble()
+
+        // 싫어요 1개
+        if (randomDouble < 0.5) {
+            val userId = generateRandomUserId(random)
+            writeArticleDislike(++articleDislikeId, articleId, userId, writer)
+            return
+        }
+        // 싫어요 2개
+        val userId1 = generateRandomUserId(random)
+
+        var userId2 = generateRandomUserId(random)
+        while (userId1 == userId2) {
+            userId2 = generateRandomUserId(random)
+        }
+        writeArticleDislike(++articleDislikeId, articleId, userId1, writer)
+        writeArticleDislike(++articleDislikeId, articleId, userId2, writer)
+        return
+    }
+
+    private fun generateRandomUserId(random: Random): Long {
+        return random.nextLong(USER_COUNT) + 1L
+    }
+
+    private fun writeArticleDislike(articleDislikeId: Long, articleId: Long, userId: Long, writer: BufferedWriter) {
+        writer.write("${articleDislikeId},$articleId,$userId,${baseTime.plusSeconds(articleDislikeId).format(formatter)}\n")
+        if (articleDislikeId % 100_000L == 0L) {
+            println("Written $articleDislikeId lines...")
+        }
+    }
+}

--- a/board-system-app/src/test/kotlin/com/ttasjwi/board/system/app/articlelike/data/ArticleLikeDataInitializer.kt
+++ b/board-system-app/src/test/kotlin/com/ttasjwi/board/system/app/articlelike/data/ArticleLikeDataInitializer.kt
@@ -1,0 +1,79 @@
+package com.ttasjwi.board.system.app.articlelike.data
+
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.io.BufferedWriter
+import java.io.File
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.util.Random
+
+@Disabled
+class ArticleLikeDataInitializer {
+
+    companion object {
+        private const val USER_COUNT = 12_000_000L
+        private const val ARTICLE_COUNT = 24_000_000L
+        private val baseTime = LocalDateTime.of(2025, 6, 10, 0, 0)
+        private val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+        private var articleLikeId = 0L
+    }
+
+    @Test
+    @DisplayName("게시글 좋아요 데이터 csv 파일 생성")
+    fun initialize() {
+        val csvFile = File("article-likes.csv")
+        val random = Random()
+
+        csvFile.bufferedWriter().use { writer ->
+
+            // 2400만 게시글에 대해서
+            for (articleId in 1L..ARTICLE_COUNT) {
+                // 40% 확률로 좋아요, 40% 확률로 좋아요 안 함
+                if (shouldLike(random)) {
+                    makeLike(articleId, random,  writer)
+                }
+            }
+        }
+    }
+
+    private fun shouldLike(random: Random): Boolean {
+        val randomDouble = random.nextDouble()
+
+        // 40% 확률로 좋아요
+        return randomDouble < 0.4
+    }
+
+    private fun makeLike(articleId: Long, random: Random, writer:BufferedWriter) {
+        val randomDouble = random.nextDouble()
+
+        // 좋아요 1개
+        if (randomDouble < 0.5) {
+            val userId = generateRandomUserId(random)
+            writeArticleLike(++articleLikeId, articleId, userId, writer)
+            return
+        }
+        // 좋아요 2개
+        val userId1 = generateRandomUserId(random)
+
+        var userId2 = generateRandomUserId(random)
+        while (userId1 == userId2) {
+            userId2 = generateRandomUserId(random)
+        }
+        writeArticleLike(++articleLikeId, articleId, userId1, writer)
+        writeArticleLike(++articleLikeId, articleId, userId2, writer)
+        return
+    }
+
+    private fun generateRandomUserId(random: Random): Long {
+        return random.nextLong(USER_COUNT) + 1L
+    }
+
+    private fun writeArticleLike(articleLikeId: Long, articleId: Long, userId: Long, writer: BufferedWriter) {
+        writer.write("${articleLikeId},$articleId,$userId,${baseTime.plusSeconds(articleLikeId).format(formatter)}\n")
+        if (articleLikeId % 100_000L == 0L) {
+            println("Written $articleLikeId lines...")
+        }
+    }
+}

--- a/board-system-app/src/test/kotlin/com/ttasjwi/board/system/app/articleview/data/ArticleViewCountDataInitializer.kt
+++ b/board-system-app/src/test/kotlin/com/ttasjwi/board/system/app/articleview/data/ArticleViewCountDataInitializer.kt
@@ -1,0 +1,32 @@
+package com.ttasjwi.board.system.app.articleview.data
+
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.io.File
+import kotlin.random.Random
+
+@Disabled
+class ArticleViewCountDataInitializer {
+
+    @Test
+    @DisplayName("게시글 조회수 데이터 생성")
+    fun initialize() {
+        val startId = 23000001L
+        val endId = 24000000L
+        val outputFile = File("article-view-counts.txt")
+
+        outputFile.bufferedWriter().use { writer ->
+            for (articleId in startId..endId) {
+
+                // 10% 확률로 조회수 가짐
+                if (Random.nextDouble() < 0.1) {
+                    val increment = Random.nextInt(1, 1001)
+                    val command = "INCRBY board-system::article-view::article::$articleId::view-count $increment"
+                    writer.write(command)
+                    writer.newLine()
+                }
+            }
+        }
+    }
+}

--- a/board-system-app/src/test/kotlin/com/ttasjwi/board/system/app/board/data/ArticleCategoryDataInitializer.kt
+++ b/board-system-app/src/test/kotlin/com/ttasjwi/board/system/app/board/data/ArticleCategoryDataInitializer.kt
@@ -1,0 +1,95 @@
+package com.ttasjwi.board.system.app.board.data
+
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.io.BufferedWriter
+import java.io.File
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+@Disabled
+class ArticleCategoryDataInitializer {
+
+    companion object {
+        private val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+    }
+
+    @Test
+    @DisplayName("게시글 카테고리 벌크 삽입 csv 파일 생성")
+    fun initialize() {
+        val csvFile = File("article_categories.csv")
+        csvFile.bufferedWriter().use { writer ->
+            for (boardId in 1L..500L) {
+                makeGeneralCategory(writer, boardId, (boardId - 1) * 4 + 1)
+                makeQuestionCategory(writer, boardId, (boardId - 1) * 4 + 2)
+                makeTipCategory(writer, boardId, (boardId - 1) * 4 + 3)
+                makeNoticeCategory(writer, boardId, (boardId - 1) * 4 + 4)
+            }
+        }
+    }
+
+    private fun makeGeneralCategory(writer: BufferedWriter, boardId: Long, articleCategoryId: Long) {
+        val name = "일반"
+        val slug = "general"
+        val allowWrite = 1
+        val allowSelfEditDelete = 1
+        val allowComment = 1
+        val allowLike = 1
+        val allowDislike = 1
+        val createdAt = LocalDateTime.now().format(formatter)
+
+        writer.write("$articleCategoryId,$name,$slug,$boardId,$allowWrite,$allowSelfEditDelete,$allowComment,$allowLike,$allowDislike,$createdAt\n")
+        if (articleCategoryId % 100 == 0L) {
+            println("Written $articleCategoryId lines...")
+        }
+    }
+
+    private fun makeQuestionCategory(writer: BufferedWriter, boardId: Long, articleCategoryId: Long) {
+        val name = "질문"
+        val slug = "question"
+        val allowWrite = 1
+        val allowSelfEditDelete = 0
+        val allowComment = 1
+        val allowLike = 1
+        val allowDislike = 1
+        val createdAt = LocalDateTime.now().format(formatter)
+
+        writer.write("$articleCategoryId,$name,$slug,$boardId,$allowWrite,$allowSelfEditDelete,$allowComment,$allowLike,$allowDislike,$createdAt\n")
+        if (articleCategoryId % 100 == 0L) {
+            println("Written $articleCategoryId lines...")
+        }
+    }
+
+    private fun makeTipCategory(writer: BufferedWriter, boardId: Long, articleCategoryId: Long) {
+        val name = "정보"
+        val slug = "tip"
+        val allowWrite = 1
+        val allowSelfEditDelete = 1
+        val allowComment = 1
+        val allowLike = 1
+        val allowDislike = 0
+        val createdAt = LocalDateTime.now().format(formatter)
+
+        writer.write("$articleCategoryId,$name,$slug,$boardId,$allowWrite,$allowSelfEditDelete,$allowComment,$allowLike,$allowDislike,$createdAt\n")
+        if (articleCategoryId % 100 == 0L) {
+            println("Written $articleCategoryId lines...")
+        }
+    }
+
+    private fun makeNoticeCategory(writer: BufferedWriter, boardId: Long, articleCategoryId: Long) {
+        val name = "공지"
+        val slug = "notice"
+        val allowWrite = 0
+        val allowSelfEditDelete = 0
+        val allowComment = 0
+        val allowLike = 0
+        val allowDislike = 0
+        val createdAt = LocalDateTime.now().format(formatter)
+
+        writer.write("$articleCategoryId,$name,$slug,$boardId,$allowWrite,$allowSelfEditDelete,$allowComment,$allowLike,$allowDislike,$createdAt\n")
+        if (articleCategoryId % 100 == 0L) {
+            println("Written $articleCategoryId lines...")
+        }
+    }
+}

--- a/board-system-app/src/test/kotlin/com/ttasjwi/board/system/app/board/data/BoardDataInitializer.kt
+++ b/board-system-app/src/test/kotlin/com/ttasjwi/board/system/app/board/data/BoardDataInitializer.kt
@@ -1,0 +1,36 @@
+package com.ttasjwi.board.system.app.board.data
+
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.io.File
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+@Disabled
+class BoardDataInitializer {
+
+    @Test
+    @DisplayName("게시판 벌크 삽입 csv 파일 생성")
+    fun initialize() {
+        val csvFile = File("boards.csv")
+        val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+        csvFile.bufferedWriter().use { writer ->
+            for (id in 1L..500L) {
+                val paddedId = id.toString().padStart(8, '0')
+
+                val name = "board${paddedId}"
+                val description = "The board of $name"
+                val managerId = id
+                val slug = "board${paddedId}"
+                val createdAt = LocalDateTime.now().format(formatter)
+
+                writer.write("$id,$name,$description,$managerId,$slug,$createdAt\n")
+
+                if (id % 10 == 0L) {
+                    println("Written $id lines...")
+                }
+            }
+        }
+    }
+}

--- a/board-system-app/src/test/kotlin/com/ttasjwi/board/system/app/user/data/UserDataInitializer.kt
+++ b/board-system-app/src/test/kotlin/com/ttasjwi/board/system/app/user/data/UserDataInitializer.kt
@@ -1,0 +1,35 @@
+package com.ttasjwi.board.system.app.user.data
+
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.io.File
+import java.time.format.DateTimeFormatter
+
+@Disabled
+class UserDataInitializer {
+
+    @Test
+    @DisplayName("회원 벌크 삽입 csv 파일 생성")
+    fun initialize() {
+        val csvFile = File("users.csv")
+        val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+        csvFile.bufferedWriter().use { writer ->
+            for (id in 1L..12_000_000L) {
+                val paddedId = id.toString().padStart(8, '0')
+
+                val email = "user${paddedId}@gmail.com"
+                val password = "{bcrypt}$2a$10\$glxdATzDUUpvB92yt7OkI.zCPjgn1R1v2uWnQ43gHo.st2t9B9hMy"
+                val username = "user${paddedId}"
+                val nickname = "user${paddedId}"
+                val role = "USER"
+                val registeredAt = java.time.LocalDateTime.now().format(formatter)
+                writer.write("$id,$email,$password,$username,$nickname,$role,$registeredAt\n")
+
+                if (id % 100000 == 0L) {
+                    println("Written $id lines...")
+                }
+            }
+        }
+    }
+}

--- a/board-system-article-read/article-read-application-service/src/main/kotlin/com/ttasjwi/board/system/articleread/domain/processor/ArticleSummaryInfiniteScrollReadProcessor.kt
+++ b/board-system-article-read/article-read-application-service/src/main/kotlin/com/ttasjwi/board/system/articleread/domain/processor/ArticleSummaryInfiniteScrollReadProcessor.kt
@@ -63,8 +63,8 @@ internal class ArticleSummaryInfiniteScrollReadProcessor(
             ),
             articleCategory = ArticleSummaryInfiniteScrollReadResponse.Article.ArticleCategory(
                 articleCategoryId = this.articleCategory.articleCategoryId.toString(),
-                name = this.board.name,
-                slug = this.board.slug,
+                name = this.articleCategory.name,
+                slug = this.articleCategory.slug,
             ),
             writer = ArticleSummaryInfiniteScrollReadResponse.Article.Writer(
                 writerId = this.writer.writerId.toString(),

--- a/board-system-article-read/article-read-application-service/src/main/kotlin/com/ttasjwi/board/system/articleread/domain/processor/ArticleSummaryPageReadProcessor.kt
+++ b/board-system-article-read/article-read-application-service/src/main/kotlin/com/ttasjwi/board/system/articleread/domain/processor/ArticleSummaryPageReadProcessor.kt
@@ -90,8 +90,8 @@ class ArticleSummaryPageReadProcessor(
             ),
             articleCategory = ArticleSummaryPageReadResponse.Article.ArticleCategory(
                 articleCategoryId = this.articleCategory.articleCategoryId.toString(),
-                name = this.board.name,
-                slug = this.board.slug,
+                name = this.articleCategory.name,
+                slug = this.articleCategory.slug,
             ),
             writer = ArticleSummaryPageReadResponse.Article.Writer(
                 writerId = this.writer.writerId.toString(),


### PR DESCRIPTION
## JIRA 티켓
- [BRD-163]

---

## 개요
- 우리 서비스에서 동작하는 기능들이 어느 정도의 신뢰성을 보이는 것은 그동안의 기능 구현, 테스트를 통해 확인했다.
- 하지만 동시에 많은 사용자가 몰렸을 때 서비스가 견딜 수 있는지 확인하는 것은 별개의 문제이다.
  - 실제 수백만, 수천만의 데이터가 삽입됐을 때에도 우리 서비스는 정상적으로 작동할 수 있을까?
  - 동시에 수천명의 사용자가 몰렸을 때도 어느 정도의 준수한 TPS 를 유지할 수 있을까?
- 다량의 데이터를 생성해서 데이터베이스에 삽입하고, 성능을 측정할 수 있도록 준비해야한다. 충분한 양의 데이터를 생성해본다.
  - 사용자 : 1200만명
  - 게시판 : 500개
  - 게시글 카테고리 : 게시판별 4개(총 2000개)
  - 게시글 : 2400만개
  - 게시글 댓글 : 2400만개
  - 게시글 좋아요/싫어요 : 각각 대략 1440만개
  - 게시글 조회수 : 최근 100만개 게시글 중 랜덤 10%에게 조회수 설정

[BRD-163]: https://ttasjwi.atlassian.net/browse/BRD-163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ