### PR TITLE
Fix: (BRD-167) 게시글 목록 페이지 조회 - AppDateTime 타입 오류 수정

### DIFF
--- a/board-system-article-read/article-read-application-service/src/main/kotlin/com/ttasjwi/board/system/articleread/domain/processor/ArticleSummaryInfiniteScrollReadProcessor.kt
+++ b/board-system-article-read/article-read-application-service/src/main/kotlin/com/ttasjwi/board/system/articleread/domain/processor/ArticleSummaryInfiniteScrollReadProcessor.kt
@@ -6,6 +6,7 @@ import com.ttasjwi.board.system.articleread.domain.model.ArticleSummaryQueryMode
 import com.ttasjwi.board.system.articleread.domain.port.ArticleSummaryStorage
 import com.ttasjwi.board.system.articleread.domain.port.ArticleViewCountStorage
 import com.ttasjwi.board.system.common.annotation.component.ApplicationProcessor
+import com.ttasjwi.board.system.common.time.AppDateTime
 
 @ApplicationProcessor
 internal class ArticleSummaryInfiniteScrollReadProcessor(
@@ -74,7 +75,7 @@ internal class ArticleSummaryInfiniteScrollReadProcessor(
             commentCount = this.commentCount,
             likeCount = this.likeCount,
             dislikeCount = this.dislikeCount,
-            createdAt = this.createdAt.toZonedDateTime(),
+            createdAt = AppDateTime.from(this.createdAt).toZonedDateTime(),
         )
     }
 }

--- a/board-system-article-read/article-read-application-service/src/main/kotlin/com/ttasjwi/board/system/articleread/domain/processor/ArticleSummaryPageReadProcessor.kt
+++ b/board-system-article-read/article-read-application-service/src/main/kotlin/com/ttasjwi/board/system/articleread/domain/processor/ArticleSummaryPageReadProcessor.kt
@@ -9,6 +9,7 @@ import com.ttasjwi.board.system.articleread.domain.port.BoardArticleCountStorage
 import com.ttasjwi.board.system.common.annotation.component.ApplicationProcessor
 import com.ttasjwi.board.system.common.page.PagingInfo
 import com.ttasjwi.board.system.common.page.calculateOffset
+import com.ttasjwi.board.system.common.time.AppDateTime
 
 @ApplicationProcessor
 class ArticleSummaryPageReadProcessor(
@@ -97,7 +98,7 @@ class ArticleSummaryPageReadProcessor(
             commentCount = this.commentCount,
             likeCount = this.likeCount,
             dislikeCount = this.dislikeCount,
-            createdAt = this.createdAt.toZonedDateTime(),
+            createdAt = AppDateTime.from(this.createdAt).toZonedDateTime(),
         )
     }
 }

--- a/board-system-article-read/article-read-domain/src/main/kotlin/com/ttasjwi/board/system/articleread/domain/model/ArticleSummaryQueryModel.kt
+++ b/board-system-article-read/article-read-domain/src/main/kotlin/com/ttasjwi/board/system/articleread/domain/model/ArticleSummaryQueryModel.kt
@@ -1,6 +1,6 @@
 package com.ttasjwi.board.system.articleread.domain.model
 
-import com.ttasjwi.board.system.common.time.AppDateTime
+import java.time.LocalDateTime
 
 interface ArticleSummaryQueryModel {
     val articleId: Long
@@ -16,5 +16,5 @@ interface ArticleSummaryQueryModel {
     val commentCount: Long
     val likeCount: Long
     val dislikeCount: Long
-    val createdAt: AppDateTime
+    val createdAt: LocalDateTime
 }

--- a/board-system-article-read/article-read-domain/src/test/kotlin/com/ttasjwi/board/system/articleread/domain/model/fixture/ArticleSummaryQueryModelFixtureTest.kt
+++ b/board-system-article-read/article-read-domain/src/test/kotlin/com/ttasjwi/board/system/articleread/domain/model/fixture/ArticleSummaryQueryModelFixtureTest.kt
@@ -72,6 +72,6 @@ class ArticleSummaryQueryModelFixtureTest {
         assertThat(articleSummary.commentCount).isEqualTo(commentCount)
         assertThat(articleSummary.likeCount).isEqualTo(likeCount)
         assertThat(articleSummary.dislikeCount).isEqualTo(dislikeCount)
-        assertThat(articleSummary.createdAt).isEqualTo(createdAt)
+        assertThat(articleSummary.createdAt).isEqualTo(createdAt.toLocalDateTime())
     }
 }

