### PR TITLE
Refactor: (BRD-166) 게시글 목록 페이지 조회 - 성능 개선(게시글 수 비정규화, 쿼리 튜닝)

### DIFF
--- a/board-system-article/article-domain/src/main/kotlin/com/ttasjwi/board/system/article/domain/model/BoardArticleCount.kt
+++ b/board-system-article/article-domain/src/main/kotlin/com/ttasjwi/board/system/article/domain/model/BoardArticleCount.kt
@@ -1,0 +1,18 @@
+package com.ttasjwi.board.system.article.domain.model
+
+class BoardArticleCount(
+    val boardId: Long,
+    val articleCount: Long
+) {
+
+    companion object {
+
+        fun restore(boardId: Long, articleCount: Long): BoardArticleCount {
+            return BoardArticleCount(boardId, articleCount)
+        }
+    }
+
+    override fun toString(): String {
+        return "BoardArticleCount(boardId=$boardId, articleCount=$articleCount)"
+    }
+}

--- a/board-system-article/article-domain/src/test/kotlin/com/ttasjwi/board/system/article/domain/model/BoardArticleCountTest.kt
+++ b/board-system-article/article-domain/src/test/kotlin/com/ttasjwi/board/system/article/domain/model/BoardArticleCountTest.kt
@@ -1,0 +1,46 @@
+package com.ttasjwi.board.system.article.domain.model
+
+import com.ttasjwi.board.system.article.domain.model.fixture.boardArticleCountFixture
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("[article-domain] BoardArticleCount: 게시판 게시글 수")
+class BoardArticleCountTest {
+
+
+    @Test
+    @DisplayName("restore : 값으로 부터 객체 복원")
+    fun restoreTest() {
+        // given
+        val boardId = 134L
+        val articleCount = 55L
+
+        // when
+        val boardArticleCount = BoardArticleCount.restore(
+            boardId = boardId,
+            articleCount = articleCount
+        )
+
+        // then
+        assertThat(boardArticleCount.boardId).isEqualTo(boardId)
+        assertThat(boardArticleCount.articleCount).isEqualTo(articleCount)
+    }
+
+    @Test
+    @DisplayName("toString() : 디버깅문자열 반환")
+    fun toStringTest() {
+        // given
+        val boardId = 134L
+        val articleCount = 55L
+
+        // when
+        val boardArticleCount = boardArticleCountFixture(
+            boardId = boardId,
+            articleCount = articleCount
+        )
+
+        // then
+        assertThat(boardArticleCount.toString()).isEqualTo("BoardArticleCount(boardId=$boardId, articleCount=$articleCount)")
+    }
+}

--- a/board-system-article/article-domain/src/test/kotlin/com/ttasjwi/board/system/article/domain/model/fixture/BoardArticleCountFixtureTest.kt
+++ b/board-system-article/article-domain/src/test/kotlin/com/ttasjwi/board/system/article/domain/model/fixture/BoardArticleCountFixtureTest.kt
@@ -1,0 +1,39 @@
+package com.ttasjwi.board.system.article.domain.model.fixture
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("[article-domain] BoardArticleCountFixture 테스트")
+class BoardArticleCountFixtureTest {
+
+    @Test
+    @DisplayName("기본값 생성 테스트")
+    fun test1() {
+        // given
+        // when
+        val boardArticleCount = boardArticleCountFixture()
+
+        // then
+        assertThat(boardArticleCount.boardId).isNotNull
+        assertThat(boardArticleCount.articleCount).isNotNull
+    }
+
+    @Test
+    @DisplayName("커스텀 값 지정 테스트")
+    fun test2() {
+        // given
+        val boardId = 134L
+        val articleCount = 55L
+
+        // when
+        val boardArticleCount = boardArticleCountFixture(
+            boardId = boardId,
+            articleCount = articleCount
+        )
+
+        // then
+        assertThat(boardArticleCount.boardId).isEqualTo(boardId)
+        assertThat(boardArticleCount.articleCount).isEqualTo(articleCount)
+    }
+}

--- a/board-system-article/article-domain/src/testFixtures/kotlin/com/ttasjwi/board/system/article/domain/model/fixture/BoardArticleCountFixture.kt
+++ b/board-system-article/article-domain/src/testFixtures/kotlin/com/ttasjwi/board/system/article/domain/model/fixture/BoardArticleCountFixture.kt
@@ -1,0 +1,13 @@
+package com.ttasjwi.board.system.article.domain.model.fixture
+
+import com.ttasjwi.board.system.article.domain.model.BoardArticleCount
+
+fun boardArticleCountFixture(
+    boardId: Long = 1L,
+    articleCount: Long = 0L,
+): BoardArticleCount {
+    return BoardArticleCount(
+        boardId = boardId,
+        articleCount = articleCount
+    )
+}

--- a/board-system-infrastructure/database-adapter/src/main/resources/schema.sql
+++ b/board-system-infrastructure/database-adapter/src/main/resources/schema.sql
@@ -50,7 +50,14 @@ CREATE TABLE IF NOT EXISTS articles(
     writer_id           BIGINT        NOT NULL,
     writer_nickname     VARCHAR(15)   NOT NULL,
     created_at          DATETIME      NOT NULL,
-    modified_at         DATETIME      NOT NULL
+    modified_at         DATETIME      NOT NULL,
+
+    INDEX idx_board_id_article_id (board_id ASC, article_id DESC)
+);
+
+CREATE TABLE IF NOT EXISTS board_article_counts(
+    board_id      BIGINT NOT NULL PRIMARY KEY,
+    article_count BIGINT NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS article_comments(


### PR DESCRIPTION

## JIRA 티켓
- [BRD-166]

---

## 개요
- 게시글 목록 조회 기능을 인덱스 추가를 통해 한번 성능 개선을 해봤다.
- 그런데 구조적으로 게시글 페이지 조회 기능에는 몇 가지 결함이 있다.
  - 페이지를 조회시 다음 페이지 그룹 존재 여부 등을 확인하기 위해서, 게시글 수를 조회하는 쿼리를 실행한다.
  - 쿼리 자체가 커버링 인덱스를 활용하지 못 하고 OFFSET 이 커졌을 때 성능을 제대로 내기 힘들다.

---