--- a/board-system-article-read/article-read-domain/src/testFixtures/kotlin/com/ttasjwi/board/system/articleread/domain/model/fixture/ArticleSummaryQueryModelFixture.kt
+++ b/board-system-article-read/article-read-domain/src/testFixtures/kotlin/com/ttasjwi/board/system/articleread/domain/model/fixture/ArticleSummaryQueryModelFixture.kt
@@ -3,6 +3,7 @@ package com.ttasjwi.board.system.articleread.domain.model.fixture
 import com.ttasjwi.board.system.articleread.domain.model.ArticleSummaryQueryModel
 import com.ttasjwi.board.system.common.time.AppDateTime
 import com.ttasjwi.board.system.common.time.fixture.appDateTimeFixture
+import java.time.LocalDateTime
 
 fun articleSummaryQueryModelFixture(
     articleId: Long = 1L,
@@ -34,7 +35,7 @@ fun articleSummaryQueryModelFixture(
         commentCount = commentCount,
         likeCount = likeCount,
         dislikeCount = dislikeCount,
-        createdAt = createdAt,
+        createdAt = createdAt.toLocalDateTime(),
     )
 }
 
@@ -52,5 +53,5 @@ data class TestArticleSummary(
     override val commentCount: Long,
     override val likeCount: Long,
     override val dislikeCount: Long,
-    override val createdAt: AppDateTime
+    override val createdAt: LocalDateTime
 ): ArticleSummaryQueryModel

--- a/board-system-infrastructure/database-adapter/src/main/kotlin/com/ttasjwi/board/system/articleread/infra/persistence/dto/QueryDslArticleSummaryQueryModel.kt
+++ b/board-system-infrastructure/database-adapter/src/main/kotlin/com/ttasjwi/board/system/articleread/infra/persistence/dto/QueryDslArticleSummaryQueryModel.kt
@@ -19,12 +19,10 @@ class QueryDslArticleSummaryQueryModel @QueryProjection constructor(
     override val commentCount: Long,
     override val likeCount: Long,
     override val dislikeCount: Long,
-    createdAt: LocalDateTime,
+    override val createdAt: LocalDateTime,
 ) : ArticleSummaryQueryModel {
 
-    override val createdAt: AppDateTime = AppDateTime.from(createdAt)
-
     override fun toString(): String {
-        return "QueryDslArticleSummaryQueryModel(articleId=$articleId, title='$title', boardId=$boardId, boardName='$boardName', boardSlug='$boardSlug', articleCategoryId=$articleCategoryId, articleCategoryName='$articleCategoryName', articleCategorySlug='$articleCategorySlug', writerId=$writerId, writerNickname='$writerNickname', commentCount=$commentCount, likeCount=$likeCount, dislikeCount=$dislikeCount, createdAt=$createdAt)"
+        return "QueryDslArticleSummaryQueryModel(articleId=$articleId, title='$title', boardId=$boardId, boardName='$boardName', boardSlug='$boardSlug', articleCategoryId=$articleCategoryId, articleCategoryName='$articleCategoryName', articleCategorySlug='$articleCategorySlug', writerId=$writerId, writerNickname='$writerNickname', commentCount=$commentCount, likeCount=$likeCount, dislikeCount=$dislikeCount, createdAt=${AppDateTime.from(createdAt)})"
     }
 }


### PR DESCRIPTION
# JIRA 티켓
- [BRD-167]

---

# 작업내역
- ArticleSummaryQueryModel 인터페이스 사양의 AppDateTime이 Spring Data Jpa 에서 알지 못 하기 때문에 문제가 발생
- LocalDateTime 사양으로 바꿨다.